### PR TITLE
[DATAGO-79884] Upversion spring-boot from 3.2.5 to 3.2.7 to address a tomcat vulnerability

### DIFF
--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -13,7 +13,7 @@
     <name>Solace Event Management Agent - Application</name>
     <description>Solace Event Management Agent - Application</description>
     <properties>
-        <spring-boot.version>3.2.5</spring-boot.version>
+        <spring-boot.version>3.2.7</spring-boot.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <spring-security-rsa.version>1.1.3</spring-security-rsa.version>
         <spring-kafka.version>3.0.10</spring-kafka.version>

--- a/service/confluent-schema-registry-plugin/pom.xml
+++ b/service/confluent-schema-registry-plugin/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <spring-boot.version>3.2.5</spring-boot.version>
+        <spring-boot.version>3.2.7</spring-boot.version>
         <httpclient.version>4.5.14</httpclient.version>
         <mockwebserver.version>4.9.0</mockwebserver.version>
         <jupiter.version>5.10.2</jupiter.version>

--- a/service/kafka-plugin/pom.xml
+++ b/service/kafka-plugin/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <spring-kafka.version>3.1.4</spring-kafka.version>
         <kafka-clients.version>3.5.0</kafka-clients.version>
-        <spring-boot.version>3.2.5</spring-boot.version>
+        <spring-boot.version>3.2.7</spring-boot.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <jupiter.version>5.10.2</jupiter.version>
         <camel.version>4.5.0</camel.version>

--- a/service/local-storage-plugin/pom.xml
+++ b/service/local-storage-plugin/pom.xml
@@ -15,7 +15,7 @@
         <snakeyaml.version>2.0</snakeyaml.version>
         <jacksondatabind.version>2.13.4.2</jacksondatabind.version>
         <junit.version>4.13.2</junit.version>
-        <spring-boot.version>3.2.5</spring-boot.version>
+        <spring-boot.version>3.2.7</spring-boot.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <jupiter.version>5.10.2</jupiter.version>
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>

--- a/service/plugin/pom.xml
+++ b/service/plugin/pom.xml
@@ -18,7 +18,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <snakeyaml.version>2.0</snakeyaml.version>
         <jackson.version>2.16.1</jackson.version>
-        <spring-boot.version>3.2.5</spring-boot.version>
+        <spring-boot.version>3.2.7</spring-boot.version>
     </properties>
 
     <dependencyManagement>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.5</version>
+        <version>3.2.7</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.solace.maas</groupId>

--- a/service/rabbitmq-plugin/pom.xml
+++ b/service/rabbitmq-plugin/pom.xml
@@ -11,7 +11,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
-        <spring-boot.version>3.2.5</spring-boot.version>
+        <spring-boot.version>3.2.7</spring-boot.version>
     </properties>
     <dependencies>
         <dependency>

--- a/service/solace-plugin/pom.xml
+++ b/service/solace-plugin/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <solace-messaging-client.version>1.0.0</solace-messaging-client.version>
         <solclientj.version>10.0.0</solclientj.version>
-        <spring-boot.version>3.2.5</spring-boot.version>
+        <spring-boot.version>3.2.7</spring-boot.version>
         <jupiter.version>5.10.2</jupiter.version>
         <camel.version>4.5.0</camel.version>
         <commons-collections4.version>4.4</commons-collections4.version>

--- a/service/terraform-plugin/pom.xml
+++ b/service/terraform-plugin/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <spring-boot.version>3.2.5</spring-boot.version>
+        <spring-boot.version>3.2.7</spring-boot.version>
         <jupiter.version>5.10.2</jupiter.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <snakeyaml.version>2.0</snakeyaml.version>


### PR DESCRIPTION
### What is the purpose of this change?
To address a vulnerability and unblock EMA from getting released.

### How was this change implemented?
Upversioned spring-boot to 3.2.7 which has the newer version of tomcat.

### How was this change tested?
Ran the application in both docker and jar modes.


### Is there anything the reviewers should focus on/be aware of?

    ...
