### PR TITLE
DATAGO-75875: event-management-agent:github.com/hashicorp/go-getter:v1.7.3,Type: app_dependency,Prisma Cloud Vulnerability

### DIFF
--- a/service/application/docker/Dockerfile
+++ b/service/application/docker/Dockerfile
@@ -8,8 +8,8 @@ WORKDIR /opt/ema
 
 ARG PLATFORM=linux_amd64
 
-COPY tofu_1.6.0-rc1_amd64.apk /opt/ema/terraform
-RUN apk --update add --allow-untrusted /opt/ema/terraform/tofu_1.6.0-rc1_amd64.apk
+COPY tofu_1.7.0_amd64.apk /opt/ema/terraform
+RUN apk --update add --allow-untrusted /opt/ema/terraform/tofu_1.7.0_amd64.apk
 
 ARG SOLACE_PROVIDER_VERSION=0.9.2-rc.2
 ADD terraform-provider-solacebroker_${SOLACE_PROVIDER_VERSION}_${PLATFORM}.tar.gz /opt/ema/terraform


### PR DESCRIPTION
### What is the purpose of this change?

Uprev open tofu from 1.6.0 to 1.7.0 to resolve go-getter vulnerability

### How was this change implemented?

Replaced the opentofu 1.6.0 apk with the 1.7.0 apk and updated the dockerfile

### How was this change tested?

I created the docker image, ran the container and did an audit scan and config push. It was successful.

### Is there anything the reviewers should focus on/be aware of?

None
