### PR TITLE
[DATAGO-64298] rename correlationId to commandCorrelationId in missed spots

### DIFF
--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/CommandManager.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/CommandManager.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.solace.maas.ep.event.management.agent.constants.Command.COMMAND_CORRELATION_ID;
 import static com.solace.maas.ep.event.management.agent.plugin.terraform.manager.TerraformManager.LOG_LEVEL_ERROR;
 import static com.solace.maas.ep.event.management.agent.plugin.terraform.manager.TerraformManager.setCommandError;
 
@@ -88,7 +89,7 @@ public class CommandManager {
         Map<String, String> topicVars = Map.of(
                 "orgId", request.getOrgId(),
                 "runtimeAgentId", eventPortalProperties.getRuntimeAgentId(),
-                "correlationId", request.getCommandCorrelationId()
+                COMMAND_CORRELATION_ID, request.getCommandCorrelationId()
         );
         commandPublisher.sendCommandResponse(request, topicVars);
     }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/constants/Command.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/constants/Command.java
@@ -1,0 +1,8 @@
+package com.solace.maas.ep.event.management.agent.constants;
+
+import com.solace.maas.ep.event.management.agent.plugin.jacoco.ExcludeFromJacocoGeneratedReport;
+
+@ExcludeFromJacocoGeneratedReport
+public class Command {
+    public static final String COMMAND_CORRELATION_ID = "commandCorrelationId";
+}

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/CommandLogsProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/CommandLogsProcessor.java
@@ -3,6 +3,7 @@ package com.solace.maas.ep.event.management.agent.processor;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.solace.maas.ep.common.messages.CommandLogMessage;
 import com.solace.maas.ep.event.management.agent.config.eventPortal.EventPortalProperties;
+import com.solace.maas.ep.event.management.agent.constants.Command;
 import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
 import com.solace.maas.ep.event.management.agent.publisher.CommandLogsPublisher;
 import lombok.extern.slf4j.Slf4j;
@@ -51,7 +52,7 @@ public class CommandLogsProcessor implements Processor {
         topicDetails.put("orgId", orgId);
         topicDetails.put("runtimeAgentId", runtimeAgentId);
         topicDetails.put("messagingServiceId", messagingServiceId);
-        topicDetails.put("commandCorrelationId", commandCorrelationId);
+        topicDetails.put(Command.COMMAND_CORRELATION_ID, commandCorrelationId);
 
         logDataPublisher.sendCommandLogData(logDataMessage, topicDetails);
     }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/publisher/CommandLogsPublisher.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/publisher/CommandLogsPublisher.java
@@ -2,6 +2,7 @@ package com.solace.maas.ep.event.management.agent.publisher;
 
 import com.solace.maas.ep.common.messages.CommandLogMessage;
 import com.solace.maas.ep.event.management.agent.config.SolaceConfiguration;
+import com.solace.maas.ep.event.management.agent.constants.Command;
 import com.solace.maas.ep.event.management.agent.plugin.publisher.SolacePublisher;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -26,7 +27,7 @@ public class CommandLogsPublisher {
 
     public void sendCommandLogData(CommandLogMessage message, Map<String, String> topicDetails) {
         String topicString = solaceConfiguration.getTopicPrefix() +
-                String.format("commandLogs/v1/%s", topicDetails.get("commandCorrelationId"));
+                String.format("commandLogs/v1/%s", topicDetails.get(Command.COMMAND_CORRELATION_ID));
 
         solacePublisher.publish(message, topicString);
     }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/publisher/CommandPublisher.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/publisher/CommandPublisher.java
@@ -1,6 +1,7 @@
 package com.solace.maas.ep.event.management.agent.publisher;
 
 import com.solace.maas.ep.event.management.agent.config.SolaceConfiguration;
+import com.solace.maas.ep.event.management.agent.constants.Command;
 import com.solace.maas.ep.event.management.agent.plugin.mop.MOPMessage;
 import com.solace.maas.ep.event.management.agent.plugin.publisher.SolacePublisher;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -24,7 +25,7 @@ public class CommandPublisher {
      * Sends the command response to EP.
      * <p>
      * The topic for command response:
-     * sc/ep/runtime/{orgId}/{runtimeAgentId}/commandResponse/v1/{correlationId}
+     * sc/ep/runtime/{orgId}/{runtimeAgentId}/commandResponse/v1/{commandCorrelationId}
      */
 
     public void sendCommandResponse(MOPMessage message, Map<String, String> topicDetails) {
@@ -32,7 +33,7 @@ public class CommandPublisher {
         String topicString =
                 String.format("%scommandResponse/v1/%s",
                         solaceConfiguration.getTopicPrefix(),
-                        topicDetails.get("correlationId"));
+                        topicDetails.get(Command.COMMAND_CORRELATION_ID));
 
         solacePublisher.publish(message, topicString);
     }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/SolaceMessageHandler.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/SolaceMessageHandler.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.solace.maas.ep.event.management.agent.constants.Command;
 import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
 import com.solace.maas.ep.event.management.agent.plugin.mop.EnumDeserializer;
 import com.solace.maas.ep.event.management.agent.plugin.mop.MOPConstants;
@@ -97,7 +98,7 @@ public abstract class SolaceMessageHandler<T extends MOPMessage> implements Mess
         }
 
         if (commandClassNames.contains(receivedClassName)) {
-            MDC.put(RouteConstants.COMMAND_CORRELATION_ID, map.get("correlationId"));
+            MDC.put(RouteConstants.COMMAND_CORRELATION_ID, map.get(Command.COMMAND_CORRELATION_ID));
             MDC.put(RouteConstants.MESSAGING_SERVICE_ID, map.get("serviceId"));
         }
     }

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/commandManager/CommandManagerTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/commandManager/CommandManagerTests.java
@@ -24,6 +24,7 @@ import org.springframework.test.context.ActiveProfiles;
 import java.util.List;
 import java.util.Map;
 
