### PR TITLE
update the conditions to create beans based on eventPortal section

### DIFF
--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/config/eventPortal/EventPortalProperties.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/config/eventPortal/EventPortalProperties.java
@@ -5,16 +5,19 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 
+import java.util.List;
+
 @Data
 @Configuration
 @PropertySource("classpath:application.yml")
 @ConfigurationProperties(prefix = "event-portal")
 public class EventPortalProperties {
-    private String runtimeAgentId;
+    private String runtimeAgentId = "standalone";
 
-    private String organizationId;
+    private String organizationId = "standalone";
 
     private String topicPrefix;
 
-    private GatewayProperties gateway;
+    private GatewayProperties gateway
+            = new GatewayProperties("standalone", "standalone", new GatewayMessagingProperties(true, false, List.of()));
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportOverAllStatusProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportOverAllStatusProcessor.java
@@ -5,13 +5,13 @@ import com.solace.maas.ep.event.management.agent.plugin.constants.ScanStatus;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 @SuppressWarnings("unchecked")
 @Slf4j
 @Component
-@ConditionalOnExpression("${eventPortal.gateway.messaging.standalone} == false")
+@ConditionalOnProperty(name = "event-portal.gateway.messaging.standalone", havingValue = "false")
 public class ScanDataImportOverAllStatusProcessor implements Processor {
 
     @Override

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportParseMetaInfFileProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportParseMetaInfFileProcessor.java
@@ -6,7 +6,7 @@ import com.solace.maas.ep.event.management.agent.scanManager.model.MetaInfFileDe
 import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -16,7 +16,7 @@ import static com.solace.maas.ep.event.management.agent.plugin.constants.RouteCo
 
 @Slf4j
 @Component
-@ConditionalOnExpression("${eventPortal.gateway.messaging.standalone} == false")
+@ConditionalOnProperty(name = "event-portal.gateway.messaging.standalone", havingValue = "false")
 public class ScanDataImportParseMetaInfFileProcessor implements Processor {
 
     @Override

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportPersistScanFilesProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportPersistScanFilesProcessor.java
@@ -9,14 +9,14 @@ import com.solace.maas.ep.event.management.agent.util.IDGenerator;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
 
 @Slf4j
 @Component
-@ConditionalOnExpression("${eventPortal.gateway.messaging.standalone} == false")
+@ConditionalOnProperty(name = "event-portal.gateway.messaging.standalone", havingValue = "false")
 public class ScanDataImportPersistScanFilesProcessor implements Processor {
 
     private final ScanTypeService scanTypeService;

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportPublishImportScanEventProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportPublishImportScanEventProcessor.java
@@ -8,7 +8,7 @@ import com.solace.maas.ep.event.management.agent.scanManager.model.MetaInfFileDe
 import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
 
 @Slf4j
 @Component
-@ConditionalOnExpression("${eventPortal.gateway.messaging.standalone} == false")
+@ConditionalOnProperty(name = "event-portal.gateway.messaging.standalone", havingValue = "false")
 public class ScanDataImportPublishImportScanEventProcessor implements Processor {
     private final String orgId;
     private final String runtimeAgentId;

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportStatusProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportStatusProcessor.java
@@ -6,12 +6,12 @@ import com.solace.maas.ep.event.management.agent.scanManager.model.MetaInfFileDe
 import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
-@ConditionalOnExpression("${eventPortal.gateway.messaging.standalone} == false")
+@ConditionalOnProperty(name = "event-portal.gateway.messaging.standalone", havingValue = "false")
 public class ScanDataImportStatusProcessor implements Processor {
     @Override
     public void process(Exchange exchange) throws Exception {

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataProcessor.java
@@ -9,7 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.time.Instant;
@@ -19,7 +19,7 @@ import java.util.Map;
 
 @Slf4j
 @Component
-@ConditionalOnExpression("${eventPortal.gateway.messaging.standalone} == false")
+@ConditionalOnProperty(name = "event-portal.gateway.messaging.standalone", havingValue = "false")
 public class ScanDataProcessor implements Processor {
 
     private final ScanDataPublisher scanDataPublisher;

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanLogsProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanLogsProcessor.java
@@ -3,13 +3,13 @@ package com.solace.maas.ep.event.management.agent.processor;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.solace.maas.ep.common.messages.ScanLogMessage;
 import com.solace.maas.ep.event.management.agent.config.eventPortal.EventPortalProperties;
-import com.solace.maas.ep.event.management.agent.publisher.ScanLogsPublisher;
 import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
+import com.solace.maas.ep.event.management.agent.publisher.ScanLogsPublisher;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
@@ -17,7 +17,7 @@ import java.util.Map;
 
 @Slf4j
 @Component
-@ConditionalOnExpression("${eventPortal.gateway.messaging.standalone} == false")
+@ConditionalOnProperty(name = "event-portal.gateway.messaging.standalone", havingValue = "false")
 public class ScanLogsProcessor implements Processor {
     private final String orgId;
     private final String runtimeAgentId;

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusOverAllProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusOverAllProcessor.java
@@ -8,7 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
@@ -19,7 +19,7 @@ import java.util.Map;
 @SuppressWarnings("CPD-START")
 @Slf4j
 @Component
-@ConditionalOnExpression("${eventPortal.gateway.messaging.standalone} == false")
+@ConditionalOnProperty(name = "event-portal.gateway.messaging.standalone", havingValue = "false")
 public class ScanStatusOverAllProcessor implements Processor {
 
     private final String orgId;

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusPerRouteProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusPerRouteProcessor.java
@@ -8,7 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
@@ -16,7 +16,7 @@ import java.util.Map;
 
 @Slf4j
 @Component
-@ConditionalOnExpression("${eventPortal.gateway.messaging.standalone} == false")
+@ConditionalOnProperty(name = "event-portal.gateway.messaging.standalone", havingValue = "false")
 @SuppressWarnings("unchecked")
 public class ScanStatusPerRouteProcessor implements Processor {
     private final String orgId;

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/publisher/HeartbeatGenerator.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/publisher/HeartbeatGenerator.java
@@ -6,6 +6,7 @@ import com.solace.maas.ep.event.management.agent.config.eventPortal.EventPortalP
 import com.solace.maas.ep.event.management.agent.plugin.jacoco.ExcludeFromJacocoGeneratedReport;
 import com.solace.maas.ep.event.management.agent.plugin.publisher.SolacePublisher;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.info.BuildProperties;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -14,7 +15,8 @@ import java.time.Instant;
 
 @ExcludeFromJacocoGeneratedReport
 @Component
-@ConditionalOnExpression("${eventPortal.gateway.messaging.standalone} == false and ${eventPortal.gateway.messaging.enableHeartbeats}")
+@ConditionalOnExpression("${eventPortal.gateway.messaging.enableHeartbeats}")
+@ConditionalOnProperty(name = "event-portal.gateway.messaging.standalone", havingValue = "false")
 public class HeartbeatGenerator {
 
     private final SolacePublisher solacePublisher;

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/publisher/ScanDataPublisher.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/publisher/ScanDataPublisher.java
@@ -2,13 +2,13 @@ package com.solace.maas.ep.event.management.agent.publisher;
 
 import com.solace.maas.ep.event.management.agent.plugin.mop.MOPMessage;
 import com.solace.maas.ep.event.management.agent.plugin.publisher.SolacePublisher;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
 
 @Component
-@ConditionalOnExpression("${eventPortal.gateway.messaging.standalone} == false")
+@ConditionalOnProperty(name = "event-portal.gateway.messaging.standalone", havingValue = "false")
 public class ScanDataPublisher {
 
     private final SolacePublisher solacePublisher;

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/publisher/ScanLogsPublisher.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/publisher/ScanLogsPublisher.java
@@ -3,7 +3,7 @@ package com.solace.maas.ep.event.management.agent.publisher;
 import com.solace.maas.ep.common.messages.ScanLogMessage;
 import com.solace.maas.ep.event.management.agent.plugin.publisher.SolacePublisher;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
@@ -11,7 +11,7 @@ import java.util.Map;
 
 @Component
 @Slf4j
-@ConditionalOnExpression("${eventPortal.gateway.messaging.standalone} == false")
+@ConditionalOnProperty(name = "event-portal.gateway.messaging.standalone", havingValue = "false")
 public class ScanLogsPublisher {
 
     private final SolacePublisher solacePublisher;

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/publisher/ScanStatusPublisher.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/publisher/ScanStatusPublisher.java
@@ -7,7 +7,7 @@ import com.solace.maas.ep.event.management.agent.plugin.publisher.SolacePublishe
 import com.solace.maas.ep.event.management.agent.plugin.route.exceptions.ScanOverallStatusException;
 import com.solace.maas.ep.event.management.agent.plugin.route.exceptions.ScanStatusException;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
@@ -16,7 +16,7 @@ import java.util.Map;
 
 @Slf4j
 @Component
-@ConditionalOnExpression("${eventPortal.gateway.messaging.standalone} == false")
+@ConditionalOnProperty(name = "event-portal.gateway.messaging.standalone", havingValue = "false")
 public class ScanStatusPublisher {
 
     private final SolacePublisher solacePublisher;

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/ScanDataPublisherRouteBuilder.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/ScanDataPublisherRouteBuilder.java
@@ -4,11 +4,11 @@ import com.solace.maas.ep.event.management.agent.plugin.processor.ScanTypeDescen
 import com.solace.maas.ep.event.management.agent.plugin.route.handler.base.AbstractRouteBuilder;
 import com.solace.maas.ep.event.management.agent.processor.ScanDataProcessor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 @Component
-@ConditionalOnExpression("${eventPortal.gateway.messaging.standalone} == false")
+@ConditionalOnProperty(name = "event-portal.gateway.messaging.standalone", havingValue = "false")
 public class ScanDataPublisherRouteBuilder extends AbstractRouteBuilder {
     private final ScanDataProcessor processor;
 

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/ScanLogsPublisherRouteBuilder.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/ScanLogsPublisherRouteBuilder.java
@@ -3,11 +3,11 @@ package com.solace.maas.ep.event.management.agent.route.ep;
 import com.solace.maas.ep.event.management.agent.processor.ScanLogsProcessor;
 import org.apache.camel.builder.RouteBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 @Component
-@ConditionalOnExpression("${eventPortal.gateway.messaging.standalone} == false")
+@ConditionalOnProperty(name = "event-portal.gateway.messaging.standalone", havingValue = "false")
 public class ScanLogsPublisherRouteBuilder extends RouteBuilder {
     private final ScanLogsProcessor scanLogsProcessor;
 

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/ScanStatusPublisherRouteBuilder.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/ScanStatusPublisherRouteBuilder.java
@@ -6,12 +6,12 @@ import com.solace.maas.ep.event.management.agent.plugin.route.handler.base.Abstr
 import com.solace.maas.ep.event.management.agent.processor.ScanStatusOverAllProcessor;
 import com.solace.maas.ep.event.management.agent.processor.ScanStatusPerRouteProcessor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
-@ConditionalOnExpression("${eventPortal.gateway.messaging.standalone} == false")
+@ConditionalOnProperty(name = "event-portal.gateway.messaging.standalone", havingValue = "false")
 @Profile("!TEST")
 public class ScanStatusPublisherRouteBuilder extends AbstractRouteBuilder {
 

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/manualImport/ImportRouteBuilder.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/manualImport/ImportRouteBuilder.java
@@ -3,14 +3,14 @@ package com.solace.maas.ep.event.management.agent.route.manualImport;
 import com.solace.maas.ep.event.management.agent.plugin.route.exceptionhandlers.ScanDataImportExceptionHandler;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import static com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants.IMPORT_ID;
 import static com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants.TRACE_ID;
 
 @Component
-@ConditionalOnExpression("${eventPortal.gateway.messaging.standalone} == false")
+@ConditionalOnProperty(name = "event-portal.gateway.messaging.standalone", havingValue = "false")
 public class ImportRouteBuilder extends RouteBuilder {
 
     @Override

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/manualImport/ScanDataImportParseMetaInfFileRouteBuilder.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/manualImport/ScanDataImportParseMetaInfFileRouteBuilder.java
@@ -1,23 +1,23 @@
 package com.solace.maas.ep.event.management.agent.route.manualImport;
 
 import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
+import com.solace.maas.ep.event.management.agent.plugin.route.exceptionhandlers.ScanDataImportExceptionHandler;
 import com.solace.maas.ep.event.management.agent.processor.ScanDataImportOverAllStatusProcessor;
 import com.solace.maas.ep.event.management.agent.processor.ScanDataImportParseMetaInfFileProcessor;
 import com.solace.maas.ep.event.management.agent.processor.ScanDataImportPersistFilePathsProcessor;
 import com.solace.maas.ep.event.management.agent.processor.ScanDataImportPersistScanDataProcessor;
 import com.solace.maas.ep.event.management.agent.processor.ScanDataImportPublishImportScanEventProcessor;
-import com.solace.maas.ep.event.management.agent.plugin.route.exceptionhandlers.ScanDataImportExceptionHandler;
 import com.solace.maas.ep.event.management.agent.scanManager.model.MetaInfFileBO;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.dataformat.JsonLibrary;
 import org.apache.camel.processor.aggregate.UseLatestAggregationStrategy;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import static com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants.IMPORT_ID;
 
 @Component
-@ConditionalOnExpression("${eventPortal.gateway.messaging.standalone} == false")
+@ConditionalOnProperty(name = "event-portal.gateway.messaging.standalone", havingValue = "false")
 public class ScanDataImportParseMetaInfFileRouteBuilder extends RouteBuilder {
 
     private final ScanDataImportParseMetaInfFileProcessor scanDataImportParseMetaInfFileProcessor;

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/manualImport/ScanDataImportParseZipFileRouteBuilder.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/manualImport/ScanDataImportParseZipFileRouteBuilder.java
@@ -5,7 +5,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.dataformat.zipfile.ZipSplitter;
 import org.apache.camel.model.dataformat.ZipFileDataFormat;
 import org.apache.camel.processor.aggregate.UseLatestAggregationStrategy;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.util.Iterator;
@@ -13,7 +13,7 @@ import java.util.Iterator;
 import static com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants.IMPORT_ID;
 
 @Component
-@ConditionalOnExpression("${eventPortal.gateway.messaging.standalone} == false")
+@ConditionalOnProperty(name = "event-portal.gateway.messaging.standalone", havingValue = "false")
 public class ScanDataImportParseZipFileRouteBuilder extends RouteBuilder {
 
     @Override

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/manualImport/ScanDataImportStreamFilesRouteBuilder.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/manualImport/ScanDataImportStreamFilesRouteBuilder.java
@@ -1,19 +1,19 @@
 package com.solace.maas.ep.event.management.agent.route.manualImport;
 
 import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
+import com.solace.maas.ep.event.management.agent.plugin.route.exceptionhandlers.ScanDataImportExceptionHandler;
 import com.solace.maas.ep.event.management.agent.processor.ScanDataImportPersistScanFilesProcessor;
 import com.solace.maas.ep.event.management.agent.processor.ScanDataImportStatusProcessor;
 import com.solace.maas.ep.event.management.agent.route.ep.aggregation.FileParseAggregationStrategy;
-import com.solace.maas.ep.event.management.agent.plugin.route.exceptionhandlers.ScanDataImportExceptionHandler;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import static com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants.IMPORT_ID;
 
 @Component
-@ConditionalOnExpression("${eventPortal.gateway.messaging.standalone} == false")
+@ConditionalOnProperty(name = "event-portal.gateway.messaging.standalone", havingValue = "false")
 public class ScanDataImportStreamFilesRouteBuilder extends RouteBuilder {
 
     private final ScanDataImportStatusProcessor scanDataImportStatusProcessor;

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/HeartbeatMessageHandler.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/HeartbeatMessageHandler.java
@@ -4,6 +4,7 @@ import com.solace.maas.ep.common.messages.HeartbeatMessage;
 import com.solace.maas.ep.event.management.agent.config.SolaceConfiguration;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 /**
@@ -13,9 +14,9 @@ import org.springframework.stereotype.Component;
  */
 @Slf4j
 @Component
-@ConditionalOnExpression("${eventPortal.gateway.messaging.standalone} == false " +
-        "and ${eventPortal.gateway.messaging.enableHeartbeats} " +
+@ConditionalOnExpression("${eventPortal.gateway.messaging.enableHeartbeats} " +
         "and ${eventPortal.gateway.messaging.testHeartbeats}")
+@ConditionalOnProperty(name = "event-portal.gateway.messaging.standalone", havingValue = "false")
 public class HeartbeatMessageHandler extends SolaceMessageHandler<HeartbeatMessage> {
 
     public HeartbeatMessageHandler(


### PR DESCRIPTION
### What is the purpose of this change?

Update the conditions to create the spring beans based on the existence of the `eventPortal` section in the `application.yml` file

### How was this change implemented?

By providing default values for the `EventPortalProperties` when the `eventPortal` doesn't exist in the `application.yml` file. Also, updating the conditions to instantiate classes based on the value of `standalone` flag.

### How was this change tested?

Manually by starting the EMA using different configs in `application.yml` file, e.g., with and without `eventPortal` section, then running scans in online and offline modes

### Is there anything the reviewers should focus on/be aware of?

N/A
