### PR TITLE
DATAGO-72931: Identical scanIds bug on Windows

### DIFF
--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/util/IDGenerator.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/util/IDGenerator.java
@@ -1,6 +1,7 @@
 package com.solace.maas.ep.event.management.agent.util;
 
 import com.solace.maas.ep.event.management.agent.util.config.idgenerator.IDGeneratorProperties;
+import jakarta.annotation.PostConstruct;
 import lombok.Data;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,7 +9,6 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.util.DigestUtils;
 
-import jakarta.annotation.PostConstruct;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.Random;
@@ -61,12 +61,16 @@ public class IDGenerator {
 
     @PostConstruct
     public void init() {
-        byte[] instanceSeed = "1".getBytes(StandardCharsets.UTF_8);
-        if (idGeneratorProperties.getOriginId() != null) {
+        if (idGeneratorProperties.getOriginId() == null) {
+            // Fallback to default seed which creates a unique seed for each instance
+            random = new SecureRandom();
+        } else {
             String instanceSeedString = idGeneratorProperties.getOriginId() + (System.nanoTime() & 65_535);
-            instanceSeed = instanceSeedString.getBytes(StandardCharsets.UTF_8);
+            byte[] instanceSeed = instanceSeedString.getBytes(StandardCharsets.UTF_8);
+            random = new SecureRandom(instanceSeed);
+
         }
 
-        random = new SecureRandom(instanceSeed);
+
     }
 }

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/util/IDGeneratorTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/util/IDGeneratorTests.java
@@ -68,4 +68,76 @@ public class IDGeneratorTests {
 
         assertThatNoException();
     }
+
+    /**
+     * Test the uniqueness of the generated random unique id with originId set to null.
+     * The test is run multiple times to ensure the uniqueness of the generated id.
+     */
+    @SneakyThrows
+    @Test
+    public void testUniquenessOfGeneratedRandomUniqueIdOfDistinctIDGeneratorWithoutOriginId() {
+        IDGeneratorProperties props = new IDGeneratorProperties();
+        props.setOriginId(null);
+        IDGenerator idGenerator = new IDGenerator(props);
+        idGenerator.init();
+        String id1 = idGenerator.generateRandomUniqueId();
+        String id2 = idGenerator.generateRandomUniqueId();
+        assertThat(id1).isNotEqualTo(id2);
+    }
+
+    /**
+     * Test the uniqueness of the generated random unique id with originId set to a specific value.
+     * The test is run multiple times to ensure the uniqueness of the generated id.
+     */
+    @SneakyThrows
+    @Test
+    public void testUniquenessOfGeneratedRandomUniqueIdOfDistinctIDGeneratorWithOriginId() {
+        IDGeneratorProperties props = new IDGeneratorProperties();
+        props.setOriginId("abc123");
+        IDGenerator idGenerator = new IDGenerator(props);
+        idGenerator.init();
+        String id1 = idGenerator.generateRandomUniqueId();
+        String id2 = idGenerator.generateRandomUniqueId();
+        assertThat(id1).isNotEqualTo(id2);
+    }
+
+    /**
+     * Test the uniqueness of the generated random unique id with originId set to null.
+     * The test IDGenerator is created twice to ensure uniqueness between different instances.
+     */
+    @SneakyThrows
+    @Test
+    public void testUniquenessOfGeneratedRandomUniqueIdOfNewIdGeneratorsWithoutOriginId() {
+        IDGeneratorProperties props = new IDGeneratorProperties();
+        props.setOriginId(null);
+
+        IDGenerator idGenerator = new IDGenerator(props);
+        idGenerator.init();
+        String id1 = idGenerator.generateRandomUniqueId();
+
+        idGenerator = new IDGenerator(props);
+        idGenerator.init();
+        String id2 = idGenerator.generateRandomUniqueId();
+        assertThat(id1).isNotEqualTo(id2);
+    }
+
+    /**
+     * Test the uniqueness of the generated random unique id with originId set to a specific value.
+     * The test IDGenerator is created twice to ensure uniqueness between different instances.
+     */
+    @SneakyThrows
+    @Test
+    public void testUniquenessOfGeneratedRandomUniqueIdOfNewIdGeneratorsWithOriginId() {
+        IDGeneratorProperties props = new IDGeneratorProperties();
+        props.setOriginId("abc123");
+
+        IDGenerator idGenerator = new IDGenerator(props);
+        idGenerator.init();
+        String id1 = idGenerator.generateRandomUniqueId();
+
+        idGenerator = new IDGenerator(props);
+        idGenerator.init();
+        String id2 = idGenerator.generateRandomUniqueId();
+        assertThat(id1).isNotEqualTo(id2);
+    }
 }


### PR DESCRIPTION
### What is the purpose of this change?
SecureRandom generates a sequence of identical numbers with a static seed on Windows, which leads to identical scandIds. This implementation fixes this issue. 

### How was this change implemented?
Removing a static seed and utilizing default seed generation of SecureRandom, if `orgId` is not defined. 

### How was this change tested?
Unit tests executed on MacOS on Intel and unit tests executed on Windows. 

### Is there anything the reviewers should focus on/be aware of?
Ideally cross-check on another Windows box the fixed agent. 
