### PR TITLE
Update SonarQube project references to SolaceProducts_event-management-agent

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,7 +70,7 @@ jobs:
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
         run: |
           mvn -B $SKIP_FLAGS_ALL_TESTS \
-            org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=SolaceLabs_event-management-agent \
+            org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=SolaceProducts_event-management-agent \
             --file service/pom.xml
       - name: WhiteSource Scan
         if: env.WHITESOURCE_SCAN=='true'

--- a/.github/workflows/release_scripts/sonarqube_vulnurability_checker.py
+++ b/.github/workflows/release_scripts/sonarqube_vulnurability_checker.py
@@ -2,7 +2,7 @@ import requests
 import os
 import textwrap
 
-SONARQUBE_PROJECT_KEY = "SolaceLabs_event-management-agent"
+SONARQUBE_PROJECT_KEY = "SolaceProducts_event-management-agent"
 SONARQUBE_PROJECT_MAIN_BRANCH = "main"
 SONARQUBE_QUERY_TOKEN = os.getenv("SONARQUBE_QUERY_TOKEN")
 SONARQUBE_HOTSPOTS_API_URL = os.getenv("SONARQUBE_HOTSPOTS_API_URL")

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Event Management Agent (Test in SolaceProducts)
+# Event Management Agent
 
 The Event Management Agent is a tool for architects and developers working with event-driven architectures (EDAs) to discover event streams flowing through event brokers as well as the related broker configuration information. It can also discover schemas from registries. The Event Management Agent can be used in two different ways:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Event Management Agent
+# Event Management Agent (Test in SolaceProducts)
 
 The Event Management Agent is a tool for architects and developers working with event-driven architectures (EDAs) to discover event streams flowing through event brokers as well as the related broker configuration information. It can also discover schemas from registries. The Event Management Agent can be used in two different ways:
 


### PR DESCRIPTION
### What is the purpose of this change?
Update SonarQube project references from `SolaceLabs_event-management-agent` to `SolaceProducts_event-management-agent`

### How was this change implemented?
- Changed build github action workflow
- Change SonarQube Checker script

### How was this change tested?
- Ran https://github.com/SolaceProducts/event-management-agent/actions/runs/6383782762
- This PR is commented successfully by SonarQube

### Is there anything the reviewers should focus on/be aware of?
For this to work:
- I renamed the project key on SonarQube and Installed SonarQube app in this org