### PR TITLE
Fix tomcat-embed-core 10.1.13 dependency

### DIFF
--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
-            <version>10.1.13</version>
+            <version>10.1.14</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/service/plugin/pom.xml
+++ b/service/plugin/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
-            <version>10.1.13</version>
+            <version>10.1.14</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -106,11 +106,6 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-socks</artifactId>
-            <version>4.1.100.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler</artifactId>
             <version>4.1.100.Final</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
### What is the purpose of this change?

To fix the `tomcat-embed-core:10.1.13`

### How was this change implemented?

By updating the dependencies in POM files to `tomcat-embed-core:10.1.14`

### How was this change tested?

By scanning Kafka and Solace Event brokers. Also, by running scans in standalone mode, then importing the scans manually. 

### Is there anything the reviewers should focus on/be aware of?

N/A
