### PR TITLE
DATAGO-64175: Add proper file separators for the OS

### DIFF
--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ImportService.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ImportService.java
@@ -119,7 +119,6 @@ public class ImportService {
         files.forEach(file -> {
             String filePath = file.getPath();
             String fileName = StringUtils.substringAfterLast(filePath, File.separator);
-
             String dataEntityType = fileName.replace(".json", "");
 
             MetaInfFileDetailsBO metaInfFileDetailsBOFile =

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ImportService.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ImportService.java
@@ -97,7 +97,7 @@ public class ImportService {
                     String message = "Could not find scan files.";
                     log.error(message);
                     return new FileNotFoundException(message);
-                }).getPath(), "/");
+                }).getPath(), File.separator);
 
         MetaInfFileBO metaInfJson = prepareMetaInfJson(files, messagingServiceId, emaId, scheduleId, scanId);
 
@@ -118,7 +118,8 @@ public class ImportService {
         List<MetaInfFileDetailsBO> metaInfFileDetailsBOFiles = new ArrayList<>();
         files.forEach(file -> {
             String filePath = file.getPath();
-            String fileName = StringUtils.substringAfterLast(filePath, "/");
+            String fileName = StringUtils.substringAfterLast(filePath, File.separator);
+
             String dataEntityType = fileName.replace(".json", "");
 
             MetaInfFileDetailsBO metaInfFileDetailsBOFile =


### PR DESCRIPTION
### What is the purpose of this change?
Fix a bug where the zip file cannot be exported on windows machines

### How was this change implemented?
Added the OS dependant File.separator instead of hardcoding the unix '/' separator.

### How was this change tested?
Tested on mac and windows.

### Is there anything the reviewers should focus on/be aware of?
No
