### PR TITLE
DATAGO-67370: Add a thread pool to command manager

### DIFF
--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -281,6 +281,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.2.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.solacesystems</groupId>
             <artifactId>solclientj</artifactId>
             <version>10.0.0</version>

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/CommandManager.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/CommandManager.java
@@ -60,7 +60,7 @@ public class CommandManager {
 
         CompletableFuture.runAsync(() -> configPush(request), configPushPool)
                 .exceptionally(e -> {
-                    log.error("Error getting terraform variables", e);
+                    log.error("Error running command", e);
                     Command firstCommand = request.getCommandBundles().get(0).getCommands().get(0);
                     setCommandError(firstCommand, (Exception) e);
                     sendResponse(request);

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/config/eventPortal/EventPortalProperties.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/config/eventPortal/EventPortalProperties.java
@@ -18,6 +18,10 @@ public class EventPortalProperties {
 
     private String topicPrefix;
 
+    private int commandThreadPoolMinSize = 5;
+    private int commandThreadPoolMaxSize = 10;
+    private int commandThreadPoolQueueSize = 1_000;
+
     private GatewayProperties gateway
             = new GatewayProperties("standalone", "standalone", new GatewayMessagingProperties(true, false, List.of()));
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/util/MdcTaskDecorator.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/util/MdcTaskDecorator.java
@@ -11,7 +11,7 @@ public class MdcTaskDecorator implements TaskDecorator {
 
     @Override
     public Runnable decorate(Runnable runnable) {
-        Map<String, String> contextMap = (Map) Optional.ofNullable(MDC.getCopyOfContextMap()).orElse(new HashMap());
+        Map<String, String> contextMap = Optional.ofNullable(MDC.getCopyOfContextMap()).orElse(new HashMap<>());
         return () -> {
             try {
                 MDC.setContextMap(contextMap);

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/util/MdcTaskDecorator.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/util/MdcTaskDecorator.java
@@ -1,0 +1,25 @@
+package com.solace.maas.ep.event.management.agent.util;
+
+import org.slf4j.MDC;
+import org.springframework.core.task.TaskDecorator;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class MdcTaskDecorator implements TaskDecorator {
+
+    @Override
+    public Runnable decorate(Runnable runnable) {
+        Map<String, String> contextMap = (Map) Optional.ofNullable(MDC.getCopyOfContextMap()).orElse(new HashMap());
+        return () -> {
+            try {
+                MDC.setContextMap(contextMap);
+                runnable.run();
+            } finally {
+                MDC.clear();
+            }
+
+        };
+    }
+}

--- a/service/application/src/main/resources/application-TEST.yml
+++ b/service/application/src/main/resources/application-TEST.yml
@@ -24,6 +24,9 @@ eventPortal:
   runtimeAgentId: ${EP_RUNTIME_AGENT_ID:1234567}
   organizationId: ${EP_ORGANIZATION_ID:myOrg123}
   topicPrefix: ${EP_TOPIC_PREFIX:sc/ep/runtime}
+  commandThreadPoolMinSize: 5
+  commandThreadPoolMaxSize: 5
+  commandThreadPoolQueueSize: 10
   gateway:
     id: decal5
     name: evmr1

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/commandManager/CommandManagerTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/commandManager/CommandManagerTests.java
@@ -14,20 +14,32 @@ import com.solace.maas.ep.event.management.agent.plugin.solace.processor.semp.Se
 import com.solace.maas.ep.event.management.agent.plugin.solace.processor.semp.SolaceHttpSemp;
 import com.solace.maas.ep.event.management.agent.plugin.terraform.manager.TerraformManager;
 import com.solace.maas.ep.event.management.agent.publisher.CommandPublisher;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.mockito.invocation.Invocation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 
 import static com.solace.maas.ep.event.management.agent.constants.Command.COMMAND_CORRELATION_ID;
 import static com.solace.maas.ep.event.management.agent.plugin.mop.MOPMessageType.generic;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -38,42 +50,99 @@ import static org.mockito.Mockito.when;
 public class CommandManagerTests {
 
     @Autowired
-    CommandManager commandManager;
+    private CommandManager commandManager;
 
     @Autowired
-    TerraformManager terraformManager;
+    private TerraformManager terraformManager;
 
     @Autowired
-    CommandPublisher commandPublisher;
+    private CommandPublisher commandPublisher;
 
     @Autowired
-    MessagingServiceDelegateService messagingServiceDelegateService;
+    private MessagingServiceDelegateService messagingServiceDelegateService;
 
     @Autowired
-    EventPortalProperties eventPortalProperties;
+    private EventPortalProperties eventPortalProperties;
+
+    private final static ThreadPoolTaskExecutor testThreadPool = new ThreadPoolTaskExecutor();
+
+    @BeforeEach
+    public void cleanup() {
+        reset(terraformManager);
+        reset(commandPublisher);
+    }
+
+    @Test
+    public void testMultiThreadedCommandManager() throws InterruptedException {
+
+        // Set up the thread pool
+        int commandThreadPoolQueueSize = eventPortalProperties.getCommandThreadPoolQueueSize();
+        testThreadPool.setCorePoolSize(commandThreadPoolQueueSize);
+        testThreadPool.initialize();
+
+
+        // Build enough requests to fill the command thread pool queue
+        List<CommandMessage> messageList = new ArrayList<>();
+        for (int i = 0; i < commandThreadPoolQueueSize; i++) {
+            messageList.add(getCommandMessage(Integer.toString(i)));
+        }
+
+        doNothing().when(commandPublisher).sendCommandResponse(any(), any());
+        doAnswer(invocation -> {
+            // Simulate the time spent for a SEMP command to complete
+            TimeUnit.SECONDS.sleep(1);
+            return null;
+        }).when(terraformManager).execute(any(), any(), any());
+
+        ArgumentCaptor<Map<String, String>> topicArgCaptor = ArgumentCaptor.forClass(Map.class);
+
+        when(messagingServiceDelegateService.getMessagingServiceClient(any())).thenReturn(
+                new SolaceHttpSemp(SempClient.builder()
+                        .username("myUsername")
+                        .password("myPassword")
+                        .connectionUrl("myConnectionUrl")
+                        .build()));
+
+        // Execute all the commands in parallel to fill the command thread pool queue
+        IntStream.rangeClosed(1, commandThreadPoolQueueSize).parallel().forEach(i ->
+                CompletableFuture.runAsync(() -> commandManager.execute(messageList.get(i - 1)), testThreadPool));
+
+        // Wait for all the threads to complete (add a timeout just in case)
+        Collection<Invocation> invocations = Mockito.mockingDetails(commandPublisher).getInvocations();
+        long timeout = System.currentTimeMillis() + 10_000;
+        while (invocations.size() < commandThreadPoolQueueSize && System.currentTimeMillis() < timeout) {
+            TimeUnit.MILLISECONDS.sleep(500);
+            invocations = Mockito.mockingDetails(commandPublisher).getInvocations();
+        }
+
+        // Verify terraform manager is called
+        ArgumentCaptor<Map<String, String>> envArgCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(terraformManager, times(commandThreadPoolQueueSize)).execute(any(), any(), envArgCaptor.capture());
+
+        // Verify the env vars are set with the terraform manager is called
+        Map<String, String> envVars = envArgCaptor.getValue();
+        assert envVars.get("TF_VAR_password").equals("myPassword");
+        assert envVars.get("TF_VAR_username").equals("myUsername");
+        assert envVars.get("TF_VAR_url").equals("myConnectionUrl");
+
+        ArgumentCaptor<CommandMessage> messageArgCaptor = ArgumentCaptor.forClass(CommandMessage.class);
+        verify(commandPublisher, times(commandThreadPoolQueueSize)).sendCommandResponse(messageArgCaptor.capture(), topicArgCaptor.capture());
+
+        Map<String, String> topicVars = topicArgCaptor.getValue();
+        assert topicVars.get("orgId").equals(eventPortalProperties.getOrganizationId());
+        assert topicVars.get("runtimeAgentId").equals(eventPortalProperties.getRuntimeAgentId());
+
+        // Make sure we get all 10 correlation ids in the response messages
+        List<String> receivedCorrelationIds = messageArgCaptor.getAllValues().stream().map(CommandMessage::getCommandCorrelationId).toList();
+        List<String> expectedCorrelationIds = IntStream.range(0, commandThreadPoolQueueSize).mapToObj(i -> "myCorrelationId" + i).toList();
+        assertTrue(receivedCorrelationIds.size() == expectedCorrelationIds.size() &&
+                receivedCorrelationIds.containsAll(expectedCorrelationIds) && expectedCorrelationIds.containsAll(receivedCorrelationIds));
+    }
 
     @Test
     public void testCommandManager() {
         // Create a command request message
-        CommandMessage message = new CommandMessage();
-        message.setOrigType(MOPSvcType.maasEventMgmt);
-        message.withMessageType(generic);
-        message.setContext("abc");
-        message.setActorId("myActorId");
-        message.setOrgId(eventPortalProperties.getOrganizationId());
-        message.setTraceId("myTraceId");
-        message.setCommandCorrelationId("myCorrelationId");
-        message.setCommandBundles(List.of(
-                CommandBundle.builder()
-                        .executionType(ExecutionType.serial)
-                        .exitOnFailure(false)
-                        .commands(List.of(
-                                Command.builder()
-                                        .commandType(CommandType.terraform)
-                                        .body("asdfasdfadsf")
-                                        .command("apply")
-                                        .build()))
-                        .build()));
+        CommandMessage message = getCommandMessage("1");
 
         doNothing().when(terraformManager).execute(any(), any(), any());
 
@@ -85,7 +154,20 @@ public class CommandManagerTests {
                         .password("myPassword")
                         .connectionUrl("myConnectionUrl")
                         .build()));
+
         commandManager.execute(message);
+        // Wait for all the threads to complete (add a timeout just in case)
+        Collection<Invocation> invocations = Mockito.mockingDetails(commandPublisher).getInvocations();
+        long timeout = System.currentTimeMillis() + 10_000;
+        while (invocations.isEmpty() && System.currentTimeMillis() < timeout) {
+            try {
+                TimeUnit.MILLISECONDS.sleep(500);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            invocations = Mockito.mockingDetails(commandPublisher).getInvocations();
+        }
+
 
         // Verify terraform manager is called
         ArgumentCaptor<Map<String, String>> envArgCaptor = ArgumentCaptor.forClass(Map.class);
@@ -103,5 +185,28 @@ public class CommandManagerTests {
         assert topicVars.get("orgId").equals(eventPortalProperties.getOrganizationId());
         assert topicVars.get("runtimeAgentId").equals(eventPortalProperties.getRuntimeAgentId());
         assert topicVars.get(COMMAND_CORRELATION_ID).equals(message.getCommandCorrelationId());
+    }
+
+    private CommandMessage getCommandMessage(String suffix) {
+        CommandMessage message = new CommandMessage();
+        message.setOrigType(MOPSvcType.maasEventMgmt);
+        message.withMessageType(generic);
+        message.setContext("abc");
+        message.setActorId("myActorId");
+        message.setOrgId(eventPortalProperties.getOrganizationId());
+        message.setTraceId("myTraceId");
+        message.setCommandCorrelationId("myCorrelationId" + suffix);
+        message.setCommandBundles(List.of(
+                CommandBundle.builder()
+                        .executionType(ExecutionType.serial)
+                        .exitOnFailure(false)
+                        .commands(List.of(
+                                Command.builder()
+                                        .commandType(CommandType.terraform)
+                                        .body("asdfasdfadsf")
+                                        .command("apply")
+                                        .build()))
+                        .build()));
+        return message;
     }
 }

--- a/service/terraform-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/terraform/real/TerraformClientRealTests.java
+++ b/service/terraform-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/terraform/real/TerraformClientRealTests.java
@@ -49,17 +49,17 @@ public class TerraformClientRealTests {
     );
 
     @Test
-    public void planCreateNewQueue() {
+    void planCreateNewQueue() {
         executeTerraformCommand("addQueue.tf", "plan ");
     }
 
     @Test
-    public void createNewQueue() {
+    void createNewQueue() {
         executeTerraformCommand("addQueue.tf", "apply");
     }
 
     @Test
-    public void create2DifferentQueues() {
+    void create2DifferentQueues() {
         ExecutorService executorService = Executors.newFixedThreadPool(10);
         Future<List<CommandBundle>> future1 = executorService.submit(() ->
                 executeTerraformCommand("addQueue.tf", "apply"));
@@ -75,7 +75,7 @@ public class TerraformClientRealTests {
     }
 
     @Test
-    public void create2OfTheSameQueue() {
+    void create2OfTheSameQueue() {
         ExecutorService executorService = Executors.newFixedThreadPool(10);
         Future<List<CommandBundle>> future1 = executorService.submit(() ->
                 executeTerraformCommand("addQueue.tf", "apply", "app123-consumer", JobStatus.success));
@@ -95,24 +95,24 @@ public class TerraformClientRealTests {
     }
 
     @Test
-    public void delete2Queues() {
+    void delete2Queues() {
         executeTerraformCommand("deleteQueue.tf", "apply");
         executeTerraformCommand("deleteQueue2.tf", "apply", "app123-consumer2");
 
     }
 
     @Test
-    public void deleteNewQueue() {
+    void deleteNewQueue() {
         executeTerraformCommand("deleteQueue.tf", "apply");
     }
 
     @Test
-    public void updateNewQueue() {
+    void updateNewQueue() {
         executeTerraformCommand("updateQueue.tf", "apply");
     }
 
     @Test
-    public void importResource() {
+    void importResource() {
         String newQueueTf = asString(resourceLoader.getResource("classpath:realTfFiles" + File.separator + "addQueue.tf"));
 
         Command commandRequest1 = Command.builder()

--- a/service/terraform-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/terraform/real/TerraformClientRealTests.java
+++ b/service/terraform-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/terraform/real/TerraformClientRealTests.java
@@ -50,7 +50,7 @@ public class TerraformClientRealTests {
 
     @Test
     void planCreateNewQueue() {
-        executeTerraformCommand("addQueue.tf", "plan ");
+        executeTerraformCommand("addQueue.tf", "plan");
     }
 
     @Test


### PR DESCRIPTION
### What is the purpose of this change?
The EMA needs to be able to handle comands in parallel

### How was this change implemented?
Added a configurable thread pool to the CommandManager. The default queue size for the thread pool is 1000 which seems more than generous for a single org. Once we move to the cloud we may want to increase this value.

### How was this change tested?
Manually tests in the IDE as well as with docker.

### Is there anything the reviewers should focus on/be aware of?
No
