### PR TITLE
DATAGO-72530: Prisma exclusion list checker in EMA should use correct format for package identifiers

### DIFF
--- a/.github/workflows/release_scripts/prisma_vulnurability_checker.py
+++ b/.github/workflows/release_scripts/prisma_vulnurability_checker.py
@@ -64,7 +64,7 @@ def find_all_high_critical_vulnerabilities_to_resolve(excluded_libraries):
     vulnerabilities_to_resolve = dict()
     for vulnerability in prisma_project_vulnerabilities:
         if vulnerability['severity'] in PRISMA_BLOCKING_VULNERABILITIES:
-            package_full_name = f"{vulnerability['packageName']}-{vulnerability['packageVersion']}"
+            package_full_name = f"{vulnerability['packageName']}:{vulnerability['packageVersion']}"
             current_vulnerability_description = vulnerability['description']
             if package_full_name in excluded_libraries:
                 print(f"ⓘ Package {package_full_name} has vulnerabilities but is in exclusion list.")


### PR DESCRIPTION
### What is the purpose of this change?
The format for checking excluded libraries for Prisma vulenrabilites, should be `library:version` instead of `library-version` to match the database schema which stores list of excluded libraries.

### How was this change implemented?
Simple change to use `library:version` when checking Prisma exclusion list

