### PR TITLE
Datago-74735: Add micrometer / StatsD metrics support

### DIFF
--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -275,6 +275,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-statsd</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>

--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -276,7 +276,7 @@
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-registry-statsd</artifactId>
+            <artifactId>``````````````````````````micr``````````````````````````ometer-registry-statsd</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -276,7 +276,7 @@
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>
-            <artifactId>``````````````````````````micr``````````````````````````ometer-registry-statsd</artifactId>
+            <artifactId>micrometer-registry-statsd</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/service/application/src/main/resources/application.yml
+++ b/service/application/src/main/resources/application.yml
@@ -23,7 +23,7 @@ management:
     metrics:
       export:
         # enable / disable shipping metrics to StatsD endpoint
-        enabled: false
+        enabled: true
         flavor: datadog
         host: 127.0.0.1
         port: 8125

--- a/service/application/src/main/resources/application.yml
+++ b/service/application/src/main/resources/application.yml
@@ -11,9 +11,18 @@ management:
     tags:
       # key - value pairs
       maas_id: my-maas-id
+    enable:
+      # enable / disable specific metrics
+      all: false
+      application:
+        started:
+          time: true
+      jvm:
+        info: true
   statsd:
     metrics:
       export:
+        # enable / disable shipping metrics to StatsD endpoint
         enabled: false
         flavor: datadog
         host: 127.0.0.1

--- a/service/application/src/main/resources/application.yml
+++ b/service/application/src/main/resources/application.yml
@@ -14,6 +14,7 @@ management:
     enable:
       # enable / disable specific metrics
       all: false
+      # sample metrics to be exposed
       application:
         started:
           time: true

--- a/service/application/src/main/resources/application.yml
+++ b/service/application/src/main/resources/application.yml
@@ -5,6 +5,21 @@ springdoc:
   swagger-ui:
     path: /event-management-agent/swagger-ui.html
 
+# micrometer / statsd
+management:
+  metrics:
+    tags:
+      # key - value pairs
+      maas_id: my-maas-id
+  statsd:
+    metrics:
+      export:
+        enabled: false
+        flavor: datadog
+        host: 127.0.0.1
+        port: 8125
+        protocol: udp
+
 server:
   port: 8180
 


### PR DESCRIPTION
### What is the purpose of this change?
Enabling EMA to expose / push metrics to a StatsD endpoint (UDP)

### How was this change implemented?

Adding java dependencies and enhancing configuration of EMA (application.yml)

### How was this change tested?

In a local development environment with a StatsD/DataDog metrics shipper running in a Docker Container

### Is there anything the reviewers should focus on/be aware of?
Metrics export via UDP are disabled by default