+import static com.solace.maas.ep.event.management.agent.constants.Command.COMMAND_CORRELATION_ID;
 import static com.solace.maas.ep.event.management.agent.plugin.mop.MOPMessageType.generic;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
@@ -101,6 +102,6 @@ public class CommandManagerTests {
         Map<String, String> topicVars = topicArgCaptor.getValue();
         assert topicVars.get("orgId").equals(eventPortalProperties.getOrganizationId());
         assert topicVars.get("runtimeAgentId").equals(eventPortalProperties.getRuntimeAgentId());
-        assert topicVars.get("correlationId").equals(message.getCommandCorrelationId());
+        assert topicVars.get(COMMAND_CORRELATION_ID).equals(message.getCommandCorrelationId());
     }
 }

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/command/model/CommandRequest.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/command/model/CommandRequest.java
@@ -12,7 +12,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CommandRequest {
-    private String correlationId;
+    private String commandCorrelationId;
     private String context;
     private String serviceId;
     private List<CommandBundle> commandBundles;

--- a/service/terraform-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/terraform/manager/TerraformLogProcessingService.java
+++ b/service/terraform-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/terraform/manager/TerraformLogProcessingService.java
@@ -56,7 +56,7 @@ public class TerraformLogProcessingService {
         }
 
         Path out = Files.createTempFile(logPath, System.currentTimeMillis() + "-"
-                + request.getCorrelationId() + "-job", ".log");
+                + request.getCommandCorrelationId() + "-job", ".log");
 
         Files.write(out, logs, Charset.defaultCharset());
     }

--- a/service/terraform-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/terraform/manager/TerraformManager.java
+++ b/service/terraform-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/terraform/manager/TerraformManager.java
@@ -43,11 +43,11 @@ public class TerraformManager {
 
     public void execute(CommandRequest request, Command command, Map<String, String> envVars) {
 
-        MDC.put(RouteConstants.COMMAND_CORRELATION_ID, request.getCorrelationId());
+        MDC.put(RouteConstants.COMMAND_CORRELATION_ID, request.getCommandCorrelationId());
         MDC.put(RouteConstants.MESSAGING_SERVICE_ID, request.getServiceId());
 
         log.debug("Executing command {} for serviceId {} correlationId {} context {}", command.getCommand(), request.getServiceId(),
-                request.getCorrelationId(), request.getContext());
+                request.getCommandCorrelationId(), request.getContext());
 
         try (TerraformClient terraformClient = terraformClientFactory.createClient()) {
 

--- a/service/terraform-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/terraform/TerraformCommandIT.java
+++ b/service/terraform-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/terraform/TerraformCommandIT.java
@@ -329,7 +329,7 @@ public class TerraformCommandIT {
                                 .exitOnFailure(false)
                                 .commands(List.of(commandRequest))
                                 .build()))
-                .correlationId("234")
+                .commandCorrelationId("234")
                 .context("app123")
                 .serviceId("ms1234")
                 .build();

--- a/service/terraform-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/terraform/real/TerraformClientRealTests.java
+++ b/service/terraform-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/terraform/real/TerraformClientRealTests.java
@@ -112,7 +112,7 @@ public class TerraformClientRealTests {
                 .build();
 
         CommandRequest terraformRequest = CommandRequest.builder()
-                .correlationId("abc123")
+                .commandCorrelationId("abc123")
                 .context("app123-consumer")
                 .commandBundles(List.of(
                         CommandBundle.builder()
@@ -156,7 +156,7 @@ public class TerraformClientRealTests {
                         .build()))
                 .context(context)
                 .serviceId("abc123")
-                .correlationId("myCorrelationId")
+                .commandCorrelationId("myCorrelationId")
                 .build();
 
         for (Command command : terraformRequest.getCommandBundles().get(0).getCommands()) {


### PR DESCRIPTION
### What is the purpose of this change?
To rename an important attribute which without this PR, the proper end-to-end flow of sending TF logs to EP won't work.

### How was this change implemented?
Renamed correlationId -> commandCorrelationId in code

### How was this change tested?
Manually and updated ITs

### Is there anything the reviewers should focus on/be aware of?
Nope
