### PR TITLE
DATAGO-64298: rotate command log files.

### DIFF
--- a/service/application/src/main/java/com/solace/maas/ep/common/messages/CommandLogMessage.java
+++ b/service/application/src/main/java/com/solace/maas/ep/common/messages/CommandLogMessage.java
@@ -12,13 +12,16 @@ public class CommandLogMessage extends MOPMessage {
 
     String commandCorrelationId;
 
+    String eventManagementAgentId;
+
     String level;
 
     String log;
 
     Long timestamp;
 
-    public CommandLogMessage(String orgId, String commandCorrelationId, String traceId, String actorId, String level, String log, Long timestamp) {
+    public CommandLogMessage(String orgId, String commandCorrelationId, String traceId, String actorId,
+                             String level, String log, Long timestamp, String runtimeAgentId) {
         super();
         withMessageType(MOPMessageType.generic)
                 .withProtocol(MOPProtocol.epConfigPush)
@@ -27,6 +30,7 @@ public class CommandLogMessage extends MOPMessage {
 
         this.orgId = orgId;
         this.commandCorrelationId = commandCorrelationId;
+        eventManagementAgentId = runtimeAgentId;
         this.level = level;
         this.log = log;
         this.timestamp = timestamp;

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/logging/CommandFilter.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/logging/CommandFilter.java
@@ -1,0 +1,24 @@
+package com.solace.maas.ep.event.management.agent.logging;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.filter.Filter;
+import ch.qos.logback.core.spi.FilterReply;
+import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+
+@Slf4j
+public class CommandFilter extends Filter<ILoggingEvent> {
+
+    @Override
+    public FilterReply decide(ILoggingEvent event) {
+
+        String commandCorrelationId = event.getMDCPropertyMap().get(RouteConstants.COMMAND_CORRELATION_ID);
+
+        if (StringUtils.isNotEmpty(commandCorrelationId)) {
+            return FilterReply.ACCEPT;
+        }
+
+        return FilterReply.DENY;
+    }
+}

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/CommandLogsProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/CommandLogsProcessor.java
@@ -47,7 +47,7 @@ public class CommandLogsProcessor implements Processor {
         String messagingServiceId = (String) properties.get(RouteConstants.MESSAGING_SERVICE_ID);
 
         CommandLogMessage logDataMessage = new CommandLogMessage(orgId, commandCorrelationId, traceId, actorId, event.getLevel().toString(),
-                String.format("%s%s", event.getFormattedMessage(), "\n"), event.getTimeStamp());
+                String.format("%s%s", event.getFormattedMessage(), "\n"), event.getTimeStamp(), runtimeAgentId);
 
         topicDetails.put("orgId", orgId);
         topicDetails.put("runtimeAgentId", runtimeAgentId);

--- a/service/application/src/main/resources/command-configs.properties
+++ b/service/application/src/main/resources/command-configs.properties
@@ -1,0 +1,1 @@
+COMMAND_PATH=${HOME}/commands

--- a/service/application/src/main/resources/logback-spring.xml
+++ b/service/application/src/main/resources/logback-spring.xml
@@ -2,6 +2,7 @@
 <configuration>
 
     <property name="LOG_LEVEL_PATTERN" value="%clr(%5p) %clr([%X{traceId:-}]){yellow}"/>
+    <property resource="command-configs.properties"/>
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
     <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
 
@@ -35,17 +36,39 @@
     </appender>
     <appender name="StreamingAppender" class="com.solace.maas.ep.event.management.agent.logging.StreamingAppender"/>
 
+
+    <appender name="RollingCommandsFile" class="ch.qos.logback.core.rolling.RollingFileAppender">
+
+        <filter class="com.solace.maas.ep.event.management.agent.logging.CommandFilter"/>
+
+        <file>${COMMAND_PATH}/logs/command-logs.log</file>
+
+        <encoder>
+            <pattern>[%X{COMMAND_CORRELATION_ID}] ------ %date [%level] [%thread] %logger{10} [%file:%line] %msg%n</pattern>
+        </encoder>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${COMMAND_PATH}/logs/command-logs-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>1MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>10MB</totalSizeCap>
+            <cleanHistoryOnStart>false</cleanHistoryOnStart>
+        </rollingPolicy>
+    </appender>
+
     <springProfile name="default,mysql,mysql-dev,DEV,TEST">
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="RollingFile"/>
             <appender-ref ref="SiftLogger"/>
+            <appender-ref ref="RollingCommandsFile"/>
             <appender-ref ref="StreamingAppender"/>
         </root>
         <logger name="com.solace.maas" level="DEBUG" additivity="false">
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="RollingFile"/>
             <appender-ref ref="SiftLogger"/>
+            <appender-ref ref="RollingCommandsFile"/>
             <appender-ref ref="StreamingAppender"/>
         </logger>
 

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/CommandLogsPublisherRouteBuilderTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/CommandLogsPublisherRouteBuilderTests.java
@@ -91,7 +91,8 @@ class CommandLogsPublisherRouteBuilderTests {
                 "traceId",
                 "actorId",
                 "level",
-                "log", Instant.now().toEpochMilli());
+                "log", Instant.now().toEpochMilli(),
+                "runtimeAgentId");
 
         assertThat(commandLogMessage.getMopProtocol()).isEqualTo(MOPProtocol.epConfigPush);
     }

--- a/service/terraform-plugin/pom.xml
+++ b/service/terraform-plugin/pom.xml
@@ -88,11 +88,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.10.1</version>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/service/terraform-plugin/pom.xml
+++ b/service/terraform-plugin/pom.xml
@@ -88,6 +88,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10.1</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/service/terraform-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/terraform/configuration/TerraformProperties.java
+++ b/service/terraform-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/terraform/configuration/TerraformProperties.java
@@ -7,6 +7,6 @@ import org.springframework.stereotype.Service;
 @Service
 @Data
 public class TerraformProperties {
-    @Value("${plugins.terraform.workingDirectoryRoot:${HOME}/tfconfig}")
+    @Value("${COMMAND_PATH:${HOME}/tfconfig}")
     private String workingDirectoryRoot;
 }

--- a/service/terraform-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/terraform/configuration/TerraformPropertiesFromFile.java
+++ b/service/terraform-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/terraform/configuration/TerraformPropertiesFromFile.java
@@ -1,0 +1,9 @@
+package com.solace.maas.ep.event.management.agent.plugin.terraform.configuration;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+@Configuration
+@PropertySource("classpath:command-configs.properties")
+public class TerraformPropertiesFromFile {
+}

--- a/service/terraform-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/terraform/manager/TerraformLogProcessingService.java
+++ b/service/terraform-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/terraform/manager/TerraformLogProcessingService.java
@@ -1,22 +1,14 @@
 package com.solace.maas.ep.event.management.agent.plugin.terraform.manager;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.solace.maas.ep.event.management.agent.plugin.command.model.CommandRequest;
 import com.solace.maas.ep.event.management.agent.plugin.command.model.CommandResult;
 import com.solace.maas.ep.event.management.agent.plugin.command.model.JobStatus;
-import com.solace.maas.ep.event.management.agent.plugin.terraform.configuration.TerraformProperties;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 
@@ -33,32 +25,10 @@ public class TerraformLogProcessingService {
     public static final String KEY_TIMESTAMP = "@timestamp";
     public static final String KEY_DIAGNOSTIC_DETAIL = "diagnosticDetail";
     public static final String KEY_DIAGNOSTIC = "diagnostic";
-    private final TerraformProperties terraformProperties;
     private final ObjectMapper objectMapper;
 
-    public TerraformLogProcessingService(ObjectMapper objectMapper, TerraformProperties terraformProperties) {
+    public TerraformLogProcessingService(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
-        this.terraformProperties = terraformProperties;
-    }
-
-    public void saveLogToFile(CommandRequest request, List<String> logs) throws IOException {
-        Path logPath = Paths.get(terraformProperties.getWorkingDirectoryRoot()
-                + File.separator
-                + request.getContext()
-                + "-"
-                + request.getServiceId()
-                + File.separator
-                + "logs"
-        );
-
-        if (Files.notExists(logPath)) {
-            Files.createDirectories(logPath);
-        }
-
-        Path out = Files.createTempFile(logPath, System.currentTimeMillis() + "-"
-                + request.getCommandCorrelationId() + "-job", ".log");
-
-        Files.write(out, logs, Charset.defaultCharset());
     }
 
     public CommandResult buildTfCommandResult(List<String> jsonLogs) {

--- a/service/terraform-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/terraform/manager/TerraformManager.java
+++ b/service/terraform-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/terraform/manager/TerraformManager.java
@@ -1,6 +1,6 @@
 package com.solace.maas.ep.event.management.agent.plugin.terraform.manager;
 
-import com.google.gson.Gson;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.solace.maas.ep.event.management.agent.plugin.command.model.Command;
 import com.solace.maas.ep.event.management.agent.plugin.command.model.CommandRequest;
 import com.solace.maas.ep.event.management.agent.plugin.command.model.CommandResult;
@@ -9,6 +9,7 @@ import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants
 import com.solace.maas.ep.event.management.agent.plugin.terraform.client.TerraformClient;
 import com.solace.maas.ep.event.management.agent.plugin.terraform.client.TerraformClientFactory;
 import com.solace.maas.ep.event.management.agent.plugin.terraform.configuration.TerraformProperties;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.MDC;
@@ -30,10 +31,11 @@ import java.util.concurrent.ExecutionException;
 @Slf4j
 public class TerraformManager {
     public static final String LOG_LEVEL_ERROR = "ERROR";
+    private static final ObjectMapper objectMapper = new ObjectMapper();
     private final TerraformLogProcessingService terraformLogProcessingService;
     private final TerraformProperties terraformProperties;
     private final TerraformClientFactory terraformClientFactory;
-    private final static String TF_CONFIG_FILENAME = "config.tf";
+    private static final String TF_CONFIG_FILENAME = "config.tf";
 
     public TerraformManager(TerraformLogProcessingService terraformLogProcessingService,
                             TerraformProperties terraformProperties, TerraformClientFactory terraformClientFactory) {
@@ -55,7 +57,7 @@ public class TerraformManager {
             Path configPath = createConfigPath(request);
             List<String> logOutput = setupTerraformClient(terraformClient, configPath);
             String commandVerb = executeTerraformCommand(command, envVars, configPath, terraformClient);
-            processTerraformResponse(request, command, commandVerb, logOutput);
+            processTerraformResponse(command, commandVerb, logOutput);
         } catch (InterruptedException e) {
             log.error("Received a thread interrupt while executing the terraform command", e);
             Thread.currentThread().interrupt();
@@ -78,12 +80,12 @@ public class TerraformManager {
         return output;
     }
 
+    @SneakyThrows
     private static void logToConsole(String tfLog) {
 
         String logMessage = String.format("Terraform output: %s", tfLog);
 
-        Gson gson = new Gson();
-        Map logMop = gson.fromJson(tfLog, Map.class);
+        Map<String, Object> logMop = objectMapper.readValue(tfLog, Map.class);
         String logLevel = (String) logMop.get("@level");
         switch (logLevel) {
             case "trace" -> log.trace(logMessage);
@@ -111,7 +113,7 @@ public class TerraformManager {
         return commandVerb;
     }
 
-    private void processTerraformResponse(CommandRequest request, Command command, String commandVerb, List<String> output) throws IOException {
+    private void processTerraformResponse(Command command, String commandVerb, List<String> output) {
         // Process logs and create the result
         if (Boolean.TRUE.equals(command.getIgnoreResult())) {
             command.setResult(CommandResult.builder()

--- a/service/terraform-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/terraform/TerraformTestConfig.java
+++ b/service/terraform-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/terraform/TerraformTestConfig.java
@@ -32,8 +32,8 @@ public class TerraformTestConfig {
 
     @Bean
     @Primary
-    public TerraformLogProcessingService getTfLogProcessingService(ObjectMapper objectMapper, TerraformProperties terraformProperties) {
-        return new TerraformLogProcessingService(objectMapper, terraformProperties);
+    public TerraformLogProcessingService getTfLogProcessingService(ObjectMapper objectMapper) {
+        return new TerraformLogProcessingService(objectMapper);
     }
 
     @Bean


### PR DESCRIPTION
### What is the purpose of this change?
To rotate command log files using logback functionality.

### How was this change implemented?
updated logback-spring.xml and removed previous manual logging functionality.

### How was this change tested?
Ran the code multiple times to see logs being rotated and eventually removed:
![Screenshot 2023-12-14 at 2 29 15 PM](https://github.com/SolaceProducts/event-management-agent/assets/40175386/0a4dae89-8b5f-430c-844e-722bae28a424)


### Is there anything the reviewers should focus on/be aware of?
Also added a new attribute `eventManagementId` to commandLogs message to satisfy a requirement
