### PR TITLE
Datago 77753 enable json log

### DIFF
--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -210,6 +210,14 @@
             <groupId>net.logstash.logback</groupId>
             <artifactId>logstash-logback-encoder</artifactId>
         </dependency>
+
+        <!-- for using conditionals in logback.xml -->
+        <dependency>
+            <groupId>org.codehaus.janino</groupId>
+            <artifactId>janino</artifactId>
+            <version>3.1.12</version>
+        </dependency>
+
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>

--- a/service/application/src/main/resources/application.yml
+++ b/service/application/src/main/resources/application.yml
@@ -10,13 +10,14 @@ server:
 
 idGenerator:
   originId: event_management_agent_${EP_EVENT_MANAGEMENT_AGENT_ID}
-
+log-file: /Users/rchakraborty/ema-logs/ema.log
 spring:
   datasource:
     url: jdbc:h2:file:./data/cache;DB_CLOSE_ON_EXIT=FALSE
     username: sa
     password: password
     driver-class-name: org.h2.Driver
+
   jpa:
     database-platform: org.hibernate.dialect.H2Dialect
     hibernate:

--- a/service/application/src/main/resources/application.yml
+++ b/service/application/src/main/resources/application.yml
@@ -23,7 +23,7 @@ server:
 
 idGenerator:
   originId: event_management_agent_${EP_EVENT_MANAGEMENT_AGENT_ID}
-log-file: /Users/rchakraborty/ema-logs/ema.log
+
 spring:
   datasource:
     url: jdbc:h2:file:./data/cache;DB_CLOSE_ON_EXIT=FALSE

--- a/service/application/src/main/resources/application.yml
+++ b/service/application/src/main/resources/application.yml
@@ -5,6 +5,19 @@ springdoc:
   swagger-ui:
     path: /event-management-agent/swagger-ui.html
 
+logging:
+  log-in-json-format: false
+  level:
+    root: INFO
+  file:
+    name: /tmp/EMA.log
+  logback:
+    rolling-policy:
+      file-name-pattern: '${LOG_FILE}.%d{yyyy-MM-dd}.%i.gz'
+      max-file-size: 10MB
+      max-history: 7
+      total-size-cap: 1GB
+
 server:
   port: 8180
 

--- a/service/application/src/main/resources/logback-spring.xml
+++ b/service/application/src/main/resources/logback-spring.xml
@@ -85,12 +85,5 @@
             <appender-ref ref="RollingCommandsFile"/>
             <appender-ref ref="StreamingAppender"/>
         </root>
-        <logger name="com.solace.maas" level="DEBUG" additivity="false">
-            <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="RollingFile"/>
-            <appender-ref ref="SiftLogger"/>
-            <appender-ref ref="RollingCommandsFile"/>
-            <appender-ref ref="StreamingAppender"/>
-        </logger>
     </springProfile>
 </configuration>

--- a/service/application/src/main/resources/logback-spring.xml
+++ b/service/application/src/main/resources/logback-spring.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-
     <property name="LOG_LEVEL_PATTERN" value="%clr(%5p) %clr([%X{traceId:-}]){yellow}"/>
     <property resource="command-configs.properties"/>
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
@@ -11,7 +10,6 @@
         <encoder>
             <pattern>%d [%thread] %-5level %-50logger{40} : %msg%n</pattern>
         </encoder>
-
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>EMA-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
             <maxFileSize>1MB</maxFileSize>
@@ -20,6 +18,30 @@
             <cleanHistoryOnStart>false</cleanHistoryOnStart>
         </rollingPolicy>
     </appender>
+
+    <appender name="RollingFileInJSONFormat" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <customFields>{"component":"event-management-agent-${EMA_ID:-}"}</customFields>
+            <providers>
+                <stackTrace>
+                    <fieldName>stackTrace</fieldName>
+                    <throwableConverter
+                            class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
+                        <rootCauseFirst>true</rootCauseFirst>
+                    </throwableConverter>
+                </stackTrace>
+            </providers>
+        </encoder>
+        <file>${LOG_FILE_PATH:-EMA.log}</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>EMA-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>10MB</totalSizeCap>
+            <cleanHistoryOnStart>false</cleanHistoryOnStart>
+        </rollingPolicy>
+    </appender>
+
     <appender name="SiftLogger" class="ch.qos.logback.classic.sift.SiftingAppender">
         <discriminator>
             <key>SCAN_ID</key>
