### PR TITLE
DATAGO-76074: ignore log streaming in standalone mode

### DIFF
--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/CommandLogStreamingProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/CommandLogStreamingProcessor.java
@@ -12,6 +12,7 @@ import com.solace.maas.ep.event.management.agent.plugin.terraform.manager.Terraf
 import com.solace.maas.ep.event.management.agent.publisher.CommandLogsPublisher;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -32,6 +33,7 @@ import static com.solace.maas.ep.event.management.agent.plugin.constants.RouteCo
 
 @Component
 @Slf4j
+@ConditionalOnProperty(name = "event-portal.gateway.messaging.standalone", havingValue = "false")
 public class CommandLogStreamingProcessor {
 
     public static final String ANY = "*";


### PR DESCRIPTION
### What is the purpose of this change?

 The beans related to log streaming to ep MUST NOT be instantiated on standalone mode  

### How was this change implemented?

Java code

### How was this change tested?

Existing Its

### Is there anything the reviewers should focus on/be aware of?

NA