### PR TITLE
DATAGO-72210: Fix for subscription aggregation bug

### DIFF
--- a/service/local-storage-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/localstorage/route/handler/DataCollectionFileWriteRouteBuilder.java
+++ b/service/local-storage-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/localstorage/route/handler/DataCollectionFileWriteRouteBuilder.java
@@ -7,6 +7,8 @@ import org.apache.camel.builder.RouteBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import static com.solace.maas.ep.event.management.agent.plugin.constants.HeaderConstants.DATA_PROCESSING_COMPLETE;
+
 @Component
 public class DataCollectionFileWriteRouteBuilder extends RouteBuilder {
     private final DataCollectionFileWriteProcessor processor;
@@ -32,7 +34,7 @@ public class DataCollectionFileWriteRouteBuilder extends RouteBuilder {
                         "${header." + RouteConstants.SCHEDULE_ID +
                         "}/${header." + RouteConstants.SCAN_ID +
                         "}/${header." + RouteConstants.SCAN_TYPE + "}.json")
-                .choice().when(header("DATA_PROCESSING_COMPLETE").isEqualTo(true))
+                .choice().when(header(DATA_PROCESSING_COMPLETE).isEqualTo(true))
                 .to("seda:dataCollectionDBWriter")
                 .endChoice()
                 .end();

--- a/service/local-storage-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/localstorage/route/handler/DataCollectionFileWriteRouteBuilder.java
+++ b/service/local-storage-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/localstorage/route/handler/DataCollectionFileWriteRouteBuilder.java
@@ -7,7 +7,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import static com.solace.maas.ep.event.management.agent.plugin.constants.HeaderConstants.DATA_PROCESSING_COMPLETE;
+import static com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants.DATA_PROCESSING_COMPLETE;
 
 @Component
 public class DataCollectionFileWriteRouteBuilder extends RouteBuilder {

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/constants/HeaderConstants.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/constants/HeaderConstants.java
@@ -1,8 +1,0 @@
-package com.solace.maas.ep.event.management.agent.plugin.constants;
-
-public class HeaderConstants {
-    public static final String DATA_PROCESSING_COMPLETE = "DATA_PROCESSING_COMPLETE";
-    public static final String RECIPIENTS = "RECIPIENTS";
-    public static final String DESTINATIONS = "DESTINATIONS";
-
-}

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/constants/HeaderConstants.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/constants/HeaderConstants.java
@@ -1,0 +1,8 @@
+package com.solace.maas.ep.event.management.agent.plugin.constants;
+
+public class HeaderConstants {
+    public static final String DATA_PROCESSING_COMPLETE = "DATA_PROCESSING_COMPLETE";
+    public static final String RECIPIENTS = "RECIPIENTS";
+    public static final String DESTINATIONS = "DESTINATIONS";
+
+}

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/constants/RouteConstants.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/constants/RouteConstants.java
@@ -38,4 +38,10 @@ public class RouteConstants {
     public static final String TOPIC_DETAILS = "TOPIC_DETAILS";
 
     public static final String IS_EMPTY_SCAN_TYPES = "IS_EMPTY_SCAN_TYPES";
+
+    public static final String DATA_PROCESSING_COMPLETE = "DATA_PROCESSING_COMPLETE";
+
+    public static final String RECIPIENTS = "RECIPIENTS";
+
+    public static final String DESTINATIONS = "DESTINATIONS";
 }

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/base/AsyncDataPublisherRouteBuilder.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/base/AsyncDataPublisherRouteBuilder.java
@@ -20,9 +20,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-import static com.solace.maas.ep.event.management.agent.plugin.constants.HeaderConstants.DESTINATIONS;
-import static com.solace.maas.ep.event.management.agent.plugin.constants.HeaderConstants.RECIPIENTS;
-
 @ExcludeFromJacocoGeneratedReport
 @SuppressWarnings("CPD-START")
 public class AsyncDataPublisherRouteBuilder extends DataPublisherRouteBuilder {
@@ -71,16 +68,16 @@ public class AsyncDataPublisherRouteBuilder extends DataPublisherRouteBuilder {
 
             from("seda:asyncEvent_" + routeId + "?blockWhenFull=true&size=1000000")
                     .setHeader(RouteConstants.SCAN_TYPE, constant(routeType))
-                    .setHeader(RECIPIENTS, method(this, "getRecipients(${header."
+                    .setHeader(RouteConstants.RECIPIENTS, method(this, "getRecipients(${header."
                             + RouteConstants.SCAN_ID + "})"))
-                    .setHeader(DESTINATIONS, method(this, "getDestinations(${header."
+                    .setHeader(RouteConstants.DESTINATIONS, method(this, "getDestinations(${header."
                             + RouteConstants.SCAN_ID + "})"))
                     .process(processor)
-                    .recipientList().header(RECIPIENTS).delimiter(";")
+                    .recipientList().header(RouteConstants.RECIPIENTS).delimiter(";")
                     .shareUnitOfWork()
                     .split(body()).streaming().shareUnitOfWork()
                     .marshal().json(JsonLibrary.Jackson)
-                    .recipientList().header(DESTINATIONS).delimiter(";")
+                    .recipientList().header(RouteConstants.DESTINATIONS).delimiter(";")
                     .shareUnitOfWork();
 
             Publisher<Exchange> exchanges = camel.fromStream("asyncProcessing_" + routeId);

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/base/AsyncDataPublisherRouteBuilder.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/base/AsyncDataPublisherRouteBuilder.java
@@ -20,6 +20,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import static com.solace.maas.ep.event.management.agent.plugin.constants.HeaderConstants.DESTINATIONS;
+import static com.solace.maas.ep.event.management.agent.plugin.constants.HeaderConstants.RECIPIENTS;
+
 @ExcludeFromJacocoGeneratedReport
 @SuppressWarnings("CPD-START")
 public class AsyncDataPublisherRouteBuilder extends DataPublisherRouteBuilder {
@@ -68,16 +71,16 @@ public class AsyncDataPublisherRouteBuilder extends DataPublisherRouteBuilder {
 
             from("seda:asyncEvent_" + routeId + "?blockWhenFull=true&size=1000000")
                     .setHeader(RouteConstants.SCAN_TYPE, constant(routeType))
-                    .setHeader("RECIPIENTS", method(this, "getRecipients(${header."
+                    .setHeader(RECIPIENTS, method(this, "getRecipients(${header."
                             + RouteConstants.SCAN_ID + "})"))
-                    .setHeader("DESTINATIONS", method(this, "getDestinations(${header."
+                    .setHeader(DESTINATIONS, method(this, "getDestinations(${header."
                             + RouteConstants.SCAN_ID + "})"))
                     .process(processor)
-                    .recipientList().header("RECIPIENTS").delimiter(";")
+                    .recipientList().header(RECIPIENTS).delimiter(";")
                     .shareUnitOfWork()
                     .split(body()).streaming().shareUnitOfWork()
                     .marshal().json(JsonLibrary.Jackson)
-                    .recipientList().header("DESTINATIONS").delimiter(";")
+                    .recipientList().header(DESTINATIONS).delimiter(";")
                     .shareUnitOfWork();
 
             Publisher<Exchange> exchanges = camel.fromStream("asyncProcessing_" + routeId);

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/base/DataAggregationRouteBuilder.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/base/DataAggregationRouteBuilder.java
@@ -14,6 +14,7 @@ import org.apache.camel.model.dataformat.JsonLibrary;
 
 import java.util.Objects;
 
+import static org.apache.camel.support.builder.PredicateBuilder.and;
 import static org.apache.camel.support.builder.PredicateBuilder.or;
 
 @ExcludeFromJacocoGeneratedReport
@@ -86,7 +87,8 @@ public class DataAggregationRouteBuilder extends DataPublisherRouteBuilder {
                 .log(LoggingLevel.TRACE, "agg complete ${body}")
                 .process(processor)
                 // Checking for empty scan types.
-                .choice().when(simple("${body.size} == 0"))
+                .choice().when(and(simple("${body.size} == 0"),
+                        header("DATA_PROCESSING_COMPLETE").isEqualTo(true)))
                 .setHeader(RouteConstants.IS_EMPTY_SCAN_TYPES, constant(true))
                 .process(scanTypeDescendentsProcessor)
                 .split(simple("${header." + RouteConstants.SCAN_TYPE + "}"))

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/base/DataAggregationRouteBuilder.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/base/DataAggregationRouteBuilder.java
@@ -14,6 +14,9 @@ import org.apache.camel.model.dataformat.JsonLibrary;
 
 import java.util.Objects;
 
+import static com.solace.maas.ep.event.management.agent.plugin.constants.HeaderConstants.DATA_PROCESSING_COMPLETE;
+import static com.solace.maas.ep.event.management.agent.plugin.constants.HeaderConstants.DESTINATIONS;
+import static com.solace.maas.ep.event.management.agent.plugin.constants.HeaderConstants.RECIPIENTS;
 import static org.apache.camel.support.builder.PredicateBuilder.and;
 import static org.apache.camel.support.builder.PredicateBuilder.or;
 
@@ -61,9 +64,9 @@ public class DataAggregationRouteBuilder extends DataPublisherRouteBuilder {
                 // Define a Route ID so we can kill this Route if needed.
                 .routeId(routeId)
                 .setHeader(RouteConstants.SCAN_TYPE, constant(routeType))
-                .setHeader("RECIPIENTS", method(this, "getRecipients(${header."
+                .setHeader(RECIPIENTS, method(this, "getRecipients(${header."
                         + RouteConstants.SCAN_ID + "})"))
-                .setHeader("DESTINATIONS", method(this, "getDestinations(${header."
+                .setHeader(DESTINATIONS, method(this, "getDestinations(${header."
                         + RouteConstants.SCAN_ID + "})"))
                 .setHeader(RouteConstants.SCAN_STATUS, constant(ScanStatus.IN_PROGRESS))
                 .to("direct:markRouteScanStatusInProgress?block=false&failIfNoConsumers=false")
@@ -73,7 +76,7 @@ public class DataAggregationRouteBuilder extends DataPublisherRouteBuilder {
                 // aggregate this data together if they need it all at once.
                 .split(body()).shareUnitOfWork().streaming().shareUnitOfWork()
                 .choice().when(header(Exchange.SPLIT_COMPLETE).isEqualTo(true))
-                .setHeader("DATA_PROCESSING_COMPLETE", constant(true))
+                .setHeader(DATA_PROCESSING_COMPLETE, constant(true))
                 .endChoice()
                 .end()
                 .log(LoggingLevel.TRACE, "agg element ${body}")
@@ -88,7 +91,7 @@ public class DataAggregationRouteBuilder extends DataPublisherRouteBuilder {
                 .process(processor)
                 // Checking for empty scan types.
                 .choice().when(and(simple("${body.size} == 0"),
-                        header("DATA_PROCESSING_COMPLETE").isEqualTo(true)))
+                        header(DATA_PROCESSING_COMPLETE).isEqualTo(true)))
                 .setHeader(RouteConstants.IS_EMPTY_SCAN_TYPES, constant(true))
                 .process(scanTypeDescendentsProcessor)
                 .split(simple("${header." + RouteConstants.SCAN_TYPE + "}"))
@@ -107,22 +110,22 @@ public class DataAggregationRouteBuilder extends DataPublisherRouteBuilder {
                 // We want to set the "DATA_PROCESSING_COMPLETE" to false, except for the last message in the
                 // aggregation bundle.
                 .choice().when(or(header(Exchange.SPLIT_COMPLETE).isEqualTo(false),
-                        header("DATA_PROCESSING_COMPLETE").isEqualTo(false)))
-                .setHeader("DATA_PROCESSING_COMPLETE", constant(false))
+                        header(DATA_PROCESSING_COMPLETE).isEqualTo(false)))
+                .setHeader(DATA_PROCESSING_COMPLETE, constant(false))
                 .endChoice()
                 .end()
                 // The Route Interceptors are injected here. They are called Asynchronously and don't return a response
                 // to this Route.
-                .recipientList().header("RECIPIENTS").delimiter(";")
+                .recipientList().header(RECIPIENTS).delimiter(";")
                 .shareUnitOfWork()
                 // Transforming the Events to JSON. Do we need to do this here? Maybe we should delegate this to the
                 // destinations instead?
                 .marshal().json(JsonLibrary.Jackson)
                 .log(LoggingLevel.TRACE, "destinations ${body}")
                 // The Destinations receiving the Data Collection events get called here.
-                .recipientList().header("DESTINATIONS").delimiter(";")
+                .recipientList().header(DESTINATIONS).delimiter(";")
                 .shareUnitOfWork()
-                .choice().when(header("DATA_PROCESSING_COMPLETE").isEqualTo(true))
+                .choice().when(header(DATA_PROCESSING_COMPLETE).isEqualTo(true))
                 .to("direct:markRouteScanStatusComplete?block=false&failIfNoConsumers=false")
                 .endChoice()
                 .end()

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/base/DataPublisherRouteBuilder.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/base/DataPublisherRouteBuilder.java
@@ -15,10 +15,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import static com.solace.maas.ep.event.management.agent.plugin.constants.HeaderConstants.DATA_PROCESSING_COMPLETE;
-import static com.solace.maas.ep.event.management.agent.plugin.constants.HeaderConstants.DESTINATIONS;
-import static com.solace.maas.ep.event.management.agent.plugin.constants.HeaderConstants.RECIPIENTS;
-
 /**
  * DataPublisherRouteBuilder creates Camel Routes intended to handle Messaging Service scans.
  */
@@ -75,9 +71,9 @@ public class DataPublisherRouteBuilder extends AbstractRouteBuilder {
                 .process(exchange -> MDC.put("scanId", exchange.getIn().getHeader(RouteConstants.SCAN_ID, String.class)))
                 .routeId(routeId)
                 .setHeader(RouteConstants.SCAN_TYPE, constant(routeType))
-                .setHeader(RECIPIENTS, method(this, "getRecipients(${header."
+                .setHeader(RouteConstants.RECIPIENTS, method(this, "getRecipients(${header."
                         + RouteConstants.SCAN_ID + "})"))
-                .setHeader(DESTINATIONS, method(this, "getDestinations(${header."
+                .setHeader(RouteConstants.DESTINATIONS, method(this, "getDestinations(${header."
                         + RouteConstants.SCAN_ID + "})"))
                 .setHeader(RouteConstants.SCAN_STATUS, constant(ScanStatus.IN_PROGRESS))
                 .to("direct:markRouteScanStatusInProgress?block=false&failIfNoConsumers=false")
@@ -97,18 +93,18 @@ public class DataPublisherRouteBuilder extends AbstractRouteBuilder {
                 .otherwise()
                 // The Route Interceptors are injected here. They are called Asynchronously and don't return a response
                 // to this Route.
-                .recipientList().header(RECIPIENTS).delimiter(";")
+                .recipientList().header(RouteConstants.RECIPIENTS).delimiter(";")
                 .split(body()).streaming().shareUnitOfWork()
                 // Transforming the Events to JSON. Do we need to do this here? Maybe we should delegate this to the
                 // destinations instead?
                 .marshal().json(JsonLibrary.Jackson)
                 .choice().when(header(Exchange.SPLIT_COMPLETE).isEqualTo(true))
-                .setHeader(DATA_PROCESSING_COMPLETE, constant(true))
+                .setHeader(RouteConstants.DATA_PROCESSING_COMPLETE, constant(true))
                 .endChoice()
                 .end()
                 // The Destinations receiving the Data Collection events get called here.
-                .recipientList().header(DESTINATIONS).delimiter(";")
-                .choice().when(header(DATA_PROCESSING_COMPLETE).isEqualTo(true))
+                .recipientList().header(RouteConstants.DESTINATIONS).delimiter(";")
+                .choice().when(header(RouteConstants.DATA_PROCESSING_COMPLETE).isEqualTo(true))
                 .to("direct:markRouteScanStatusComplete?block=false&failIfNoConsumers=false")
                 .endChoice()
                 .end()


### PR DESCRIPTION
### What is the purpose of this change?

The subscription scan was ending prematurely after getting a few queues without subscriptions. It was erroneously signaling the end of the subscription scan.

### How was this change implemented?

The subscription scan should only conclude once the last batch of data has been processed. Therefore, the condition to end the scan when it's empty has been enhanced to verify whether it's handling the final batch of data.

### How was this change tested?

It was manually tested with the standard kafka and Solace configurations. I also tested with an empty schema registry to make sure the base case of 0 entities is also working. Also, I created a scenario similar to Mars, where I have a big batch of queues with no subscriptions. Without the fix, the scan failed, and with the fix, it succeeded.

### Is there anything the reviewers should focus on/be aware of?

Aly Rasmy tested this against the customer data, and the EMA scan appears to have completed correctly from the logs, but we ran into a timeout issue which will be address by increasing the ep-core timeout.