@@ -34,6 +56,7 @@
             </appender>
         </sift>
     </appender>
+
     <appender name="StreamingAppender" class="com.solace.maas.ep.event.management.agent.logging.StreamingAppender"/>
 
 
@@ -44,7 +67,8 @@
         <file>${COMMAND_PATH}/logs/command-logs.log</file>
 
         <encoder>
-            <pattern>[%X{COMMAND_CORRELATION_ID}] ------ %date [%level] [%thread] %logger{10} [%file:%line] %msg%n</pattern>
+            <pattern>[%X{COMMAND_CORRELATION_ID}] ------ %date [%level] [%thread] %logger{10} [%file:%line] %msg%n
+            </pattern>
         </encoder>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
@@ -67,6 +91,23 @@
         <logger name="com.solace.maas" level="DEBUG" additivity="false">
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="RollingFile"/>
+            <appender-ref ref="SiftLogger"/>
+            <appender-ref ref="RollingCommandsFile"/>
+            <appender-ref ref="StreamingAppender"/>
+        </logger>
+    </springProfile>
+
+    <springProfile name="solaceCloud">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="RollingFileInJSONFormat"/>
+            <appender-ref ref="SiftLogger"/>
+            <appender-ref ref="RollingCommandsFile"/>
+            <appender-ref ref="StreamingAppender"/>
+        </root>
+        <logger name="com.solace.maas" level="DEBUG" additivity="false">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="RollingFileInJSONFormat"/>
             <appender-ref ref="SiftLogger"/>
             <appender-ref ref="RollingCommandsFile"/>
             <appender-ref ref="StreamingAppender"/>

--- a/service/application/src/main/resources/logback-spring.xml
+++ b/service/application/src/main/resources/logback-spring.xml
@@ -4,44 +4,6 @@
     <property resource="command-configs.properties"/>
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
     <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
-
-    <appender name="RollingFile" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>EMA.log</file>
-        <encoder>
-            <pattern>%d [%thread] %-5level %-50logger{40} : %msg%n</pattern>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>EMA-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-            <maxFileSize>1MB</maxFileSize>
-            <maxHistory>30</maxHistory>
-            <totalSizeCap>10MB</totalSizeCap>
-            <cleanHistoryOnStart>false</cleanHistoryOnStart>
-        </rollingPolicy>
-    </appender>
-
-    <appender name="RollingFileInJSONFormat" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-            <customFields>{"component":"event-management-agent-${EMA_ID:-}"}</customFields>
-            <providers>
-                <stackTrace>
-                    <fieldName>stackTrace</fieldName>
-                    <throwableConverter
-                            class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
-                        <rootCauseFirst>true</rootCauseFirst>
-                    </throwableConverter>
-                </stackTrace>
-            </providers>
-        </encoder>
-        <file>${LOG_FILE_PATH:-EMA.log}</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>EMA-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-            <maxFileSize>10MB</maxFileSize>
-            <maxHistory>30</maxHistory>
-            <totalSizeCap>10MB</totalSizeCap>
-            <cleanHistoryOnStart>false</cleanHistoryOnStart>
-        </rollingPolicy>
-    </appender>
-
     <appender name="SiftLogger" class="ch.qos.logback.classic.sift.SiftingAppender">
         <discriminator>
             <key>SCAN_ID</key>
@@ -56,7 +18,41 @@
             </appender>
         </sift>
     </appender>
+    <springProperty name="agentId" source="event-portal.runtime-agent-id"/>
+    <springProperty name="USE_JSON_LOG" source="logging.log-in-json-format"/>
+    <property name="USE_JSON" value="${USE_JSON_LOG}"/>
 
