### PR TITLE
DATAGO-63031: Fix logging of traceId, actorId and orgId so it's consistent between EMA and EP

### DIFF
--- a/service/application/docker/buildEventManagementAgentDocker.sh
+++ b/service/application/docker/buildEventManagementAgentDocker.sh
@@ -88,9 +88,26 @@ export JAR_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceSt
 cp ../target/event-management-agent-${JAR_VERSION}.jar .
 
 cd ..
-docker build docker -t event-management-agent:${IMAGE_TAG} --build-arg BASE_IMAGE=${BASE_IMAGE}\
+if docker buildx inspect container > /dev/null ; then
+    echo "Found docker driver multiarch"
+else
+    echo "Creating docker driver multiarch"
+    docker buildx create --name container --driver=docker-container 
+fi
+
+#docker buildx use multiarch
+
+#docker buildx build --no-cache --platform=linux/amd64,linux/arm64 -t 868978040651.dkr.ecr.us-east-1.amazonaws.com/event-management-agent:${IMAGE_TAG} --build-arg BASE_IMAGE=${BASE_IMAGE}\
+#       --build-arg JAR_FILE=event-management-agent-${JAR_VERSION}.jar --build-arg GITHASH=${GITHASH}\
+#       --build-arg BUILD_TIMESTAMP="${BUILD_TIMESTAMP}" --build-arg GITBRANCH=${GITBRANCH} \
+#       --push --builder=container $(pwd)/docker
+docker buildx build --no-cache --platform=linux/amd64,linux/arm64 -t event-management-agent:${IMAGE_TAG} --build-arg BASE_IMAGE=${BASE_IMAGE}\
        --build-arg JAR_FILE=event-management-agent-${JAR_VERSION}.jar --build-arg GITHASH=${GITHASH}\
-       --build-arg BUILD_TIMESTAMP="${BUILD_TIMESTAMP}" --build-arg GITBRANCH=${GITBRANCH}
+       --build-arg BUILD_TIMESTAMP="${BUILD_TIMESTAMP}" --build-arg GITBRANCH=${GITBRANCH} \
+       --load --builder=container $(pwd)/docker
+#docker build docker --platform=linux/arm64,linux/amd64 -t event-management-agent:${IMAGE_TAG} --build-arg BASE_IMAGE=${BASE_IMAGE}\
+#       --build-arg JAR_FILE=event-management-agent-${JAR_VERSION}.jar --build-arg GITHASH=${GITHASH}\
+#       --build-arg BUILD_TIMESTAMP="${BUILD_TIMESTAMP}" --build-arg GITBRANCH=${GITBRANCH}
 cd ${script_dir}
 
 # cleanup

--- a/service/application/docker/buildEventManagementAgentDocker.sh
+++ b/service/application/docker/buildEventManagementAgentDocker.sh
@@ -88,26 +88,9 @@ export JAR_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceSt
 cp ../target/event-management-agent-${JAR_VERSION}.jar .
 
 cd ..
-if docker buildx inspect container > /dev/null ; then
-    echo "Found docker driver multiarch"
-else
-    echo "Creating docker driver multiarch"
-    docker buildx create --name container --driver=docker-container 
-fi
-
-#docker buildx use multiarch
-
-#docker buildx build --no-cache --platform=linux/amd64,linux/arm64 -t 868978040651.dkr.ecr.us-east-1.amazonaws.com/event-management-agent:${IMAGE_TAG} --build-arg BASE_IMAGE=${BASE_IMAGE}\
-#       --build-arg JAR_FILE=event-management-agent-${JAR_VERSION}.jar --build-arg GITHASH=${GITHASH}\
-#       --build-arg BUILD_TIMESTAMP="${BUILD_TIMESTAMP}" --build-arg GITBRANCH=${GITBRANCH} \
-#       --push --builder=container $(pwd)/docker
-docker buildx build --no-cache --platform=linux/amd64,linux/arm64 -t event-management-agent:${IMAGE_TAG} --build-arg BASE_IMAGE=${BASE_IMAGE}\
+docker build docker -t event-management-agent:${IMAGE_TAG} --build-arg BASE_IMAGE=${BASE_IMAGE}\
        --build-arg JAR_FILE=event-management-agent-${JAR_VERSION}.jar --build-arg GITHASH=${GITHASH}\
-       --build-arg BUILD_TIMESTAMP="${BUILD_TIMESTAMP}" --build-arg GITBRANCH=${GITBRANCH} \
-       --load --builder=container $(pwd)/docker
-#docker build docker --platform=linux/arm64,linux/amd64 -t event-management-agent:${IMAGE_TAG} --build-arg BASE_IMAGE=${BASE_IMAGE}\
-#       --build-arg JAR_FILE=event-management-agent-${JAR_VERSION}.jar --build-arg GITHASH=${GITHASH}\
-#       --build-arg BUILD_TIMESTAMP="${BUILD_TIMESTAMP}" --build-arg GITBRANCH=${GITBRANCH}
+       --build-arg BUILD_TIMESTAMP="${BUILD_TIMESTAMP}" --build-arg GITBRANCH=${GITBRANCH}
 cd ${script_dir}
 
 # cleanup

--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <springdoc.version>1.6.11</springdoc.version>
         <snakeyaml.version>2.0</snakeyaml.version>
-        <spring-cloud-starter-sleuth.version>3.1.5</spring-cloud-starter-sleuth.version>
         <spring-security-rsa.version>1.1.1</spring-security-rsa.version>
         <spring-kafka.version>3.0.10</spring-kafka.version>
         <kafka-clients.version>3.5.0</kafka-clients.version>
