### PR TITLE
DATAGO-80463: micrometer statsd log spam

### DIFF
--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/EMAApplication.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/EMAApplication.java
@@ -51,6 +51,8 @@ public class EMAApplication {
 
         properties.put("spring.application.name", "event-management-agent");
         properties.put("server.port", "8180");
+        properties.put("management.statsd.metrics.export.enabled", "false");
         return properties;
     }
 }
+


### PR DESCRIPTION
### What is the purpose of this change?
Fixing log spam of micrometers statsd exporter when `management.statsd.metrics.export.enabled: false` in `env.yml` is not provided.

### How was this change implemented?

Added SpringBoot default configuration in `EMAApplication.java` (lowest precedence)

### How was this change tested?

In local development environment
- created a Docker image 
- started EMA without any `management.micrometer.*` configurations defined in `env.yml`
- could not observer log spam anymore

- started EMA with configuration `management.statsd.metrics.export.enabled: true` in `env.yml`
- log spam can be observed - as expected due to missing `statsd` UDP listener

### Is there anything the reviewers should focus on/be aware of?

nope