+    <appender name="RollingFile" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <if condition='property("USE_JSON").equals("true")'>
+            <then>
+                <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                    <customFields>{"component":"event-management-agent-${agentId}"}</customFields>
+                    <providers>
+                        <stackTrace>
+                            <fieldName>stackTrace</fieldName>
+                            <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
+                                <rootCauseFirst>true</rootCauseFirst>
+                            </throwableConverter>
+                        </stackTrace>
+                    </providers>
+                </encoder>
+            </then>
+            <else>
+                <encoder>
+                    <pattern>%d [%thread] %-5level %-50logger{40} : %msg%n</pattern>
+                </encoder>
+            </else>
+        </if>
+
+        <file>${LOG_FILE:-EMA.log}</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOGBACK_ROLLINGPOLICY_FILE_NAME_PATTERN:-EMA-%d{yyyy-MM-dd}.%i.log}</fileNamePattern>
+            <maxFileSize>${LOGBACK_ROLLINGPOLICY_MAX_FILE_SIZE:-10MB}</maxFileSize>
+            <maxHistory>${LOGBACK_ROLLINGPOLICY_MAX_HISTORY:-7}</maxHistory>
+            <totalSizeCap>${LOGBACK_ROLLINGPOLICY_TOTAL_SIZE_CAP:-10MB}</totalSizeCap>
+            <cleanHistoryOnStart>false</cleanHistoryOnStart>
+        </rollingPolicy>
+    </appender>
     <appender name="StreamingAppender" class="com.solace.maas.ep.event.management.agent.logging.StreamingAppender"/>
 
 
@@ -81,7 +77,8 @@
     </appender>
 
     <springProfile name="default,mysql,mysql-dev,DEV,TEST">
-        <root level="INFO">
+        <springProperty scope="context" name="LOG_ROOT" source="logging.level.root"/>
+        <root level="${LOG_ROOT:-INFO}">
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="RollingFile"/>
             <appender-ref ref="SiftLogger"/>
@@ -96,23 +93,4 @@
             <appender-ref ref="StreamingAppender"/>
         </logger>
     </springProfile>