@@ -61,11 +60,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-sleuth</artifactId>
-            <version>${spring-cloud-starter-sleuth.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>
@@ -253,6 +247,11 @@
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-observation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-observation-test</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -240,6 +240,25 @@
             <version>1.1.2-SNAPSHOT</version>
         </dependency>
 
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-tracing-bridge-brave</artifactId>
+            <!--version>1.1.1</version-->
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>context-propagation</artifactId>
+            <version>1.0.3</version>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-observation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>org.hamcrest</groupId>
@@ -283,12 +302,13 @@
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
     </dependencies>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.springframework.cloud</groupId>
-                <artifactId>spring-cloud-dependencies</artifactId>
-                <version>2021.0.5</version>
+                <groupId>io.micrometer</groupId>
+                <artifactId>micrometer-tracing-bom</artifactId>
+                <version>1.0.4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.solace.maas</groupId>
@@ -282,6 +283,18 @@
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
     </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>2021.0.5</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <build>
         <plugins>
             <plugin>

--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -301,19 +301,6 @@
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
     </dependencies>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.micrometer</groupId>
-                <artifactId>micrometer-tracing-bom</artifactId>
-                <version>1.0.4</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <build>
         <plugins>
             <plugin>

--- a/service/application/src/main/java/com/solace/maas/ep/common/messages/ScanDataImportMessage.java
+++ b/service/application/src/main/java/com/solace/maas/ep/common/messages/ScanDataImportMessage.java
@@ -16,8 +16,6 @@ public class ScanDataImportMessage extends MOPMessage {
 
     String scanId;
 
-    String traceId;
-
     String messagingServiceId;
 
     String runtimeAgentId;
@@ -37,10 +35,10 @@ public class ScanDataImportMessage extends MOPMessage {
 
         this.orgId = orgId;
         this.scanId = scanId;
-        this.traceId = traceId;
         this.messagingServiceId = messagingServiceId;
         this.runtimeAgentId = runtimeAgentId;
         this.scanTypes = scanTypes;
+        setTraceId(traceId);
     }
 
     @Override

--- a/service/application/src/main/java/com/solace/maas/ep/common/messages/ScanDataMessage.java
+++ b/service/application/src/main/java/com/solace/maas/ep/common/messages/ScanDataMessage.java
@@ -12,15 +12,13 @@ public class ScanDataMessage extends MOPMessage {
 
     String scanId;
 
-    String traceId;
-
     String scanType;
 
     String data;
 
     private String timestamp;
 
-    public ScanDataMessage(String orgId, String scanId, String traceId, String scanType, String data, String timestamp) {
+    public ScanDataMessage(String orgId, String scanId, String traceId, String actorId, String scanType, String data, String timestamp) {
         super();
         withMessageType(MOPMessageType.generic)
                 .withProtocol(MOPProtocol.scanData)
@@ -29,10 +27,11 @@ public class ScanDataMessage extends MOPMessage {
 
         this.orgId = orgId;
         this.scanId = scanId;
-        this.traceId = traceId;
         this.scanType = scanType;
         this.data = data;
         this.timestamp = timestamp;
+        setTraceId(traceId);
+        setActorId(actorId);
     }
 
     @Override

--- a/service/application/src/main/java/com/solace/maas/ep/common/messages/ScanDataStatusMessage.java
+++ b/service/application/src/main/java/com/solace/maas/ep/common/messages/ScanDataStatusMessage.java
@@ -16,15 +16,13 @@ public class ScanDataStatusMessage extends MOPMessage {
 
     String scanId;
 
-    String traceId;
-
     String status;
 
     String description;
 
     String scanType;
 
-    public ScanDataStatusMessage(String orgId, String scanId, String traceId, String status, String description, String scanType) {
+    public ScanDataStatusMessage(String orgId, String scanId, String traceId, String actorId, String status, String description, String scanType) {
         super();
         withMessageType(MOPMessageType.generic)
                 .withProtocol(MOPProtocol.scanDataControl)
@@ -33,10 +31,11 @@ public class ScanDataStatusMessage extends MOPMessage {
 
         this.orgId = orgId;
         this.scanId = scanId;
-        this.traceId = traceId;
         this.status = status;
         this.description = description;
         this.scanType = scanType;
+        setTraceId(traceId);
+        setActorId(actorId);
     }
 
     @Override

--- a/service/application/src/main/java/com/solace/maas/ep/common/messages/ScanLogMessage.java
+++ b/service/application/src/main/java/com/solace/maas/ep/common/messages/ScanLogMessage.java
@@ -12,15 +12,13 @@ public class ScanLogMessage extends MOPMessage {
 
     String scanId;
 
-    String traceId;
-
     String level;
 
     String log;
 
     Long timestamp;
 
-    public ScanLogMessage(String orgId, String scanId, String traceId, String level, String log, Long timestamp) {
+    public ScanLogMessage(String orgId, String scanId, String traceId, String actorId, String level, String log, Long timestamp) {
         super();
         withMessageType(MOPMessageType.generic)
                 .withProtocol(MOPProtocol.scanDataControl)
@@ -29,10 +27,11 @@ public class ScanLogMessage extends MOPMessage {
 
         this.orgId = orgId;
         this.scanId = scanId;
-        this.traceId = traceId;
         this.level = level;
         this.log = log;
         this.timestamp = timestamp;
+        setTraceId(traceId);
+        setActorId(actorId);
     }
 
     @Override

--- a/service/application/src/main/java/com/solace/maas/ep/common/messages/ScanStatusMessage.java
+++ b/service/application/src/main/java/com/solace/maas/ep/common/messages/ScanStatusMessage.java
@@ -18,15 +18,13 @@ public class ScanStatusMessage extends MOPMessage {
 
     String scanId;
 
-    String traceId;
-
     String status;
 
     String description;
 
     private List<String> scanTypes;
 
-    public ScanStatusMessage(String orgId, String scanId, String traceId, String status, String description, List<String> scanTypes) {
+    public ScanStatusMessage(String orgId, String scanId, String traceId, String actorId, String status, String description, List<String> scanTypes) {
         super();
         withMessageType(MOPMessageType.generic)
                 .withProtocol(MOPProtocol.scanDataControl)
@@ -35,10 +33,11 @@ public class ScanStatusMessage extends MOPMessage {
 
         this.orgId = orgId;
         this.scanId = scanId;
-        this.traceId = traceId;
         this.status = status;
         this.description = description;
         this.scanTypes = scanTypes;
+        setTraceId(traceId);
+        setActorId(actorId);
     }
 
     @Override

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/logging/StreamingAppender.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/logging/StreamingAppender.java
@@ -11,6 +11,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.ProducerTemplate;
+import org.slf4j.MDC;
 
 import java.util.List;
 
@@ -52,7 +53,7 @@ public class StreamingAppender extends AppenderBase<ILoggingEvent> {
 
             exchange.getIn().setBody(event);
 
-            //MDC.clear();
+            MDC.clear();
         }).whenComplete((exchange, exception) -> {
             if (exception != null) {
                 log.error("Exception occurred while executing route publishLogs for scan {}.", scanId, exception);

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/logging/StreamingAppender.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/logging/StreamingAppender.java
@@ -2,16 +2,15 @@ package com.solace.maas.ep.event.management.agent.logging;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
-import com.solace.maas.ep.event.management.agent.repository.model.route.RouteEntity;
 import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
 import com.solace.maas.ep.event.management.agent.plugin.manager.loader.PluginLoader;
 import com.solace.maas.ep.event.management.agent.plugin.route.RouteBundle;
 import com.solace.maas.ep.event.management.agent.plugin.route.handler.base.MessagingServiceRouteDelegate;
+import com.solace.maas.ep.event.management.agent.repository.model.route.RouteEntity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.ProducerTemplate;
-import org.slf4j.MDC;
 
 import java.util.List;
 
@@ -30,6 +29,7 @@ public class StreamingAppender extends AppenderBase<ILoggingEvent> {
                 sendLogsAsync(event,
                         event.getMDCPropertyMap().get(RouteConstants.SCAN_ID),
                         event.getMDCPropertyMap().get(RouteConstants.TRACE_ID),
+                        event.getMDCPropertyMap().get(RouteConstants.ACTOR_ID),
                         event.getMDCPropertyMap().get(RouteConstants.SCAN_TYPE),
                         event.getMDCPropertyMap().get(RouteConstants.SCHEDULE_ID),
                         event.getMDCPropertyMap().get(RouteConstants.MESSAGING_SERVICE_ID));
@@ -37,20 +37,22 @@ public class StreamingAppender extends AppenderBase<ILoggingEvent> {
         }
     }
 
-    public void sendLogsAsync(ILoggingEvent event, String scanId, String traceId, String scanType, String groupId, String messagingServiceId) {
+    public void sendLogsAsync(ILoggingEvent event, String scanId, String traceId, String actorId,
+                              String scanType, String groupId, String messagingServiceId) {
         RouteEntity route = creatLoggingRoute(scanType, messagingServiceId);
 
         producerTemplate.asyncSend(route.getId(), exchange -> {
             // Need to set headers to let the Route have access to the Scan ID, Group ID, and Messaging Service ID.
             exchange.getIn().setHeader(RouteConstants.SCAN_ID, scanId);
             exchange.getIn().setHeader(RouteConstants.TRACE_ID, traceId);
+            exchange.getIn().setHeader(RouteConstants.ACTOR_ID, actorId);
             exchange.getIn().setHeader(RouteConstants.SCAN_TYPE, scanType);
             exchange.getIn().setHeader(RouteConstants.SCHEDULE_ID, groupId);
             exchange.getIn().setHeader(RouteConstants.MESSAGING_SERVICE_ID, messagingServiceId);
 
             exchange.getIn().setBody(event);
 
-            MDC.clear();
+            //MDC.clear();
         }).whenComplete((exchange, exception) -> {
             if (exception != null) {
                 log.error("Exception occurred while executing route publishLogs for scan {}.", scanId, exception);

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportParseMetaInfFileProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportParseMetaInfFileProcessor.java
@@ -6,6 +6,7 @@ import com.solace.maas.ep.event.management.agent.scanManager.model.MetaInfFileDe
 import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
+import org.slf4j.MDC;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Component;
 
@@ -23,6 +24,7 @@ public class ScanDataImportParseMetaInfFileProcessor implements Processor {
     public void process(Exchange exchange) throws Exception {
         MetaInfFileBO metaInfFileBO = exchange.getIn().getBody(MetaInfFileBO.class);
         String traceId = (String) exchange.getProperty(TRACE_ID);
+        MDC.put(TRACE_ID, traceId);
 
         exchange.getIn().setHeader(RouteConstants.SCAN_ID, metaInfFileBO.getScanId());
         exchange.getIn().setHeader(RouteConstants.MESSAGING_SERVICE_ID, metaInfFileBO.getMessagingServiceId());

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataProcessor.java
@@ -46,10 +46,11 @@ public class ScanDataProcessor implements Processor {
         String messagingServiceId = (String) properties.get(RouteConstants.MESSAGING_SERVICE_ID);
         String scanId = (String) properties.get(RouteConstants.SCAN_ID);
         String traceId = (String) properties.get(RouteConstants.TRACE_ID);
+        String actorId = (String) properties.get(RouteConstants.ACTOR_ID);
         String scanType = (String) properties.get(RouteConstants.SCAN_TYPE);
         Boolean isImportOp = (Boolean) properties.get(RouteConstants.IS_DATA_IMPORT);
 
-        ScanDataMessage scanDataMessage = new ScanDataMessage(orgId, scanId, traceId, scanType, body, Instant.now().toString());
+        ScanDataMessage scanDataMessage = new ScanDataMessage(orgId, scanId, traceId, actorId, scanType, body, Instant.now().toString());
 
         topicDetails.put("orgId", orgId);
         topicDetails.put("runtimeAgentId", runtimeAgentId);

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanLogsProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanLogsProcessor.java
@@ -3,8 +3,8 @@ package com.solace.maas.ep.event.management.agent.processor;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.solace.maas.ep.common.messages.ScanLogMessage;
 import com.solace.maas.ep.event.management.agent.config.eventPortal.EventPortalProperties;
-import com.solace.maas.ep.event.management.agent.publisher.ScanLogsPublisher;
 import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
+import com.solace.maas.ep.event.management.agent.publisher.ScanLogsPublisher;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
@@ -42,9 +42,10 @@ public class ScanLogsProcessor implements Processor {
         ILoggingEvent event = (ILoggingEvent) exchange.getIn().getBody();
         String scanId = (String) properties.get(RouteConstants.SCAN_ID);
         String traceId = (String) properties.get(RouteConstants.TRACE_ID);
+        String actorId = (String) properties.get(RouteConstants.ACTOR_ID);
         String messagingServiceId = (String) properties.get(RouteConstants.MESSAGING_SERVICE_ID);
 
-        ScanLogMessage logDataMessage = new ScanLogMessage(orgId, scanId, traceId, event.getLevel().toString(),
+        ScanLogMessage logDataMessage = new ScanLogMessage(orgId, scanId, traceId, actorId, event.getLevel().toString(),
                 String.format("%s%s", event.getFormattedMessage(), "\n"), event.getTimeStamp());
 
         topicDetails.put("orgId", orgId);

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusOverAllProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusOverAllProcessor.java
@@ -41,6 +41,7 @@ public class ScanStatusOverAllProcessor implements Processor {
         String messagingServiceId = (String) properties.get(RouteConstants.MESSAGING_SERVICE_ID);
         String scanId = (String) properties.get(RouteConstants.SCAN_ID);
         String traceId = (String) properties.get(RouteConstants.TRACE_ID);
+        String actorId = (String) properties.get(RouteConstants.ACTOR_ID);
         ScanStatus status = (ScanStatus) properties.get(RouteConstants.SCAN_STATUS);
         String description = (String) properties.get(RouteConstants.SCAN_STATUS_DESC);
 
@@ -54,7 +55,7 @@ public class ScanStatusOverAllProcessor implements Processor {
         topicDetails.put("scanType", scanType);
         topicDetails.put("status", status.name());
 
-        ScanStatusMessage generalStatusMessage = new ScanStatusMessage(orgId, scanId, traceId, status.name(), description, scanTypes);
+        ScanStatusMessage generalStatusMessage = new ScanStatusMessage(orgId, scanId, traceId, actorId, status.name(), description, scanTypes);
 
         exchange.getIn().setHeader(RouteConstants.GENERAL_STATUS_MESSAGE, generalStatusMessage);
         exchange.getIn().setHeader(RouteConstants.TOPIC_DETAILS, topicDetails);

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusPerRouteProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusPerRouteProcessor.java
@@ -43,8 +43,6 @@ public class ScanStatusPerRouteProcessor implements Processor {
         ScanStatus status = (ScanStatus) properties.get(RouteConstants.SCAN_STATUS);
         String description = (String) properties.get(RouteConstants.SCAN_STATUS_DESC);
 
-        //MDC.put(RouteConstants.ACTOR_ID, actorId);
-
         topicDetails.put("orgId", orgId);
         topicDetails.put("runtimeAgentId", runtimeAgentId);
         topicDetails.put("messagingServiceId", messagingServiceId);

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusPerRouteProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusPerRouteProcessor.java
@@ -38,9 +38,12 @@ public class ScanStatusPerRouteProcessor implements Processor {
         String messagingServiceId = (String) properties.get(RouteConstants.MESSAGING_SERVICE_ID);
         String scanId = (String) properties.get(RouteConstants.SCAN_ID);
         String traceId = (String) properties.get(RouteConstants.TRACE_ID);
+        String actorId = (String) properties.get(RouteConstants.ACTOR_ID);
         String scanType = (String) properties.get(RouteConstants.SCAN_TYPE);
         ScanStatus status = (ScanStatus) properties.get(RouteConstants.SCAN_STATUS);
         String description = (String) properties.get(RouteConstants.SCAN_STATUS_DESC);
+
+        //MDC.put(RouteConstants.ACTOR_ID, actorId);
 
         topicDetails.put("orgId", orgId);
         topicDetails.put("runtimeAgentId", runtimeAgentId);
@@ -49,7 +52,8 @@ public class ScanStatusPerRouteProcessor implements Processor {
         topicDetails.put("status", status.name());
         topicDetails.put("scanDataType", scanType);
 
-        ScanDataStatusMessage scanDataStatusMessage = new ScanDataStatusMessage(orgId, scanId, traceId, status.name(), description, scanType);
+        ScanDataStatusMessage scanDataStatusMessage = new ScanDataStatusMessage(orgId, scanId, traceId, actorId,
+                status.name(), description, scanType);
 
         exchange.getIn().setHeader(RouteConstants.SCAN_DATA_STATUS_MESSAGE, scanDataStatusMessage);
         exchange.getIn().setHeader(RouteConstants.TOPIC_DETAILS, topicDetails);

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanTypeDescendentsProcessorImpl.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanTypeDescendentsProcessorImpl.java
@@ -4,11 +4,11 @@ import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants
 import com.solace.maas.ep.event.management.agent.plugin.processor.ScanTypeDescendentsProcessor;
 import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanRecipientHierarchyEntity;
 import com.solace.maas.ep.event.management.agent.repository.scan.ScanRecipientHierarchyRepository;
+import jakarta.transaction.Transactional;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.Exchange;
 import org.springframework.stereotype.Component;
 
-import jakarta.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -33,6 +33,7 @@ public class ScanTypeDescendentsProcessorImpl implements ScanTypeDescendentsProc
 
         String scanId = (String) properties.get(RouteConstants.SCAN_ID);
         String traceId = (String) properties.get(RouteConstants.TRACE_ID);
+        String actorId = (String) properties.get(RouteConstants.ACTOR_ID);
         String scanType = (String) properties.get(RouteConstants.SCAN_TYPE);
         boolean isEmptyScanTypes = (boolean) properties.get(RouteConstants.IS_EMPTY_SCAN_TYPES);
 
@@ -43,7 +44,8 @@ public class ScanTypeDescendentsProcessorImpl implements ScanTypeDescendentsProc
 
         if (isEmptyScanTypes) {
             allDescendentScanTypes.forEach(type ->
-                    log.info("Scan request [{}], trace ID [{}]: Encountered an empty scan type [{}].", scanId, traceId, type));
+                    log.info("Scan request [{}], trace ID [{}], actor ID [{}]: Encountered an empty scan type [{}].",
+                            scanId, traceId, actorId, type));
         }
 
         exchange.getIn().setHeader(RouteConstants.SCAN_TYPE, allDescendentScanTypes);

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/repository/model/scan/ScanEntity.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/repository/model/scan/ScanEntity.java
@@ -4,13 +4,6 @@ import com.solace.maas.ep.event.management.agent.plugin.jacoco.ExcludeFromJacoco
 import com.solace.maas.ep.event.management.agent.repository.model.file.DataCollectionFileEntity;
 import com.solace.maas.ep.event.management.agent.repository.model.mesagingservice.MessagingServiceEntity;
 import com.solace.maas.ep.event.management.agent.repository.model.route.RouteEntity;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import org.hibernate.annotations.CreationTimestamp;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -22,6 +15,13 @@ import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
 import java.io.Serializable;
 import java.time.Instant;
 import java.util.List;
@@ -44,6 +44,9 @@ public class ScanEntity implements Serializable {
 
     @Column(name = "TRACE_ID")
     private String traceId;
+
+    @Column(name = "ACTOR_ID")
+    private String actorId;
 
     @OneToMany(mappedBy = "scan", fetch = FetchType.LAZY, cascade = CascadeType.MERGE)
     private List<ScanTypeEntity> scanTypes;

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/scanManager/ScanManager.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/scanManager/ScanManager.java
@@ -45,10 +45,12 @@ public class ScanManager {
         String messagingServiceId = scanRequestBO.getMessagingServiceId();
         String scanId = scanRequestBO.getScanId();
         String traceId = scanRequestBO.getTraceId();
+        String actorId = scanRequestBO.getActorId();
         String groupId = UUID.randomUUID().toString();
 
         MDC.put(RouteConstants.SCAN_ID, scanId);
         MDC.put(RouteConstants.TRACE_ID, traceId);
+        MDC.put(RouteConstants.ACTOR_ID, actorId);
         MDC.put(RouteConstants.SCHEDULE_ID, groupId);
         MDC.put(RouteConstants.MESSAGING_SERVICE_ID, messagingServiceId);
 
@@ -97,7 +99,7 @@ public class ScanManager {
                 )
                 .collect(Collectors.toList()).stream().flatMap(List::stream).collect(Collectors.toList());
 
-        return scanService.singleScan(routes, groupId, scanId, traceId, messagingServiceEntity, runtimeAgentId);
+        return scanService.singleScan(routes, groupId, scanId, traceId, actorId, messagingServiceEntity, runtimeAgentId);
     }
 
     private MessagingServiceEntity retrieveMessagingServiceEntity(String messagingServiceId) {

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/scanManager/model/ScanRequestBO.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/scanManager/model/ScanRequestBO.java
@@ -23,6 +23,8 @@ public class ScanRequestBO extends AbstractBaseBO<String> {
 
     private String traceId;
 
+    private String actorId;
+
     private List<String> scanTypes;
 
     private List<String> destinations;
@@ -32,6 +34,7 @@ public class ScanRequestBO extends AbstractBaseBO<String> {
         return "{ messaging service id:[" + messagingServiceId + ']' +
                 ", scan id: [" + scanId + ']' +
                 ", trace id: " + traceId +
+                ", actor id: " + actorId +
                 ", scan types: " + scanTypes +
                 ", destinations: " + destinations +
                 " }";

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/scanManager/rest/DataImportControllerImpl.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/scanManager/rest/DataImportControllerImpl.java
@@ -1,12 +1,12 @@
 package com.solace.maas.ep.event.management.agent.scanManager.rest;
 
+import brave.Tracer;
 import com.solace.maas.ep.event.management.agent.constants.RestEndpoint;
 import com.solace.maas.ep.event.management.agent.scanManager.model.ImportRequestBO;
 import com.solace.maas.ep.event.management.agent.scanManager.model.ZipRequestBO;
 import com.solace.maas.ep.event.management.agent.service.ImportService;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.HttpHeaders;
@@ -32,10 +32,12 @@ import java.io.InputStream;
 @RequestMapping(RestEndpoint.MESSAGING_SERVICE_URL)
 public class DataImportControllerImpl implements DataImportController {
 
+    private final Tracer tracer;
     private final ImportService importService;
 
     @Autowired
-    public DataImportControllerImpl(ImportService importService) {
+    public DataImportControllerImpl(Tracer tracer, ImportService importService) {
+        this.tracer = tracer;
         this.importService = importService;
     }
 
@@ -44,7 +46,8 @@ public class DataImportControllerImpl implements DataImportController {
     public ResponseEntity<String> read(@Parameter(description = "The scan data zip file to be imported.")
                                        @RequestPart("file") final MultipartFile file) {
         try {
-            String traceId = MDC.get("traceId");
+            //String traceId = MDC.get("traceId");
+            String traceId = tracer.currentSpan().context().traceIdString();
             ImportRequestBO importRequestBO = ImportRequestBO.builder()
                     .dataFile(file)
                     .traceId(traceId)

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/scanManager/rest/DataImportControllerImpl.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/scanManager/rest/DataImportControllerImpl.java
@@ -24,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.InputStream;
+import java.util.Objects;
 
 @Slf4j
 @Validated
@@ -47,7 +48,7 @@ public class DataImportControllerImpl implements DataImportController {
     public ResponseEntity<String> read(@Parameter(description = "The scan data zip file to be imported.")
                                        @RequestPart("file") final MultipartFile file) {
         try {
-            String traceId = trace.currentSpan().context().traceId();
+            String traceId = Objects.requireNonNull(trace.currentSpan()).context().traceId();
             ImportRequestBO importRequestBO = ImportRequestBO.builder()
                     .dataFile(file)
                     .traceId(traceId)

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/ScanCommandMessageHandler.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/ScanCommandMessageHandler.java
@@ -57,6 +57,7 @@ public class ScanCommandMessageHandler extends SolaceMessageHandler<ScanCommandM
                 .messagingServiceId(message.getMessagingServiceId())
                 .scanId(!StringUtils.isEmpty(message.getScanId()) ? message.getScanId() : UUID.randomUUID().toString())
                 .traceId(message.getTraceId())
+                .actorId(message.getActorId())
                 .scanTypes(entityTypes)
                 .destinations(scanRequestDestinations)
                 .build();

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/SolaceMessageHandler.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/SolaceMessageHandler.java
@@ -69,15 +69,17 @@ public abstract class SolaceMessageHandler<T extends MOPMessage> implements Mess
 
             String receivedClassName = messageClass.getSimpleName();
 
-            if ("ScanCommandMessage" .equals(receivedClassName) || "ScanDataImportMessage" .equals(receivedClassName)) {
+            if ("ScanCommandMessage".equals(receivedClassName) || "ScanDataImportMessage".equals(receivedClassName)) {
                 Map<String, Object> map = objectMapper.readValue(messageAsString, Map.class);
                 String scanId = (String) map.get("scanId");
                 String traceId = (String) map.get("traceId");
+                String actorId = (String) map.get("actorId");
                 String messagingServiceId = (String) map.get("messagingServiceId");
 
                 MDC.clear();
                 MDC.put(RouteConstants.SCAN_ID, scanId);
                 MDC.put(RouteConstants.TRACE_ID, traceId);
+                MDC.put(RouteConstants.ACTOR_ID, actorId);
                 MDC.put(RouteConstants.MESSAGING_SERVICE_ID, messagingServiceId);
             }
 

--- a/service/application/src/main/resources/logback-spring.xml
+++ b/service/application/src/main/resources/logback-spring.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
-    <property name="LOG_LEVEL_PATTERN" value="%clr(%5p) %clr([%X{X-B3-TraceId:-}]){yellow}"/>
+    <property name="LOG_LEVEL_PATTERN" value="%clr(%5p) %clr([%X{traceId:-}]){yellow}"/>
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
     <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
 

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/ScanLogsPublisherRouteBuilderTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/ScanLogsPublisherRouteBuilderTests.java
@@ -89,6 +89,7 @@ public class ScanLogsPublisherRouteBuilderTests {
                 "orgId",
                 "scanId",
                 "traceId",
+                "actorId",
                 "level",
                 "log", Instant.now().toEpochMilli());
 

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/ScanStatusMarkerAndLoggerRouteBuilderTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/ScanStatusMarkerAndLoggerRouteBuilderTests.java
@@ -59,7 +59,7 @@ public class ScanStatusMarkerAndLoggerRouteBuilderTests {
         exchange.getIn().setHeader(RouteConstants.SCAN_TYPE, "queueListing");
         exchange.getIn().setHeader(RouteConstants.SCAN_STATUS, ScanStatus.IN_PROGRESS);
         exchange.getIn().setHeader(RouteConstants.TRACE_ID, "1234");
-        exchange.getIn().setHeader(RouteConstants.TRACE_ID, "4321");
+        exchange.getIn().setHeader(RouteConstants.ACTOR_ID, "4321");
 
         AdviceWith.adviceWith(camelContext, "markRouteScanStatusInProgress",
                 route -> {

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/ScanStatusMarkerAndLoggerRouteBuilderTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/ScanStatusMarkerAndLoggerRouteBuilderTests.java
@@ -59,6 +59,7 @@ public class ScanStatusMarkerAndLoggerRouteBuilderTests {
         exchange.getIn().setHeader(RouteConstants.SCAN_TYPE, "queueListing");
         exchange.getIn().setHeader(RouteConstants.SCAN_STATUS, ScanStatus.IN_PROGRESS);
         exchange.getIn().setHeader(RouteConstants.TRACE_ID, "1234");
+        exchange.getIn().setHeader(RouteConstants.TRACE_ID, "4321");
 
         AdviceWith.adviceWith(camelContext, "markRouteScanStatusInProgress",
                 route -> {

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/processor/ScanDataProcessorTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/processor/ScanDataProcessorTests.java
@@ -64,6 +64,7 @@ public class ScanDataProcessorTests {
                 "orgId",
                 "scanId",
                 "traceId",
+                "actorId",
                 "scanType",
                 " body",
                 Instant.now().toString());

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusOverAllProcessorTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusOverAllProcessorTests.java
@@ -69,6 +69,7 @@ public class ScanStatusOverAllProcessorTests {
                 null,
                 "scan1",
                 "traceId",
+                "actorId",
                 ScanStatus.IN_PROGRESS.name(),
                 "description",
                 List.of("scanTypes"));

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusPerRouteProcessorTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusPerRouteProcessorTests.java
@@ -69,6 +69,7 @@ public class ScanStatusPerRouteProcessorTests {
                 null,
                 "scan1",
                 "traceId",
+                "actorId",
                 ScanStatus.IN_PROGRESS.name(),
                 "description",
                 "queueListing");

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/scanManager/ScanManagerTest.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/scanManager/ScanManagerTest.java
@@ -62,7 +62,7 @@ class ScanManagerTest {
         when(messagingServiceDelegateService.getMessagingServiceById("id"))
                 .thenReturn(messagingServiceEntity);
 
-        when(scanService.singleScan(List.of(), "groupId", "scanId", "traceId",
+        when(scanService.singleScan(List.of(), "groupId", "scanId", "traceId", "actorId",
                 mock(MessagingServiceEntity.class), "runtimeAgent1"))
                 .thenReturn(Mockito.anyString());
 
@@ -70,6 +70,7 @@ class ScanManagerTest {
                 "id",
                 "scanId",
                 "traceId",
+                "actorId",
                 List.of("topics"),
                 List.of());
 
@@ -79,6 +80,7 @@ class ScanManagerTest {
                 "id",
                 "scanId",
                 "traceId",
+                "actorId",
                 List.of("TEST_SCAN_1"),
                 List.of());
 
@@ -88,6 +90,7 @@ class ScanManagerTest {
                 "id",
                 "scanId",
                 "traceId",
+                "actorId",
                 List.of("TEST_SCAN_2"),
                 List.of());
 
@@ -101,7 +104,7 @@ class ScanManagerTest {
         String confluentSchemaRegistryId = "confluentId";
 
         ScanRequestBO scanRequestBO = new ScanRequestBO(
-                messagingServiceId, "scanId", "traceId",
+                messagingServiceId, "scanId", "traceId", "actorId",
                 List.of("KAFKA_ALL", "CONFLUENT_SCHEMA_REGISTRY_SCHEMA"),
                 List.of("FILE_WRITER"));
 
@@ -147,7 +150,7 @@ class ScanManagerTest {
                     .thenReturn(destinations);
             when(kafkaRouteDelegate.generateRouteList(destinations, List.of(), "KAFKA_ALL", messagingServiceId))
                     .thenReturn(routes);
-            when(scanService.singleScan(List.of(), "groupId", "scanId", "traceId",
+            when(scanService.singleScan(List.of(), "groupId", "scanId", "traceId", "actorId",
                     mock(MessagingServiceEntity.class), "runtimeAgent1"))
                     .thenReturn(Mockito.anyString());
 

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/scanManager/mapper/ScanRequestMapperTest.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/scanManager/mapper/ScanRequestMapperTest.java
@@ -1,9 +1,9 @@
 package com.solace.maas.ep.event.management.agent.scanManager.mapper;
 
+import com.solace.maas.ep.common.model.ScanRequestDTO;
 import com.solace.maas.ep.event.management.agent.TestConfig;
 import com.solace.maas.ep.event.management.agent.model.User;
 import com.solace.maas.ep.event.management.agent.scanManager.model.ScanRequestBO;
-import com.solace.maas.ep.common.model.ScanRequestDTO;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -31,6 +31,7 @@ public class ScanRequestMapperTest {
                 "id",
                 "scanId",
                 "traceId",
+                "actorId",
                 List.of("TEST_SCAN"),
                 List.of());
 
@@ -47,6 +48,7 @@ public class ScanRequestMapperTest {
                 "id",
                 "scanId",
                 "traceId",
+                "actorId",
                 List.of("TEST_SCAN"),
                 List.of());
 

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/scanManager/rest/DataImportControllerTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/scanManager/rest/DataImportControllerTests.java
@@ -1,5 +1,6 @@
 package com.solace.maas.ep.event.management.agent.scanManager.rest;
 
+import brave.Tracer;
 import com.solace.maas.ep.event.management.agent.TestConfig;
 import com.solace.maas.ep.event.management.agent.scanManager.model.ImportRequestBO;
 import com.solace.maas.ep.event.management.agent.scanManager.model.ZipRequestBO;
@@ -35,13 +36,15 @@ public class DataImportControllerTests {
     public ExpectedException exception = ExpectedException.none();
 
     @Mock
+    public Tracer tracer;
+    @Mock
     ImportService importService;
 
     @SneakyThrows
     @Test
     public void testDataImportControllerRead() {
 
-        DataImportController controller = new DataImportControllerImpl(importService);
+        DataImportController controller = new DataImportControllerImpl(tracer, importService);
 
         MultipartFile multipartFile =
                 new MockMultipartFile("file", "test.json", MediaType.APPLICATION_JSON_VALUE,
@@ -59,7 +62,7 @@ public class DataImportControllerTests {
     @Test
     public void testDataImportControllerZip() {
 
-        DataImportController controller = new DataImportControllerImpl(importService);
+        DataImportController controller = new DataImportControllerImpl(tracer, importService);
 
         ZipRequestBO zipRequestBO = ZipRequestBO.builder()
                 .scanId("scanId")
@@ -80,7 +83,7 @@ public class DataImportControllerTests {
     @Test
     public void testDataImportControllerZipWithBadRequest() {
 
-        DataImportController controller = new DataImportControllerImpl(importService);
+        DataImportController controller = new DataImportControllerImpl(tracer, importService);
 
         ResponseEntity<InputStreamResource> reply =
                 controller.zip("scanId");
@@ -93,7 +96,7 @@ public class DataImportControllerTests {
     @SneakyThrows
     @Test
     public void testDataImportControllerException() {
-        DataImportController controller = new DataImportControllerImpl(importService);
+        DataImportController controller = new DataImportControllerImpl(tracer, importService);
 
         MultipartFile multipartFile =
                 new MockMultipartFile("file", "test.json", MediaType.APPLICATION_JSON_VALUE,

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/scanManager/rest/DataImportControllerTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/scanManager/rest/DataImportControllerTests.java
@@ -4,11 +4,13 @@ import com.solace.maas.ep.event.management.agent.TestConfig;
 import com.solace.maas.ep.event.management.agent.scanManager.model.ImportRequestBO;
 import com.solace.maas.ep.event.management.agent.scanManager.model.ZipRequestBO;
 import com.solace.maas.ep.event.management.agent.service.ImportService;
+import io.micrometer.tracing.Tracer;
 import lombok.SneakyThrows;
 import org.junit.Rule;
 import org.junit.jupiter.api.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.HttpStatus;
@@ -37,11 +39,14 @@ public class DataImportControllerTests {
     @Mock
     ImportService importService;
 
+    @Autowired
+    Tracer tracer;
+
     @SneakyThrows
     @Test
     public void testDataImportControllerRead() {
 
-        DataImportController controller = new DataImportControllerImpl(importService);
+        DataImportController controller = new DataImportControllerImpl(importService, tracer);
 
         MultipartFile multipartFile =
                 new MockMultipartFile("file", "test.json", MediaType.APPLICATION_JSON_VALUE,
@@ -59,7 +64,7 @@ public class DataImportControllerTests {
     @Test
     public void testDataImportControllerZip() {
 
-        DataImportController controller = new DataImportControllerImpl(importService);
+        DataImportController controller = new DataImportControllerImpl(importService, tracer);
 
         ZipRequestBO zipRequestBO = ZipRequestBO.builder()
                 .scanId("scanId")
@@ -80,7 +85,7 @@ public class DataImportControllerTests {
     @Test
     public void testDataImportControllerZipWithBadRequest() {
 
-        DataImportController controller = new DataImportControllerImpl(importService);
+        DataImportController controller = new DataImportControllerImpl(importService, tracer);
 
         ResponseEntity<InputStreamResource> reply =
                 controller.zip("scanId");
@@ -93,7 +98,7 @@ public class DataImportControllerTests {
     @SneakyThrows
     @Test
     public void testDataImportControllerException() {
-        DataImportController controller = new DataImportControllerImpl(importService);
+        DataImportController controller = new DataImportControllerImpl(importService, tracer);
 
         MultipartFile multipartFile =
                 new MockMultipartFile("file", "test.json", MediaType.APPLICATION_JSON_VALUE,

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/scanManager/rest/DataImportControllerTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/scanManager/rest/DataImportControllerTests.java
@@ -1,6 +1,5 @@
 package com.solace.maas.ep.event.management.agent.scanManager.rest;
 
-import brave.Tracer;
 import com.solace.maas.ep.event.management.agent.TestConfig;
 import com.solace.maas.ep.event.management.agent.scanManager.model.ImportRequestBO;
 import com.solace.maas.ep.event.management.agent.scanManager.model.ZipRequestBO;
@@ -36,15 +35,13 @@ public class DataImportControllerTests {
     public ExpectedException exception = ExpectedException.none();
 
     @Mock
-    public Tracer tracer;
-    @Mock
     ImportService importService;
 
     @SneakyThrows
     @Test
     public void testDataImportControllerRead() {
 
-        DataImportController controller = new DataImportControllerImpl(tracer, importService);
+        DataImportController controller = new DataImportControllerImpl(importService);
 
         MultipartFile multipartFile =
                 new MockMultipartFile("file", "test.json", MediaType.APPLICATION_JSON_VALUE,
@@ -62,7 +59,7 @@ public class DataImportControllerTests {
     @Test
     public void testDataImportControllerZip() {
 
-        DataImportController controller = new DataImportControllerImpl(tracer, importService);
+        DataImportController controller = new DataImportControllerImpl(importService);
 
         ZipRequestBO zipRequestBO = ZipRequestBO.builder()
                 .scanId("scanId")
@@ -83,7 +80,7 @@ public class DataImportControllerTests {
     @Test
     public void testDataImportControllerZipWithBadRequest() {
 
-        DataImportController controller = new DataImportControllerImpl(tracer, importService);
+        DataImportController controller = new DataImportControllerImpl(importService);
 
         ResponseEntity<InputStreamResource> reply =
                 controller.zip("scanId");
@@ -96,7 +93,7 @@ public class DataImportControllerTests {
     @SneakyThrows
     @Test
     public void testDataImportControllerException() {
-        DataImportController controller = new DataImportControllerImpl(tracer, importService);
+        DataImportController controller = new DataImportControllerImpl(importService);
 
         MultipartFile multipartFile =
                 new MockMultipartFile("file", "test.json", MediaType.APPLICATION_JSON_VALUE,

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/scanManager/rest/EMAControllerTest.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/scanManager/rest/EMAControllerTest.java
@@ -45,6 +45,7 @@ public class EMAControllerTest {
                 "id",
                 "scanConnected",
                 "traceId",
+                "actorId",
                 List.of("TEST_SCAN_TYPE"),
                 List.of());
 
@@ -75,6 +76,7 @@ public class EMAControllerTest {
                 "id",
                 "scanId",
                 "traceId",
+                "actorId",
                 List.of("TEST_SCAN"),
                 List.of("EVENT_PORTAL"));
 
@@ -104,6 +106,7 @@ public class EMAControllerTest {
                 "id",
                 "scanId",
                 "traceId",
+                "actorId",
                 List.of("TEST_SCAN"),
                 List.of());
 

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/service/ScanServiceTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/service/ScanServiceTests.java
@@ -42,13 +42,13 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
-import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ActiveProfiles("TEST")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = TestConfig.class)
@@ -151,6 +151,7 @@ public class ScanServiceTests {
                 "groupId",
                 "scanId",
                 "traceId",
+                "actorId",
                 mock(MessagingServiceEntity.class),
                 "runtimeAgent1");
 
@@ -312,7 +313,7 @@ public class ScanServiceTests {
         ScanService service = new ScanService(mock(ScanRepository.class), mock(ScanRecipientHierarchyRepository.class),
                 mock(ScanTypeRepository.class),
                 mock(ScanStatusRepository.class), mock(ScanRouteService.class), mock(RouteService.class), template, idGenerator);
-        service.sendScanStatus("scanId", "groupId", "messagingServiceId", "traceId",
+        service.sendScanStatus("scanId", "groupId", "messagingServiceId", "traceId", "actorId",
                 "queueListing", ScanStatus.IN_PROGRESS);
 
         assertThatNoException();

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/constants/RouteConstants.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/constants/RouteConstants.java
@@ -9,7 +9,9 @@ public class RouteConstants {
 
     public static final String SCAN_ID = "SCAN_ID";
 
-    public static final String TRACE_ID = "TRACE_ID";
+    public static final String TRACE_ID = "traceId";
+
+    public static final String ACTOR_ID = "ACTOR_ID";
 
     public static final String SCAN_TYPE = "SCAN_TYPE";
 

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/mop/MOPMessage.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/mop/MOPMessage.java
@@ -74,6 +74,9 @@ public abstract class MOPMessage implements Serializable {
     private String destinationName;
     private DestinationType destinationType;
 
+    private String actorId;
+    private String orgId;
+
     // This field indicates the priority of the message.
     // Default is 4. Valid number is from 0(lowest) to 9(highest)
     // This field can only take effect when the destination queue or topic endpoint has toggled `Respect Message

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/processor/logging/MDCProcessor.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/processor/logging/MDCProcessor.java
@@ -19,6 +19,9 @@ public class MDCProcessor implements Processor {
         MDC.put(RouteConstants.TRACE_ID,
                 exchange.getIn().getHeader(RouteConstants.TRACE_ID, String.class));
 
+        MDC.put(RouteConstants.ACTOR_ID,
+                exchange.getIn().getHeader(RouteConstants.ACTOR_ID, String.class));
+
         MDC.put(RouteConstants.SCAN_TYPE,
                 exchange.getIn().getHeader(RouteConstants.SCAN_TYPE, String.class));
 

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/base/ScanStatusMarkerAndLoggerRouteBuilder.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/base/ScanStatusMarkerAndLoggerRouteBuilder.java
@@ -15,11 +15,13 @@ public class ScanStatusMarkerAndLoggerRouteBuilder extends RouteBuilder {
         from("direct:markRouteScanStatusInProgress")
                 .routeId("markRouteScanStatusInProgress")
                 .log("Scan request [${header." + RouteConstants.SCAN_ID + "}], trace ID [${header." +
-                        RouteConstants.TRACE_ID + "}]: The status of [${header." +
+                        RouteConstants.TRACE_ID + "}]: actorId [${header." + RouteConstants.ACTOR_ID + "}]:" +
+                        " The status of [${header." +
                         RouteConstants.SCAN_TYPE + "}]" + " is: [" + ScanStatus.IN_PROGRESS + "].")
                 .to("direct:perRouteScanStatusPublisher?block=false&failIfNoConsumers=false")
                 .log("Scan request [${header." + RouteConstants.SCAN_ID + "}], trace ID [${header." +
-                        RouteConstants.TRACE_ID + "}]: Retrieving [${header." + RouteConstants.SCAN_TYPE
+                        RouteConstants.TRACE_ID + "}]: actorId [${header." + RouteConstants.ACTOR_ID + "}]:" +
+                        " Retrieving [${header." + RouteConstants.SCAN_TYPE
                         + "}] details from event broker [${header." + RouteConstants.MESSAGING_SERVICE_ID + "}].");
 
 
@@ -27,18 +29,21 @@ public class ScanStatusMarkerAndLoggerRouteBuilder extends RouteBuilder {
                 .routeId("markRouteScanStatusComplete")
                 .to("direct:processScanStatusAsComplete?block=false&failIfNoConsumers=false")
                 .log("Scan request [${header." + RouteConstants.SCAN_ID + "}], trace ID [${header." +
-                        RouteConstants.TRACE_ID + "}]: The status of [${header." +
+                        RouteConstants.TRACE_ID + "}]: actorId [${header." + RouteConstants.ACTOR_ID + "}]:" +
+                        "The status of [${header." +
                         RouteConstants.SCAN_TYPE + "}]" + " is: [" + ScanStatus.COMPLETE + "].");
 
 
         from("direct:markRouteImportStatusInProgress")
                 .routeId("markRouteImportStatusInProgress")
                 .log("Scan import request [${header." + RouteConstants.SCAN_ID + "}], trace ID [${header." +
-                        RouteConstants.TRACE_ID + "}]: The status of [${header." +
+                        RouteConstants.TRACE_ID + "}]: actorId [${header." + RouteConstants.ACTOR_ID + "}]:" +
+                        "The status of [${header." +
                         RouteConstants.SCAN_TYPE + "}]" + " is: [" + ScanStatus.IN_PROGRESS + "].")
                 .to("direct:perRouteScanStatusPublisher?block=false&failIfNoConsumers=false")
                 .log("Scan import request [${header." + RouteConstants.SCAN_ID + "}], trace ID [${header." +
-                        RouteConstants.TRACE_ID + "}]: Retrieving [${header." +
+                        RouteConstants.TRACE_ID + "}]: actorId [${header." + RouteConstants.ACTOR_ID + "}]:" +
+                        "The status of [${header." +
                         RouteConstants.SCAN_TYPE + "}] details from file: [${body.fileName}].");
 
 
@@ -46,7 +51,8 @@ public class ScanStatusMarkerAndLoggerRouteBuilder extends RouteBuilder {
                 .routeId("markRouteImportStatusComplete")
                 .to("direct:processScanStatusAsComplete?block=false&failIfNoConsumers=false")
                 .log("Scan import request [${header." + RouteConstants.SCAN_ID + "}], trace ID [${header." +
-                        RouteConstants.TRACE_ID + "}]: The status of [${header." +
+                        RouteConstants.TRACE_ID + "}]: actorId [${header." + RouteConstants.ACTOR_ID + "}]:" +
+                        "The status of [${header." +
                         RouteConstants.SCAN_TYPE + "}]" + " is: [" + ScanStatus.COMPLETE + "].");
     }
 }


### PR DESCRIPTION
### What is the purpose of this change?

1. When a scan is initiated from EP, EP logs the messages received from the EMA as well as activities caused by those messages. We want the orgId, traceId and actorId in the EP logs to be the same for the EP initiated logs, as well as the logs caused by messages received by the EMA. To accomplish this, orgId, traceId and actorId must be passed along the entire flow from EP, through the EMA and then back to EP again. This way, all logs (even on the EMA) will contain the same data and be easier to correlate.

2. When a scan import is initiated on the EMA, we similarly want the traceId to be consistent for all of the logs in EP and EMA in order to make it easier to see the entire stream of logs for the scan import action. In the case of import, we don't set the actorId, since the EMA REST API is unauthenticated, so there is no way to determine the user.

### How was this change implemented?

Actor id was already added to the MOPMessage in maas-base. As part of this change, it is being added to the EMA's MOPMessage structure as well so it is available to all messages.

In EP, the actor Id is set on the scan command message sent to the EMA. The EMA maintains this actorId through all of the routes, and sends it back to EP in the response messages so EP can add it to the logging context.

In the EMA, the actorId is added to the MDCContext and exchange headers wherever this is done from the traceId.

For scan import operations, we want to set a traceId on the EMA. Since sleuth is no longer supported with the move to spring boot 3.0, micrometer was added as the tracing framework. The micrometer generated traceId gets used in the EMA logs, as well as gets sent to EP, so it can be used as the traceId for the EP logs as well.


The RouteConstant for the trace id is changed to "traceId" since this is what micrometer uses and we get this added to our logs for free.

### How was this change tested?

The following operations were tested:
**Functionality**
* Scan initiated from EP
* Scan initiated from EMA
* File download initiated from EMA
* Scan import initiated from EMA

**Backward Compatability**
* Scan initiated from EP using an old EMA
* Scan initiated from an old EMA to EP

### Is there anything the reviewers should focus on/be aware of?

Micrometer generates 128 bit trace ids which are twice as long as what sleuth generates. 

