### PR TITLE
DATAGO-71844: Update README with configuration push instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,12 +290,12 @@ The Event Management Agent configuration push functionality is dependent on the 
 
 ### OpenTofu
 
-OpenTofu can be installed on Linux or MacOS by following these [installation instructions](https://opentofu.org/docs/intro/install/).
+Follow [these installation instructions](https://opentofu.org/docs/intro/install/) to install OpenTofu on Linux or MacOS.
 
 The Event Management Agent requires the `terraform` executable to be available and aliased to `tofu`. To accomplish this, follow the instructions below to create an executable script:
 ```
 printf '#!/bin/bash\ntofu $*' > terraform
-chmod +x
+chmod +x terraform
 ```
 The `terraform` script mentioned above needs to be added to the system's PATH.
 

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ To run a scan and export operation using the CLI from docker:
 The commands are as follows:
 
 ```
-CMD_LINE_ARGS="scan mysolacebroker /path/to/scan.zip  --springdoc.api-docs.enabled=false --spring.main.web-application-type=none"
+export CMD_LINE_ARGS="scan mysolacebroker /path/to/scan.zip  --springdoc.api-docs.enabled=false --spring.main.web-application-type=none"
 ```
 
 ```
@@ -255,7 +255,7 @@ To run a scan file upload using the CLI from docker:
 The commands are as follows:
 
 ```
-CMD_LINE_ARGS="upload /path/to/scan.zip  --springdoc.api-docs.enabled=false --spring.main.web-application-type=none"
+export CMD_LINE_ARGS="upload /tmp/scan.zip --springdoc.api-docs.enabled=false --spring.main.web-application-type=none"
 ```
 
 ```
@@ -275,6 +275,52 @@ curl -X 'POST' \
   -H 'Content-Type: multipart/form-data' \
   -F 'file=@scan.zip;type=application/zip'
 ```
+
+# Solace Event Broker Configuration Push
+
+The Event Management Agent enables the Solace PubSub+ Cloud Event Portal to directly deploy configuration to Solace PubSub+ Event Brokers. This functionality is available when the Event Management Agent is deployed as a Docker container or (for development purposes) executed from the jar file. Configuration push utilizes [OpenTofu](https://opentofu.org/) (a fork of the [Terraform](https://developer.hashicorp.com/terraform/) infrastructure management tool) along with the [Solace Terraform Provider](https://github.com/SolaceProducts/terraform-provider-solacebroker).
+
+## Configuration Push With Docker (Recommended)
+
+The Docker image of the Event Management Agent includes all necessary library dependencies for deploying configurations to Solace PubSub+ Event Brokers and is the recommended option. Setup the agents by following the instructions for [running the Event Management Agent in connected mode](#running-the-event-management-agent-in-connected-mode).
+
+## Configuration Push With The Jar File (Development)
+
+The Event Management Agent configuration push functionality is dependent on the [OpenTofu](https://github.com/opentofu/opentofu) and [Solace Terraform Provider](https://github.com/SolaceProducts/terraform-provider-solacebroker) libraries. These dependencies must be installed before [running the Event Management Agent as a process](#running-the-event-management-agent-as-a-process).
+
+### OpenTofu
+
+OpenTofu can be installed on Linux or MacOS by following these [installation instructions](https://opentofu.org/docs/intro/install/).
+
+The Event Management Agent requires the `terraform` executable to be available and aliased to `tofu`. To achieve this, create an executable script as described below:
+```
+printf '#!/bin/bash\ntofu $*' > terraform
+chmod +x
+```
+The `terraform` script created above must be placed in the operating systems path.
+
+### Solace Terraform Provider
+
+The [Solace Terraform Provider](https://github.com/SolaceProducts/terraform-provider-solacebroker) can be installed on a variety of operating systems and machine architectures.
+
+1. Visit the [latest software release](https://github.com/SolaceProducts/terraform-provider-solacebroker/releases) page to select and download the asset that fits your installation needs. For example, if you are setting up on MacOS with Apple silicon, choose the terraform-provider-solacebroker_0.9.2_darwin_arm64.zip file, assuming version 0.9.2 is the most recent.
+
+2. Unzip the file. This will yield a LICENSE file, a README.md file, and the provider plugin file (terraform-provider-solacebroker_0.9.2 in this case).
+
+3. Create or update your `${HOME}/.tofurc` (MacOS and Linux) configuration file with a `provider_installation` section that contains the following `dev_overrides`.
+
+ create a file in your home directory called `.tofurc` with the following content:
+```
+provider_installation {
+  dev_overrides {
+    "registry.terraform.io/solaceproducts/solacebroker" = "/path/containing/terraform-provider-solacebroker"
+  }
+
+  direct {}
+}
+```
+where "/path/containing/terraform-provider-solacebroker" is replaced with the directory location of the `terraform-provider-solacebroker_0.9.2` file.
+
 
 # Building the Event Management Agent
 

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ The Event Management Agent enables the Solace PubSub+ Cloud Event Portal to dire
 
 ## Configuration Push With Docker (Recommended)
 
-The Docker image of the Event Management Agent includes all necessary library dependencies for deploying configurations to Solace PubSub+ Event Brokers and is the recommended option for running configuration push. Set up the agents by following the instructions for [running the Event Management Agent in connected mode](#running-the-event-management-agent-in-connected-mode).
+The Docker image of the Event Management Agent includes all necessary library dependencies for deploying configurations to Solace PubSub+ Event Brokers and is the recommended option for performing configuration push. Set up the agent by following the instructions for [running the Event Management Agent in connected mode](#running-the-event-management-agent-in-connected-mode).
 
 ## Configuration Push With The Jar File (Development)
 
@@ -303,7 +303,7 @@ The `terraform` script mentioned above needs to be added to the system's PATH.
 
 The [Solace Terraform Provider](https://github.com/SolaceProducts/terraform-provider-solacebroker) can be installed on a variety of operating systems and machine architectures.
 
-1. Visit the [latest software release](https://github.com/SolaceProducts/terraform-provider-solacebroker/releases) page to select and download the asset that fits your installation needs. For example, if you are installing on MacOS with Apple silicon, choose the terraform-provider-solacebroker_0.9.2_darwin_arm64.zip file (assuming 0.9.2 is the most recent version).
+1. Visit the [latest software release](https://github.com/SolaceProducts/terraform-provider-solacebroker/releases) page to select and download the asset that fits your installation requirements. For example, if you are installing on MacOS with Apple silicon, choose the terraform-provider-solacebroker_0.9.2_darwin_arm64.zip file (assuming 0.9.2 is the most recent version).
 
 2. Unzip the file. This will yield a LICENSE file, a README.md file, and the provider plugin file (`terraform-provider-solacebroker_0.9.2` in the example case).
 
@@ -317,7 +317,7 @@ provider_installation {
   direct {}
 }
 ```
-where "/path/containing/terraform-provider-solacebroker" is replaced with the directory location of the `terraform-provider-solacebroker_0.9.2` file.
+where "/path/containing/terraform-provider-solacebroker" is replaced with the directory location of the `terraform-provider-solacebroker_0.9.2` file (not including the filename).
 
 
 # Building the Event Management Agent

--- a/README.md
+++ b/README.md
@@ -276,13 +276,13 @@ curl -X 'POST' \
   -F 'file=@scan.zip;type=application/zip'
 ```
 
-# Solace Event Broker Configuration Push
+# Solace PubSub+ Event Broker Configuration Push
 
 The Event Management Agent enables the Solace PubSub+ Cloud Event Portal to directly deploy configuration to Solace PubSub+ Event Brokers. This functionality is available when the Event Management Agent is deployed as a Docker container or (for development purposes) executed from the jar file. Configuration push utilizes [OpenTofu](https://opentofu.org/) (a fork of the [Terraform](https://developer.hashicorp.com/terraform/) infrastructure management tool) along with the [Solace Terraform Provider](https://github.com/SolaceProducts/terraform-provider-solacebroker).
 
 ## Configuration Push With Docker (Recommended)
 
-The Docker image of the Event Management Agent includes all necessary library dependencies for deploying configurations to Solace PubSub+ Event Brokers and is the recommended option. Setup the agents by following the instructions for [running the Event Management Agent in connected mode](#running-the-event-management-agent-in-connected-mode).
+The Docker image of the Event Management Agent includes all necessary library dependencies for deploying configurations to Solace PubSub+ Event Brokers and is the recommended option for running configuration push. Set up the agents by following the instructions for [running the Event Management Agent in connected mode](#running-the-event-management-agent-in-connected-mode).
 
 ## Configuration Push With The Jar File (Development)
 
@@ -292,24 +292,22 @@ The Event Management Agent configuration push functionality is dependent on the 
 
 OpenTofu can be installed on Linux or MacOS by following these [installation instructions](https://opentofu.org/docs/intro/install/).
 
-The Event Management Agent requires the `terraform` executable to be available and aliased to `tofu`. To achieve this, create an executable script as described below:
+The Event Management Agent requires the `terraform` executable to be available and aliased to `tofu`. To accomplish this, follow the instructions below to create an executable script:
 ```
 printf '#!/bin/bash\ntofu $*' > terraform
 chmod +x
 ```
-The `terraform` script created above must be placed in the operating systems path.
+The `terraform` script mentioned above needs to be added to the system's PATH.
 
 ### Solace Terraform Provider
 
 The [Solace Terraform Provider](https://github.com/SolaceProducts/terraform-provider-solacebroker) can be installed on a variety of operating systems and machine architectures.
 
-1. Visit the [latest software release](https://github.com/SolaceProducts/terraform-provider-solacebroker/releases) page to select and download the asset that fits your installation needs. For example, if you are setting up on MacOS with Apple silicon, choose the terraform-provider-solacebroker_0.9.2_darwin_arm64.zip file, assuming version 0.9.2 is the most recent.
+1. Visit the [latest software release](https://github.com/SolaceProducts/terraform-provider-solacebroker/releases) page to select and download the asset that fits your installation needs. For example, if you are installing on MacOS with Apple silicon, choose the terraform-provider-solacebroker_0.9.2_darwin_arm64.zip file (assuming 0.9.2 is the most recent version).
 
-2. Unzip the file. This will yield a LICENSE file, a README.md file, and the provider plugin file (terraform-provider-solacebroker_0.9.2 in this case).
+2. Unzip the file. This will yield a LICENSE file, a README.md file, and the provider plugin file (`terraform-provider-solacebroker_0.9.2` in the example case).
 
-3. Create or update your `${HOME}/.tofurc` (MacOS and Linux) configuration file with a `provider_installation` section that contains the following `dev_overrides`.
-
- create a file in your home directory called `.tofurc` with the following content:
+3. Create or update your `${HOME}/.tofurc` (MacOS and Linux) configuration file with a `provider_installation` section that contains the following `dev_overrides`:
 ```
 provider_installation {
   dev_overrides {


### PR DESCRIPTION
### What is the purpose of this change?

Add instructions for installing OpenTofu and the Solace Terraform Provider to the EMA README.md.

### How was this change implemented?

Added a section to the README describing how to run the EMA for the configuration push feature. Added a section for docker as the recommended option and added a "development" section for running the EMA as a jar file. This "development" section includes instructions for installing OpenTofu and the solace Terraform Provider for MacOS and Linux.

### How was this change tested?

N/A

### Is there anything the reviewers should focus on/be aware of?

N/A