-
-    <springProfile name="solaceCloud">
-        <root level="INFO">
-            <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="RollingFileInJSONFormat"/>
-            <appender-ref ref="SiftLogger"/>
-            <appender-ref ref="RollingCommandsFile"/>
-            <appender-ref ref="StreamingAppender"/>
-        </root>
-        <logger name="com.solace.maas" level="DEBUG" additivity="false">
-            <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="RollingFileInJSONFormat"/>
-            <appender-ref ref="SiftLogger"/>
-            <appender-ref ref="RollingCommandsFile"/>
-            <appender-ref ref="StreamingAppender"/>
-        </logger>
-
-    </springProfile>
-
 </configuration>

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/logging/LogbackConfigurationTestsWithJsonEncoder.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/logging/LogbackConfigurationTestsWithJsonEncoder.java
@@ -1,0 +1,67 @@
+package com.solace.maas.ep.event.management.agent.logging;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.rolling.RollingFileAppender;
+import ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_CLASS;
+
+@ActiveProfiles("TEST")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+        "logging.log-in-json-format=true",
+        "logging.level.root=ERROR",
+        "logging.file.name=CEMA-TEST.log",
+        "logging.logback.rolling-policy.file-name-pattern=${LOG_FILE}.%d{yyyy-MM-dd}.%i.gz",
+        "logging.logback.rolling-policy.max-file-size=1MB",
+        "logging.logback.rolling-policy.max-history=30"
+
+})
+@DirtiesContext(classMode = AFTER_CLASS)
+class LogbackConfigurationTestsWithJsonEncoder {
+
+    @BeforeEach
+    void beforeTest() {
+        LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+        context.reset();
+    }
+
+    @Test
+    //CPD-OFF
+    void testRollingFileAppenderWithPatternLayoutEncoder() {
+        LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+        for (ch.qos.logback.classic.Logger logger : context.getLoggerList()) {
+            logger.iteratorForAppenders().forEachRemaining(appender -> {
+                if (appender.getName().equals("RollingFile")) {
+                    commonAssertions(appender);
+                    encoderSpecificAssertions((RollingFileAppender) appender);
+                }
+            });
+        }
+    }
+    //CPD-ON
+
+
+    private void encoderSpecificAssertions(RollingFileAppender<ILoggingEvent> rollingFileAppender) {
+        assertThat(rollingFileAppender.getEncoder().getClass())
+                .hasToString("class net.logstash.logback.encoder.LogstashEncoder");
+    }
+
+    private void commonAssertions(Appender<ILoggingEvent> appender) {
+        RollingFileAppender<ILoggingEvent> rollingFile = (RollingFileAppender) appender;
+        assertThat(appender.getContext().getCopyOfPropertyMap().get("LOG_ROOT")).isEqualTo("ERROR");
+        SizeAndTimeBasedRollingPolicy<ILoggingEvent> rollingPolicy = (SizeAndTimeBasedRollingPolicy) rollingFile.getRollingPolicy();
+        assertThat(rollingPolicy.getFileNamePattern()).isEqualTo("CEMA-TEST.log.%d{yyyy-MM-dd}.%i.gz");
+        assertThat(rollingFile.getFile()).isEqualTo("CEMA-TEST.log");
+        assertThat(rollingPolicy.getMaxHistory()).isEqualTo(30);
+        assertThat(rollingPolicy.isCleanHistoryOnStart()).isFalse();
+    }
+}

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/logging/LogbackConfigurationTestsWithPatternLayoutEncoder.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/logging/LogbackConfigurationTestsWithPatternLayoutEncoder.java
@@ -1,0 +1,65 @@
+package com.solace.maas.ep.event.management.agent.logging;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.rolling.RollingFileAppender;
+import ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_CLASS;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+        "logging.log-in-json-format=false",
+        "logging.level.root=DEBUG",
+        "logging.file.name=CEMA-TEST.log",
+        "logging.logback.rolling-policy.file-name-pattern='${LOG_FILE}.%d{yyyy-MM-dd}.%i.gz'",
+        "logging.logback.rolling-policy.max-file-size=1MB",
+        "logging.logback.rolling-policy.max-history=10"
+
+})
+@ActiveProfiles("TEST")
+@DirtiesContext(classMode = AFTER_CLASS)
+public class LogbackConfigurationTestsWithPatternLayoutEncoder {
+
+    @BeforeEach
+    void beforeTest(){
+        LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+        context.reset();
+    }
+
+    @Test
+    void testRollingFileAppenderWithPatternLayoutEncoder() {
+        LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+        for (ch.qos.logback.classic.Logger logger : context.getLoggerList()) {
+            logger.iteratorForAppenders().forEachRemaining(appender -> {
+                if (appender.getName().equals("RollingFile")) {
+                    commonAssertions(appender);
+                    encoderSpecificAssertions((RollingFileAppender) appender);
+                }
+            });
+        }
+    }
+
+    void commonAssertions(Appender<ILoggingEvent> appender) {
+        RollingFileAppender<ILoggingEvent> rollingFile = (RollingFileAppender) appender;
+        assertThat(appender.getContext().getCopyOfPropertyMap().get("LOG_ROOT")).isEqualTo("DEBUG");
+        assertThat(rollingFile.getFile()).isEqualTo("CEMA-TEST.log");
+        SizeAndTimeBasedRollingPolicy<ILoggingEvent> rollingPolicy = (SizeAndTimeBasedRollingPolicy) rollingFile.getRollingPolicy();
+        assertThat(rollingPolicy.getFileNamePattern()).isEqualTo("CEMA-TEST.log.%d{yyyy-MM-dd}.%i.gz");
+        assertThat(rollingPolicy.getMaxHistory()).isEqualTo(10);
+        assertThat(rollingPolicy.isCleanHistoryOnStart()).isFalse();
+    }
+
+    void encoderSpecificAssertions(RollingFileAppender<ILoggingEvent> rollingFileAppender) {
+        assertThat(rollingFileAppender.getEncoder().getClass())
+                .hasToString("class ch.qos.logback.classic.encoder.PatternLayoutEncoder");
+    }
+
+}


### PR DESCRIPTION
### What is the purpose of this change?

Implement asks of https://sol-jira.atlassian.net/browse/DATAGO-77753

Demo posted here: https://solacedotcom.slack.com/archives/C06LQ9DME4W/p1719583559696409?thread_ts=1719506584.264529&cid=C06LQ9DME4W

### How was this change implemented?

Updated logback-spring.xml with conditionals to support json or regular format. The xml file is also taking configurations set via application.yml into account for various configuration such as log file location, log rotation parameters etc. 

### How was this change tested?

IT test. Please note the comments on the IT test files

### Is there anything the reviewers should focus on/be aware of?

    ...
