### PR TITLE
DATAGO-73412: event-management-agent:spring-web:6.0.17,Type: app_dependency,Prisma Cloud Vulnerability

### DIFF
--- a/service/confluent-schema-registry-plugin/pom.xml
+++ b/service/confluent-schema-registry-plugin/pom.xml
@@ -17,6 +17,7 @@
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
         <jackson-dataformat-cbor.version>2.13.4</jackson-dataformat-cbor.version>
         <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
+        <spring-web.version>6.0.18</spring-web.version>
     </properties>
     <dependencies>
         <dependency>
@@ -59,6 +60,13 @@
             <artifactId>junit-jupiter-engine</artifactId>
             <version>${jupiter.version}</version>
             <scope>test</scope>
+        </dependency>
+        <!-- Override version 6.0.17 from spring-boot-starter-web 3.1.9 that has a vulnerability without moving to
+         v3.2.3 which uses 6.1.4 (we would require 6.1.5) -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <version>${spring-web.version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/service/kafka-plugin/pom.xml
+++ b/service/kafka-plugin/pom.xml
@@ -22,6 +22,7 @@
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
         <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
         <jackson.version>2.16.1</jackson.version>
+        <spring-web.version>6.0.18</spring-web.version>
     </properties>
 
     <dependencyManagement>
@@ -32,6 +33,13 @@
                 <version>${jackson.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <!-- Override version 6.0.17 from spring-boot-starter-web 3.1.9 that has a vulnerability without moving to
+         v3.2.3 which uses 6.1.4 (we would require 6.1.5) -->
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-web</artifactId>
+                <version>${spring-web.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/service/local-storage-plugin/pom.xml
+++ b/service/local-storage-plugin/pom.xml
@@ -22,6 +22,7 @@
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
         <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
         <jackson.version>2.16.1</jackson.version>
+        <spring-web.version>6.0.18</spring-web.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -31,6 +32,13 @@
                 <version>${jackson.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <!-- Override version 6.0.17 from spring-boot-starter-web 3.1.9 that has a vulnerability without moving to
+         v3.2.3 which uses 6.1.4 (we would require 6.1.5) -->
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-web</artifactId>
+                <version>${spring-web.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -42,6 +42,7 @@
         <jacoco.line.percentage>0.8</jacoco.line.percentage>
         <camel.version>4.2.0</camel.version>
         <mockito-inline.version>5.2.0</mockito-inline.version>
+        <spring-web.version>6.0.18</spring-web.version>
     </properties>
 
     <dependencyManagement>
@@ -69,6 +70,13 @@
                         <artifactId>jackson-databind</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <!-- Override version 6.0.17 from spring-boot-starter-web 3.1.9 that has a vulnerability without moving to
+         v3.2.3 which uses 6.1.4 (we would require 6.1.5) -->
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-web</artifactId>
+                <version>${spring-web.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/service/rabbitmq-plugin/pom.xml
+++ b/service/rabbitmq-plugin/pom.xml
@@ -10,6 +10,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
+        <spring-web.version>6.0.18</spring-web.version>
     </properties>
     <dependencies>
         <dependency>
@@ -26,6 +27,13 @@
             <groupId>com.solace.maas</groupId>
             <artifactId>plugin</artifactId>
             <version>1.6.3-SNAPSHOT</version>
+        </dependency>
+        <!-- Override version 6.0.17 from spring-boot-starter-web 3.1.9 that has a vulnerability without moving to
+         v3.2.3 which uses 6.1.4 (we would require 6.1.5) -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <version>${spring-web.version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/service/solace-plugin/pom.xml
+++ b/service/solace-plugin/pom.xml
@@ -21,6 +21,7 @@
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
         <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
         <jackson.version>2.16.0</jackson.version>
+        <spring-web.version>6.0.18</spring-web.version>
     </properties>
 
     <dependencyManagement>
@@ -31,6 +32,13 @@
                 <version>${jackson.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <!-- Override version 6.0.17 from spring-boot-starter-web 3.1.9 that has a vulnerability without moving to
+         v3.2.3 which uses 6.1.4 (we would require 6.1.5) -->
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-web</artifactId>
+                <version>${spring-web.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/service/terraform-plugin/pom.xml
+++ b/service/terraform-plugin/pom.xml
@@ -19,6 +19,7 @@
         <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
         <maas.jobs.version>2.0.11</maas.jobs.version>
         <jackson.version>2.16.1</jackson.version>
+        <spring-web.version>6.0.18</spring-web.version>
     </properties>
     <dependencies>
         <dependency>
@@ -87,6 +88,13 @@
                     <artifactId>logback-classic</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <!-- Override version 6.0.17 from spring-boot-starter-web 3.1.9 that has a vulnerability without moving to
+         v3.2.3 which uses 6.1.4 (we would require 6.1.5) -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <version>${spring-web.version}</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
### What is the purpose of this change?

Uprev spring-web from 6.0.17 -> 6.0.18 to solve a vulnerability.

### How was this change implemented?

Adding an explicit dependency to spring-web v6.0.18 in each module's pom. It's best to do it this way because upgrading spring parent isn't going to get us a good version that isn't vulnerable. We must override it. We also can't simply add the version number to the properties section because it's not a variable to be overridden like that on spring's side. So, we explicitly add the dependency override until we can upgrade to a version of spring-web that is safe in spring-parent 3.1.10 or 3.2.4 which don't exist yet. 

### How was this change tested?

Ran the EMA and saw no issues.
See attached dependencies before and after from `mvn dependency:tree`.

### Is there anything the reviewers should focus on/be aware of?
AFTER
[dependencies_AFTER.txt](https://github.com/SolaceProducts/event-management-agent/files/14711833/dependencies_AFTER.txt)

BEFORE
[dependencies_BEFORE.txt](https://github.com/SolaceProducts/event-management-agent/files/14711834/dependencies_BEFORE.txt)
