### PR TITLE
DATAGO-74587: Add a retry handler to the Messaging Service that represents the eVMR…

### DIFF
--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/config/SolaceConfiguration.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/config/SolaceConfiguration.java
@@ -66,7 +66,7 @@ public class SolaceConfiguration {
         log.info("Connecting to event portal using EMA client {}.", clientName);
         return MessagingService.builder(ConfigurationProfile.V1)
                 .fromProperties(vmrConfiguration)
-                .withReconnectionRetryStrategy(RetryStrategy.foreverRetry(15000))
+                .withReconnectionRetryStrategy(RetryStrategy.foreverRetry(15_000))
                 .build()
                 .connect();
     }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/config/SolaceConfiguration.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/config/SolaceConfiguration.java
@@ -2,12 +2,13 @@ package com.solace.maas.ep.event.management.agent.config;
 
 import com.solace.maas.ep.event.management.agent.config.eventPortal.EventPortalProperties;
 import com.solace.maas.ep.event.management.agent.messagingServices.RtoMessagingService;
+import com.solace.maas.ep.event.management.agent.plugin.config.EnableRtoCondition;
 import com.solace.maas.ep.event.management.agent.plugin.jacoco.ExcludeFromJacocoGeneratedReport;
+import com.solace.maas.ep.event.management.agent.plugin.messagingService.RtoMessageBuilder;
 import com.solace.maas.ep.event.management.agent.plugin.publisher.SolacePublisher;
 import com.solace.maas.ep.event.management.agent.subscriber.SolaceSubscriber;
-import com.solace.maas.ep.event.management.agent.plugin.config.EnableRtoCondition;
-import com.solace.maas.ep.event.management.agent.plugin.messagingService.RtoMessageBuilder;
 import com.solace.messaging.MessagingService;
+import com.solace.messaging.config.RetryStrategy;
 import com.solace.messaging.config.SolaceProperties;
 import com.solace.messaging.config.profile.ConfigurationProfile;
 import com.solace.messaging.publisher.DirectMessagePublisher;
@@ -40,8 +41,8 @@ public class SolaceConfiguration {
     @SuppressWarnings("PMD.LooseCoupling")
     public SolaceConfiguration(Properties vmrConfig, ArrayList<String> sessionConfig,
                                EventPortalProperties eventPortalProperties) {
-        this.vmrConfiguration = vmrConfig;
-        this.sessionConfiguration = sessionConfig;
+        vmrConfiguration = vmrConfig;
+        sessionConfiguration = sessionConfig;
         this.eventPortalProperties = eventPortalProperties;
     }
 
@@ -65,6 +66,7 @@ public class SolaceConfiguration {
         log.info("Connecting to event portal using EMA client {}.", clientName);
         return MessagingService.builder(ConfigurationProfile.V1)
                 .fromProperties(vmrConfiguration)
+                .withReconnectionRetryStrategy(RetryStrategy.foreverRetry(15000))
                 .build()
                 .connect();
     }


### PR DESCRIPTION
## **User description**
### What is the purpose of this change?

If the EMA suffers a prolonged network outage (more than 90ish seconds) it cannot reconnect to the eVMR. The only remedial action is to restart the EMA.

### How was this change implemented?

Added a retry handler to the Messaging Service that represents the eVMR. It will attempt to reconnect every 15 seconds as long as the eVMR is running.

### How was this change tested?

The following steps were performed with and without the fix:
1. run the EMA locally
2. dis-connected my laptop from the network for 5 minutes
3. re-connected my laptop to the network

Without the fix, the EMA did not reconnect to the eVMR.
With the fix, the EMA reconnected to the eVMR added its subscriptions and could perform discovery operations.

### Is there anything the reviewers should focus on/be aware of?

N/A
    ...


___

## **Type**
enhancement


___

## **Description**
- Implemented a reconnection strategy for the Messaging Service to automatically attempt reconnection every 15 seconds indefinitely. This enhancement addresses the issue where the EMA could not reconnect to the eVMR after a network outage.
- Minor code refactoring for better readability and maintenance.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SolaceConfiguration.java</strong><dd><code>Implement Reconnection Strategy in Messaging Service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

service/application/src/main/java/com/solace/maas/ep/event/management/agent/config/SolaceConfiguration.java
<li>Added <code>RetryStrategy.foreverRetry(15_000)</code> to the <code>MessagingService</code> <br>builder to implement a reconnection strategy.<br> <li> Minor refactoring in constructor parameter assignments for clarity.<br> <li> Organized imports and annotations.


</details>
    

  </td>
  <td><a href="https://github.com/SolaceProducts/event-management-agent/pull/175/files#diff-09d1434dfc312c2564a61ff57456253d855380385104e0f8729e082063720894">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

