### PR TITLE
DATAGO-71059: Fix command line too many args bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,19 +187,19 @@ A discovery scan and file export can be run as a single command from a terminal 
 ### Discovery Scan and File Export from CLI Using the Jar File
 
 The Event Management Agent jar file can be obtained by either:
-* downloading the file from the [releases page](https://github.com/SolaceProducts/event-management-agent/releases). A release of `1.5.0` or greater is required.
+* downloading the file from the [releases page](https://github.com/SolaceProducts/event-management-agent/releases). A release of `1.5.1` or greater is required.
 * running a [build of the source code](#installing-maven-dependencies-and-building-the-event-management-agent-jar-file)
 
 To run a scan:
 * provide the id of the event broker specified in the connection file. (e.g. mysolacebroker)
-* provide the event-management-agent jar file. (e.g. event-management-agent-1.5.0-SNAPSHOT.jar)
+* provide the event-management-agent jar file. (e.g. event-management-agent-1.5.1-SNAPSHOT.jar)
 * provide the path and filename for the resulting scan data zip file. (e.g. /path/to/scan.zip)
 * provide the location of the connection file (e.g. /path/to/file/AcmeRetailStandalone.yml)
 
 The command is as follows:
 
 ```
-java -jar event-management-agent-1.5.0-SNAPSHOT.jar scan mysolacebroker /path/to/scan.zip --springdoc.api-docs.enabled=false --spring.main.web-application-type=none --spring.config.location=/path/to/file/AcmeRetailStandalone.yml
+java -jar event-management-agent-1.5.1-SNAPSHOT.jar scan mysolacebroker /path/to/scan.zip --springdoc.api-docs.enabled=false --spring.main.web-application-type=none --spring.config.location=/path/to/file/AcmeRetailStandalone.yml
 ```
 
 ### Discovery Scan and File Export From CLI Using Docker
@@ -230,18 +230,18 @@ See [Generating the Event Management Agent connection file](#generating-the-even
 ### Discovery File Upload From CLI Using the Jar File
 
 The Event Management Agent jar file can be obtained by either:
-* downloading the file from the [releases page](https://github.com/SolaceProducts/event-management-agent/releases). A release of `1.5.0` or greater is required.
+* downloading the file from the [releases page](https://github.com/SolaceProducts/event-management-agent/releases). A release of `1.5.1` or greater is required.
 * running a [build of the source code](#installing-maven-dependencies-and-building-the-event-management-agent-jar-file)
 
 To run a scan file upload:
-* provide the event-management-agent jar file. (e.g. event-management-agent-1.5.0-SNAPSHOT.jar)
+* provide the event-management-agent jar file. (e.g. event-management-agent-1.5.1-SNAPSHOT.jar)
 * provide the path and filename of the scan data zip file. (e.g. /path/to/scan.zip)
 * provide the location of the connection file (e.g. /path/to/file/AcmeRetail.yml)
 
 The command is as follows:
 
 ```
-java -jar event-management-agent-1.5.0-SNAPSHOT.jar upload /path/to/scan.zip --springdoc.api-docs.enabled=false --spring.main.web-application-type=none --spring.config.location=/path/to/file/AcmeRetail.yml
+java -jar event-management-agent-1.5.1-SNAPSHOT.jar upload /path/to/scan.zip --springdoc.api-docs.enabled=false --spring.main.web-application-type=none --spring.config.location=/path/to/file/AcmeRetail.yml
 ```
 
 ### Discovery Scan and File Export From CLI Using Docker

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/cli/EmaCommandLine.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/cli/EmaCommandLine.java
@@ -43,7 +43,7 @@ public class EmaCommandLine implements CommandLineRunner {
 
                 if ("scan".equals(type)) {
                     int expectedScanArgNum = 3;
-                    if (args.length == expectedScanArgNum) {
+                    if (args.length >= expectedScanArgNum) {
                         String messagingServiceId = args[1];
                         String filePathAndName = args[2];
 
@@ -53,7 +53,7 @@ public class EmaCommandLine implements CommandLineRunner {
                     }
                 } else if ("upload".equals(type)) {
                     int expectedImportArgNum = 2;
-                    if (args.length == expectedImportArgNum) {
+                    if (args.length >= expectedImportArgNum) {
                         String fileNameAndPath = args[1];
                         commandLineImport.runUpload(fileNameAndPath);
                     } else {
@@ -74,17 +74,11 @@ public class EmaCommandLine implements CommandLineRunner {
     private void checkArgsLength(int length, int expectedImportArgNum) {
         if (length < expectedImportArgNum) {
             notEnoughArguments();
-        } else {
-            tooManyArguments();
         }
     }
 
     private void notEnoughArguments() {
         log.error("Not enough arguments passed to the application.");
-    }
-
-    private void tooManyArguments() {
-        log.error("Too many arguments passed to the application.");
     }
 
     public void shutdownSpringBootApplication() {

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/cli/CliImportTest.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/cli/CliImportTest.java
@@ -69,12 +69,6 @@ public class CliImportTest {
     }
 
     @Test
-    public void testImportCLICommandTooManyArgs() throws Exception {
-        emaCommandLine.run("upload", "/tmp/scan.zip", "/tmp/scan.zip");
-        assertTrue(listAppender.list.get(0).getFormattedMessage().contains("Too many arguments passed to the application."));
-    }
-
-    @Test
     public void testCLIBadCommand() throws Exception {
         emaCommandLine.run("flamingo");
         assertTrue(listAppender.list.get(0).getFormattedMessage().contains("Unknown command: flamingo"));

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/cli/CliScanTest.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/cli/CliScanTest.java
@@ -101,10 +101,4 @@ public class CliScanTest {
         assertTrue(listAppender.list.get(0).getFormattedMessage().contains("Not enough arguments passed to the application."));
     }
 
-    @Test
-    public void testScanCLICommandTooManyArgs() throws Exception {
-        emaCommandLine.run("scan", "abcdef", "/tmp/scan.zip", "flamingos");
-        assertTrue(listAppender.list.get(0).getFormattedMessage().contains("Too many arguments passed to the application."));
-    }
-
 }


### PR DESCRIPTION
### What is the purpose of this change?

When running the CLI command with java -jar, it is over counting the number of command line arguments

### How was this change implemented?

For now, allow it to overcount, until we can find a better way.

### How was this change tested?

Manually from terminal

### Is there anything the reviewers should focus on/be aware of?

No
