### PR TITLE
DATAGO-66943: Fix vulnerabilities for logback-classic and logback-core

### DIFF
--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -55,10 +55,28 @@
             <artifactId>spring-boot-starter</artifactId>
             <exclusions>
                 <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-core</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.yaml</groupId>
                     <artifactId>snakeyaml</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.4.12</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>1.4.12</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/service/local-storage-plugin/pom.xml
+++ b/service/local-storage-plugin/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.solace.maas.plugin.localstorage</groupId>
     <artifactId>local-storage-plugin</artifactId>
@@ -46,6 +47,10 @@
             <version>${camel.version}</version>
             <exclusions>
                 <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.yaml</groupId>
                     <artifactId>snakeyaml</artifactId>
                 </exclusion>
@@ -88,6 +93,10 @@
             <artifactId>spring-boot-starter</artifactId>
             <version>${spring-boot-starter.version}</version>
             <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.yaml</groupId>
                     <artifactId>snakeyaml</artifactId>

--- a/service/terraform-plugin/pom.xml
+++ b/service/terraform-plugin/pom.xml
@@ -31,7 +31,16 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.4.12</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
### What is the purpose of this change?
Address vulnerabilities in logback-classic and logback-core version 1.4.11.

### How was this change implemented?
Excluded the library where appropriate and then re-included it at a higher level where needed.

### How was this change tested?
Manually tested a config push running from IDE

### Is there anything the reviewers should focus on/be aware of?
No


Output of mvn dependency tree:
```
> mvn dependency:tree | grep logback
[INFO] +- ch.qos.logback:logback-classic:jar:1.4.12:compile
[INFO] |  +- ch.qos.logback:logback-core:jar:1.4.12:compile
[INFO] +- ch.qos.logback:logback-classic:jar:1.4.12:compile
[INFO] +- ch.qos.logback:logback-core:jar:1.4.12:compile
```

Covers vulnerabilities in https://sol-jira.atlassian.net/browse/DATAGO-66942 and https://sol-jira.atlassian.net/browse/DATAGO-66943