### PR TITLE
DATAGO-78232: Add new spring variable to override the use of user.home

### DIFF
--- a/service/application/src/main/resources/command-configs.properties
+++ b/service/application/src/main/resources/command-configs.properties
@@ -1,1 +1,1 @@
-COMMAND_PATH=${user.home}${file.separator}commands
+COMMAND_PATH=${app.commandroot:-${user.home}}${file.separator}commands

--- a/service/terraform-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/terraform/configuration/TerraformProperties.java
+++ b/service/terraform-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/terraform/configuration/TerraformProperties.java
@@ -7,6 +7,6 @@ import org.springframework.stereotype.Service;
 @Service
 @Data
 public class TerraformProperties {
-    @Value("${COMMAND_PATH:${user.home}${file.separator}tfcommands}")
+    @Value("${app.commandroot:${user.home}}${file.separator}tfcommands")
     private String workingDirectoryRoot;
 }


### PR DESCRIPTION
### What is the purpose of this change?

When running the docker image in k8s, the user.home get's set to '?' which causes the EMA to fail to load

### How was this change implemented?

Anywhere that we use user.home, we add another variable that can be set on the command line (or via an env var) that overrides the use of user.home, so the "command" and "tfcommand" directories get created as expected.

I was able to test this in docker using the following command:
```
docker run -d -p 8180:8180 -v greg1.yml:/config/ema.yml --env JAVA_OPTS="-Dapp.commandroot=/opt" --name event-management-agent event-management-agent:ema-test1
```
The "magic" here is setting the environment variable `JAVA_OPTS` to be `-Dapp.commandroot=/opt`. This overrides the use of `user.home`. For the kubernetes deployment, we must add the `JAVA_OPTS` env var via sidekick.

### How was this change tested?

Tested with jar from the command line and with docker container.
Tested with and without the new 'app.commandroot' variable set. With app.commandroot set, it as used as the root directory instead of the user's home directory.
Tested with config push and scan

### Is there anything the reviewers should focus on/be aware of?

None
