### PR TITLE
Use SolaceProducts GitHub Packages Repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ docker pull solace/event-management-agent
 
 * clone the Event Management Agent GitHub repository
 ```
-git clone https://github.com/SolaceLabs/event-management-agent.git
+git clone https://github.com/SolaceProducts/event-management-agent.git
 cd event-management-agent
 ```
 
@@ -202,7 +202,7 @@ curl -X 'POST' \
 ## Cloning the GitHub Event Management Agent repository
 
 ```
-git@github.com:SolaceLabs/event-management-agent.git
+git@github.com:SolaceProducts/event-management-agent.git
 ```
 
 ### Installing Maven dependencies and building the Event Management Agent jar file

--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>com.solace.maas</groupId>
         <artifactId>maas-event-management-agent-parent</artifactId>
-        <version>1.1.2-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <groupId>com.solace.maas</groupId>
     <artifactId>event-management-agent</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Solace Event Management Agent - Application</name>
     <description>Solace Event Management Agent - Application</description>
@@ -216,27 +216,27 @@
         <dependency>
             <groupId>com.solace.maas</groupId>
             <artifactId>plugin</artifactId>
-            <version>1.1.2-SNAPSHOT</version>
+            <version>1.1.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.solace.maas.plugin.kafka</groupId>
             <artifactId>kafka-plugin</artifactId>
-            <version>1.1.2-SNAPSHOT</version>
+            <version>1.1.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.solace.maas.plugin.solace</groupId>
             <artifactId>solace-plugin</artifactId>
-            <version>1.1.2-SNAPSHOT</version>
+            <version>1.1.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.solace.maas.plugin.localstorage</groupId>
             <artifactId>local-storage-plugin</artifactId>
-            <version>1.1.2-SNAPSHOT</version>
+            <version>1.1.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.solace.maas.plugin.confluent-schema-registry</groupId>
             <artifactId>confluent-schema-registry-plugin</artifactId>
-            <version>1.1.2-SNAPSHOT</version>
+            <version>1.1.1-SNAPSHOT</version>
         </dependency>
 
         <!-- for testing -->

--- a/service/confluent-schema-registry-plugin/pom.xml
+++ b/service/confluent-schema-registry-plugin/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.solace.maas.plugin.confluent-schema-registry</groupId>
     <artifactId>confluent-schema-registry-plugin</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Solace Event Management Agent - Confluent Schema Registry Plugin</name>
     <description>Solace Event Management Agent - Confluent Schema Registry Plugin</description>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.solace.maas</groupId>
             <artifactId>plugin</artifactId>
-            <version>1.1.2-SNAPSHOT</version>
+            <version>1.1.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/service/confluent-schema-registry-plugin/pom.xml
+++ b/service/confluent-schema-registry-plugin/pom.xml
@@ -100,7 +100,7 @@
         <repository>
             <id>github</id>
             <name>GitHub Packages</name>
-            <url>https://maven.pkg.github.com/SolaceLabs/event-management-agent</url>
+            <url>https://maven.pkg.github.com/SolaceProducts/event-management-agent</url>
         </repository>
     </distributionManagement>
 

--- a/service/kafka-plugin/pom.xml
+++ b/service/kafka-plugin/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.solace.maas.plugin.kafka</groupId>
     <artifactId>kafka-plugin</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Solace Event Management Agent - Kafka Plugin</name>
     <description>Solace Event Management Agent - Kafka Plugin</description>
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>com.solace.maas</groupId>
             <artifactId>plugin</artifactId>
-            <version>1.1.2-SNAPSHOT</version>
+            <version>1.1.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/service/kafka-plugin/pom.xml
+++ b/service/kafka-plugin/pom.xml
@@ -158,7 +158,7 @@
         <repository>
             <id>github</id>
             <name>GitHub Packages</name>
-            <url>https://maven.pkg.github.com/SolaceLabs/event-management-agent</url>
+            <url>https://maven.pkg.github.com/SolaceProducts/event-management-agent</url>
         </repository>
     </distributionManagement>
 </project>

--- a/service/local-storage-plugin/pom.xml
+++ b/service/local-storage-plugin/pom.xml
@@ -160,7 +160,7 @@
         <repository>
             <id>github</id>
             <name>GitHub Packages</name>
