### PR TITLE
DATAGO-66413: Rename correlationId -> commandCorrelationId

### DIFF
--- a/service/application/src/main/java/com/solace/maas/ep/common/messages/CommandMessage.java
+++ b/service/application/src/main/java/com/solace/maas/ep/common/messages/CommandMessage.java
@@ -12,7 +12,7 @@ import java.util.List;
 @Data
 public class CommandMessage extends MOPMessage {
 
-    private String correlationId;
+    private String commandCorrelationId;
     private String context;
     private String serviceId;
     private List<CommandBundle> commandBundles;
@@ -22,7 +22,7 @@ public class CommandMessage extends MOPMessage {
     }
 
     public CommandMessage(String serviceId,
-                          String correlationId,
+                          String commandCorrelationId,
                           String context,
                           List<CommandBundle> commandBundles) {
         super();
@@ -31,7 +31,7 @@ public class CommandMessage extends MOPMessage {
                 .withVersion("1")
                 .withUhFlag(MOPUHFlag.ignore);
         this.serviceId = serviceId;
-        this.correlationId = correlationId;
+        this.commandCorrelationId = commandCorrelationId;
         this.context = context;
         this.commandBundles = commandBundles;
     }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/CommandManager.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/CommandManager.java
@@ -88,7 +88,7 @@ public class CommandManager {
         Map<String, String> topicVars = Map.of(
                 "orgId", request.getOrgId(),
                 "runtimeAgentId", eventPortalProperties.getRuntimeAgentId(),
-                "correlationId", request.getCorrelationId()
+                "correlationId", request.getCommandCorrelationId()
         );
         commandPublisher.sendCommandResponse(request, topicVars);
     }

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/commandManager/CommandManagerTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/commandManager/CommandManagerTests.java
@@ -61,7 +61,7 @@ public class CommandManagerTests {
         message.setActorId("myActorId");
         message.setOrgId(eventPortalProperties.getOrganizationId());
         message.setTraceId("myTraceId");
-        message.setCorrelationId("myCorrelationId");
+        message.setCommandCorrelationId("myCorrelationId");
         message.setCommandBundles(List.of(
                 CommandBundle.builder()
                         .executionType(ExecutionType.serial)
@@ -101,6 +101,6 @@ public class CommandManagerTests {
         Map<String, String> topicVars = topicArgCaptor.getValue();
         assert topicVars.get("orgId").equals(eventPortalProperties.getOrganizationId());
         assert topicVars.get("runtimeAgentId").equals(eventPortalProperties.getRuntimeAgentId());
-        assert topicVars.get("correlationId").equals(message.getCorrelationId());
+        assert topicVars.get("correlationId").equals(message.getCommandCorrelationId());
     }
 }

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/realTests/NegativeTerraformEVMRConnectedTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/realTests/NegativeTerraformEVMRConnectedTests.java
@@ -446,7 +446,7 @@ public class NegativeTerraformEVMRConnectedTests {
         message.setOrgId(eventPortalProperties.getOrganizationId());
         message.setTraceId("myTraceId");
         message.setServiceId(serviceId);
-        message.setCorrelationId(correlationId);
+        message.setCommandCorrelationId(correlationId);
     }
 
 


### PR DESCRIPTION
### What is the purpose of this change?

correlationId is being clobbered by the Id in MopMessage. We didn't intend for it to override this value, so we must rename it.

### How was this change implemented?

Renamed correlationId -> commandCorrelationId

### How was this change tested?

Manually in a dev environment, sending a request to the EMA and verifying the response back.

### Is there anything the reviewers should focus on/be aware of?

None
