### PR TITLE
DATAGO-72325: Add OS independent home directory and file separator character

### DIFF
--- a/service/application/src/main/resources/command-configs.properties
+++ b/service/application/src/main/resources/command-configs.properties
@@ -1,1 +1,1 @@
-COMMAND_PATH=${HOME}/commands
+COMMAND_PATH=${user.home}${file.separator}commands

--- a/service/terraform-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/terraform/configuration/TerraformProperties.java
+++ b/service/terraform-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/terraform/configuration/TerraformProperties.java
@@ -7,6 +7,6 @@ import org.springframework.stereotype.Service;
 @Service
 @Data
 public class TerraformProperties {
-    @Value("${COMMAND_PATH:${HOME}/tfconfig}")
+    @Value("${COMMAND_PATH:${user.home}${file.separator}tfcommands}")
     private String workingDirectoryRoot;
 }

--- a/service/terraform-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/terraform/TerraformCommandIT.java
+++ b/service/terraform-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/terraform/TerraformCommandIT.java
@@ -12,7 +12,9 @@ import com.solace.maas.ep.event.management.agent.plugin.terraform.configuration.
 import com.solace.maas.ep.event.management.agent.plugin.terraform.manager.TerraformManager;
 import org.apache.commons.lang.StringUtils;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,6 +52,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ActiveProfiles("TEST")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = TerraformTestConfig.class)
 
 public class TerraformCommandIT {
@@ -64,6 +67,11 @@ public class TerraformCommandIT {
 
     @Autowired
     private ResourceLoader resourceLoader;
+
+    @BeforeAll
+    public void setup() {
+        terraformProperties.setWorkingDirectoryRoot(System.getProperty("java.io.tmpdir"));
+    }
 
     @AfterEach
     public void reset_mocks() {
@@ -209,7 +217,7 @@ public class TerraformCommandIT {
                 "\tid = \"default/MyConsumer1/a%2Fb%2Fc\"\n" +
                 "}";
 
-        String content = Files.readString(Path.of(terraformProperties.getWorkingDirectoryRoot() + "/app123-ms1234/import.tf"));
+        String content = Files.readString(Path.of(terraformProperties.getWorkingDirectoryRoot() + "/app123-ms1234/sync.tf"));
         assertEquals(content, expectedImportTf);
 
         // Check the responses


### PR DESCRIPTION
### What is the purpose of this change?

By default, the EMA tries to create a directory using linux/mac friendly path syntax. This causes a bug when running on Windows

### How was this change implemented?

Change the linux/mac friendly path syntax with a syntax that works on linux, mac and Windows.

### How was this change tested?

Tested on a Windows VM using UTM. The EMA started up and was able to run a scan.

### Is there anything the reviewers should focus on/be aware of?

No
