### PR TITLE
DATAGO-71875: Change bash to ash in the terraform script

### DIFF
--- a/service/application/docker/Dockerfile
+++ b/service/application/docker/Dockerfile
@@ -16,7 +16,7 @@ ADD terraform-provider-solacebroker_${SOLACE_PROVIDER_VERSION}_${PLATFORM}.tar.g
 
 COPY .terraformrc /root/.terraformrc
 
-RUN printf '#!/bin/bash\ntofu $*' > /opt/ema/terraform/terraform
+RUN printf '#!/bin/ash\ntofu $*' > /opt/ema/terraform/terraform
 RUN chmod +x /opt/ema/terraform/terraform
 
 ENV PATH $PATH:/opt/ema/terraform


### PR DESCRIPTION
### What is the purpose of this change?

Configuration push is broken on the EMA. The terraform re-direct script is broken in the docker container.

### How was this change implemented?

The terraform re-direct script was set to use `/bin/bash` which was working up until the latest base image upgrade. Now `/bin/bash` fails in the alpine containers, and instead we need to use `/bin/ash`

### How was this change tested?

Created docker container manually and tested configuration push.

### Is there anything the reviewers should focus on/be aware of?

No