-            <url>https://maven.pkg.github.com/SolaceLabs/event-management-agent</url>
+            <url>https://maven.pkg.github.com/SolaceProducts/event-management-agent</url>
         </repository>
     </distributionManagement>
 </project>

--- a/service/local-storage-plugin/pom.xml
+++ b/service/local-storage-plugin/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.solace.maas.plugin.localstorage</groupId>
     <artifactId>local-storage-plugin</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Solace Event Management Agent - Local Storage Plugin</name>
     <description>Solace Event Management Agent - Local Storage Plugin</description>
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>com.solace.maas</groupId>
             <artifactId>plugin</artifactId>
-            <version>1.1.2-SNAPSHOT</version>
+            <version>1.1.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>

--- a/service/plugin/pom.xml
+++ b/service/plugin/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>com.solace.maas</groupId>
         <artifactId>maas-event-management-agent-parent</artifactId>
-        <version>1.1.2-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <groupId>com.solace.maas</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Solace Event Management Agent - Plugin</name>
     <description>Solace Event Management Agent - Plugin</description>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>com.solace.maas</groupId>
     <artifactId>maas-event-management-agent-parent</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Solace Event Management Agent Maven Parent</name>
     <description>Solace Solace Event Management Agent Maven Parent</description>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -401,14 +401,14 @@
     <scm>
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
-        <url>git@github.com:SolaceLabs/event-management-agent.git</url>
+        <url>git@github.com:SolaceProducts/event-management-agent.git</url>
         <tag>HEAD</tag>
     </scm>
     <distributionManagement>
         <repository>
             <id>github</id>
             <name>GitHub Packages</name>
-            <url>https://maven.pkg.github.com/SolaceLabs/event-management-agent</url>
+            <url>https://maven.pkg.github.com/SolaceProducts/event-management-agent</url>
         </repository>
     </distributionManagement>
 </project>

--- a/service/rabbitmq-plugin/pom.xml
+++ b/service/rabbitmq-plugin/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.solace.maas.plugin.rabbitmq</groupId>
     <artifactId>rabbitmq-plugin</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Solace Event Management Agent - RabbitMQ Plugin</name>
     <description>Solace Event Management Agent - RabbitMQ Plugin</description>
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>com.solace.maas</groupId>
             <artifactId>plugin</artifactId>
-            <version>1.1.2-SNAPSHOT</version>
+            <version>1.1.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <build>

--- a/service/rabbitmq-plugin/pom.xml
+++ b/service/rabbitmq-plugin/pom.xml
@@ -63,7 +63,7 @@
         <repository>
             <id>github</id>
             <name>GitHub Packages</name>
-            <url>https://maven.pkg.github.com/SolaceLabs/event-management-agent</url>
+            <url>https://maven.pkg.github.com/SolaceProducts/event-management-agent</url>
         </repository>
     </distributionManagement>
 </project>

--- a/service/solace-plugin/pom.xml
+++ b/service/solace-plugin/pom.xml
@@ -163,7 +163,7 @@
         <repository>
             <id>github</id>
             <name>GitHub Packages</name>
-            <url>https://maven.pkg.github.com/SolaceLabs/event-management-agent</url>
+            <url>https://maven.pkg.github.com/SolaceProducts/event-management-agent</url>
         </repository>
     </distributionManagement>
 </project>

--- a/service/solace-plugin/pom.xml
+++ b/service/solace-plugin/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.solace.maas.plugin.solace</groupId>
     <artifactId>solace-plugin</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Solace Event Management Agent - Solace Plugin</name>
     <description>Solace Event Management Agent - Solace Plugin</description>
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>com.solace.maas</groupId>
             <artifactId>plugin</artifactId>
-            <version>1.1.2-SNAPSHOT</version>
+            <version>1.1.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>


### PR DESCRIPTION
### What is the purpose of this change?
Changing refrences to GitHub Packages repositories to SolaceProducts

### How was this change implemented?
Updating pom files to use `https://maven.pkg.github.com/SolaceProducts/event-management-agent` instead of
`https://maven.pkg.github.com/SolaceLabs/event-management-agent`