### PR TITLE
[DATAGO-80317] fix issues blocking standalone mode from executing. 

### DIFF
--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/CommandLogStreamingProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/CommandLogStreamingProcessor.java
@@ -32,7 +32,7 @@ import static com.solace.maas.ep.event.management.agent.plugin.constants.RouteCo
 
 @Component
 @Slf4j
-@ConditionalOnExpression("${event-portal.gateway.messaging.standalone:false}== false && ${event-portal.managed:false} == false")
+@ConditionalOnExpression("${event-portal.gateway.messaging.standalone:true}== false && ${event-portal.managed:false} == false")
 public class CommandLogStreamingProcessor {
 
     public static final String ANY = "*";

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/CommandMessageHandler.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/CommandMessageHandler.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
-@ConditionalOnExpression("${event-portal.gateway.messaging.standalone:false}== false && ${event-portal.managed:false} == false")
+@ConditionalOnExpression("${event-portal.gateway.messaging.standalone:true}== false && ${event-portal.managed:false} == false")
 public class CommandMessageHandler extends SolaceDirectMessageHandler<CommandMessage> {
 
     private final CommandMessageProcessor commandMessageProcessor;

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/DiscoveryMessageHandler.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/DiscoveryMessageHandler.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
-@ConditionalOnExpression("${event-portal.gateway.messaging.standalone:false}== false && ${event-portal.managed:false} == false")
+@ConditionalOnExpression("${event-portal.gateway.messaging.standalone:true}== false && ${event-portal.managed:false} == false")
 public class DiscoveryMessageHandler extends SolaceDirectMessageHandler<MOPMessage> {
 
     public DiscoveryMessageHandler(

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/ScanCommandMessageHandler.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/ScanCommandMessageHandler.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
-@ConditionalOnExpression("${event-portal.gateway.messaging.standalone:false}== false && ${event-portal.managed:false} == false")
+@ConditionalOnExpression("${event-portal.gateway.messaging.standalone:true}== false && ${event-portal.managed:false} == false")
 public class ScanCommandMessageHandler extends SolaceDirectMessageHandler<ScanCommandMessage> {
 
     private final ScanCommandMessageProcessor scanCommandMessageProcessor;

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/SolacePersistentMessageHandler.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/SolacePersistentMessageHandler.java
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 
 @Slf4j
 @Service
-@ConditionalOnExpression("${event-portal.gateway.messaging.standalone:false}== false && ${event-portal.managed:false} == true")
+@ConditionalOnExpression("${event-portal.gateway.messaging.standalone:true}== false && ${event-portal.managed:false} == true")
 public class SolacePersistentMessageHandler extends BaseSolaceMessageHandler implements MessageReceiver.MessageHandler,
         ApplicationListener<ApplicationReadyEvent> {
     private final Map<String, Class> cachedJSONDecoders = new HashMap();

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/StartImportScanCommandMessageHandler.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/StartImportScanCommandMessageHandler.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 
 @Slf4j
 @Component
-@ConditionalOnExpression("${event-portal.gateway.messaging.standalone:false}== false && ${event-portal.managed:false} == false")
+@ConditionalOnExpression("${event-portal.gateway.messaging.standalone:true}== false && ${event-portal.managed:false} == false")
 public class StartImportScanCommandMessageHandler extends SolaceDirectMessageHandler<ScanDataImportMessage> {
 
     private final ProducerTemplate producerTemplate;

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/scanManager/ScanManagerHandleErrorTest.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/scanManager/ScanManagerHandleErrorTest.java
@@ -69,9 +69,9 @@ class ScanManagerHandleErrorTest {
                 Optional.empty()
         );
         // should just do "nothing" and not throw an exception when scanStatusPublisher is not present
-        assertDoesNotThrow(() -> {
-            scanManagerUnderTest.handleError(mockEx, createScanCommandMessage());
-        });
+        assertDoesNotThrow(() ->
+            scanManagerUnderTest.handleError(mockEx, createScanCommandMessage()));
+
     }
 
     private ScanCommandMessage createScanCommandMessage(){

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/scanManager/ScanManagerHandleErrorTest.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/scanManager/ScanManagerHandleErrorTest.java
@@ -14,6 +14,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
@@ -47,7 +48,7 @@ class ScanManagerHandleErrorTest {
                 messagingServiceDelegateService,
                 scanService,
                 eventPortalProperties,
-                scanStatusPublisher
+                Optional.of(scanStatusPublisher)
         );
         scanManagerUnderTest.handleError(mockEx,createScanCommandMessage());
         verify(scanStatusPublisher, times(1)).sendOverallScanStatus(any(),any());

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/scanManager/ScanManagerHandleErrorTest.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/scanManager/ScanManagerHandleErrorTest.java
@@ -16,6 +16,7 @@ import org.springframework.test.context.ActiveProfiles;
 import java.util.List;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -38,7 +39,7 @@ class ScanManagerHandleErrorTest {
     private ScanStatusPublisher scanStatusPublisher;
 
     @Test
-    void testScanManagerHandleError(){
+    void testScanManagerConnectedHandleError(){
         when(eventPortalProperties.getOrganizationId()).thenReturn("orgId");
         when(eventPortalProperties.getRuntimeAgentId()).thenReturn("runtimeAgentId");
 
@@ -54,7 +55,24 @@ class ScanManagerHandleErrorTest {
         verify(scanStatusPublisher, times(1)).sendOverallScanStatus(any(),any());
     }
 
+    @Test
+    void testScanManagerStandaloneHandleError(){
+        when(eventPortalProperties.getOrganizationId()).thenReturn("orgId");
+        when(eventPortalProperties.getRuntimeAgentId()).thenReturn("runtimeAgentId");
 
+        RuntimeException mockEx = new RuntimeException("Mock Exception");
+
+        ScanManager scanManagerUnderTest = new ScanManager(
+                messagingServiceDelegateService,
+                scanService,
+                eventPortalProperties,
+                Optional.empty()
+        );
+        // should just do "nothing" and not throw an exception when scanStatusPublisher is not present
+        assertDoesNotThrow(() -> {
+            scanManagerUnderTest.handleError(mockEx, createScanCommandMessage());
+        });
+    }
 
     private ScanCommandMessage createScanCommandMessage(){
         return new ScanCommandMessage(


### PR DESCRIPTION
### What is the purpose of this change?
To fix bugs when running the application in standalone mode and certain config values are not available.

### How was this change implemented?
Made the existence of a troublesome bean optional.
Also update the default for `event-portal.gateway.messaging.standalone` in conditionalExpressions to set to True.

### How was this change tested?
Updated tests, and manually created docker image, then ran scans from both standalone and connected mode. They both worked.

Connected:
-----------------
![Screenshot 2024-07-16 at 3 53 16 PM](https://github.com/user-attachments/assets/41291c91-8e7b-4f0e-880c-b40373b2dc30)
Standalone:
-----------------
![Screenshot 2024-07-16 at 3 42 43 PM](https://github.com/user-attachments/assets/9cbb6840-2a1b-41ac-9cdd-71e70b4da6ed)


### Is there anything the reviewers should focus on/be aware of?
Nope.
