### PR TITLE
DATAGO-81660: event-management-agent Dockerfile must account for correct user and user home directory setup

### DIFF
--- a/service/application/docker/Dockerfile
+++ b/service/application/docker/Dockerfile
@@ -12,7 +12,7 @@ RUN adduser -D $USER && \
     mkdir -p /opt/ema && \
     chmod 777 /opt/ema && \
     mkdir -p /opt/ema/terraform && \
-    chmod 777 /opt/ema/terraform &&\
+    chmod 777 /opt/ema/terraform && \
     chown -R $USER:$USER $HOME && \
     chown -R $USER:$USER /opt/ema/    
 

--- a/service/application/docker/Dockerfile
+++ b/service/application/docker/Dockerfile
@@ -7,13 +7,8 @@ ENV HOME /home/$USER
 
 VOLUME /tmp
 
-# install sudo as root
-RUN apk add --update sudo
-
 # create user
-RUN adduser -D $USER \
-        && echo "$USER ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/$USER \
-        && chmod 0440 /etc/sudoers.d/$USER
+RUN adduser -D $USER
 
 RUN mkdir -p /opt/ema && chmod 777 /opt/ema && mkdir -p /opt/ema/terraform && chmod 777 /opt/ema/terraform
 WORKDIR /opt/ema
@@ -26,9 +21,9 @@ RUN apk --update add --allow-untrusted /opt/ema/terraform/tofu_1.7.0_amd64.apk
 ARG SOLACE_PROVIDER_VERSION=0.9.2-rc.2
 ADD terraform-provider-solacebroker_${SOLACE_PROVIDER_VERSION}_${PLATFORM}.tar.gz /opt/ema/terraform
 
-RUN sudo chown -R $USER:$USER $HOME
+RUN chown -R $USER:$USER $HOME
 
-RUN sudo chown -R $USER:$USER /opt/ema/
+RUN chown -R $USER:$USER /opt/ema/
 
 COPY .terraformrc $HOME/.terraformrc
 

--- a/service/application/docker/Dockerfile
+++ b/service/application/docker/Dockerfile
@@ -1,7 +1,19 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+# default user name is "emauser"
+ARG USER=emauser
+ENV HOME /home/$USER
+
 VOLUME /tmp
+
+# install sudo as root
+RUN apk add --update sudo
+
+# create user
+RUN adduser -D $USER \
+        && echo "$USER ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/$USER \
+        && chmod 0440 /etc/sudoers.d/$USER
 
 RUN mkdir -p /opt/ema && chmod 777 /opt/ema && mkdir -p /opt/ema/terraform && chmod 777 /opt/ema/terraform
 WORKDIR /opt/ema
@@ -14,7 +26,11 @@ RUN apk --update add --allow-untrusted /opt/ema/terraform/tofu_1.7.0_amd64.apk
 ARG SOLACE_PROVIDER_VERSION=0.9.2-rc.2
 ADD terraform-provider-solacebroker_${SOLACE_PROVIDER_VERSION}_${PLATFORM}.tar.gz /opt/ema/terraform
 
-COPY .terraformrc /root/.terraformrc
+RUN sudo chown -R $USER:$USER $HOME
+
+RUN sudo chown -R $USER:$USER /opt/ema/
+
+COPY .terraformrc $HOME/.terraformrc
 
 RUN printf '#!/bin/ash\ntofu $*' > /opt/ema/terraform/terraform
 RUN chmod +x /opt/ema/terraform/terraform
@@ -31,5 +47,8 @@ ENV GITHASH="${GITHASH}" \
 
 ARG JAR_FILE
 ADD ${JAR_FILE} app.jar
+
+# switch to the created user from root
+USER $USER
 
 ENTRYPOINT [ "sh", "-c", "java $JAVA_OPTS -Djava.security.egd=file:/dev/./urandom -jar /opt/ema/app.jar $CMD_LINE_ARGS --spring.config.location=file:/config/ema.yml"]

--- a/service/application/docker/Dockerfile
+++ b/service/application/docker/Dockerfile
@@ -7,10 +7,15 @@ ENV HOME /home/$USER
 
 VOLUME /tmp
 
-# create user
-RUN adduser -D $USER
+# create user and directory setup
+RUN adduser -D $USER && \
+    mkdir -p /opt/ema && \
+    chmod 777 /opt/ema && \
+    mkdir -p /opt/ema/terraform && \
+    chmod 777 /opt/ema/terraform &&\
+    chown -R $USER:$USER $HOME && \
+    chown -R $USER:$USER /opt/ema/    
 
-RUN mkdir -p /opt/ema && chmod 777 /opt/ema && mkdir -p /opt/ema/terraform && chmod 777 /opt/ema/terraform
 WORKDIR /opt/ema
 
 ARG PLATFORM=linux_amd64
@@ -18,19 +23,16 @@ ARG PLATFORM=linux_amd64
 COPY tofu_1.7.0_amd64.apk /opt/ema/terraform
 RUN apk --update add --allow-untrusted /opt/ema/terraform/tofu_1.7.0_amd64.apk
 
-ARG SOLACE_PROVIDER_VERSION=0.9.2-rc.2
-ADD terraform-provider-solacebroker_${SOLACE_PROVIDER_VERSION}_${PLATFORM}.tar.gz /opt/ema/terraform
-
-RUN chown -R $USER:$USER $HOME
-
-RUN chown -R $USER:$USER /opt/ema/
+# switch to the created user from root
+USER $USER
 
 COPY .terraformrc $HOME/.terraformrc
-
 RUN printf '#!/bin/ash\ntofu $*' > /opt/ema/terraform/terraform
 RUN chmod +x /opt/ema/terraform/terraform
-
 ENV PATH $PATH:/opt/ema/terraform
+
+ARG SOLACE_PROVIDER_VERSION=0.9.2-rc.2
+ADD terraform-provider-solacebroker_${SOLACE_PROVIDER_VERSION}_${PLATFORM}.tar.gz /opt/ema/terraform
 
 ARG GITHASH
 ARG GITBRANCH
@@ -42,8 +44,5 @@ ENV GITHASH="${GITHASH}" \
 
 ARG JAR_FILE
 ADD ${JAR_FILE} app.jar
-
-# switch to the created user from root
-USER $USER
 
 ENTRYPOINT [ "sh", "-c", "java $JAVA_OPTS -Djava.security.egd=file:/dev/./urandom -jar /opt/ema/app.jar $CMD_LINE_ARGS --spring.config.location=file:/config/ema.yml"]

--- a/service/application/docker/Dockerfile
+++ b/service/application/docker/Dockerfile
@@ -23,9 +23,6 @@ ARG PLATFORM=linux_amd64
 COPY tofu_1.7.0_amd64.apk /opt/ema/terraform
 RUN apk --update add --allow-untrusted /opt/ema/terraform/tofu_1.7.0_amd64.apk
 
-# switch to the created user from root
-USER $USER
-
 COPY .terraformrc $HOME/.terraformrc
 RUN printf '#!/bin/ash\ntofu $*' > /opt/ema/terraform/terraform
 RUN chmod +x /opt/ema/terraform/terraform
@@ -41,6 +38,9 @@ ARG BUILD_TIMESTAMP
 ENV GITHASH="${GITHASH}" \
     GITBRANCH="${GITBRANCH}" \
     BUILD_TIMESTAMP="${BUILD_TIMESTAMP}"
+
+# switch to the created user from root
+USER $USER
 
 ARG JAR_FILE
 ADD ${JAR_FILE} app.jar


### PR DESCRIPTION
### What is the purpose of this change?

Implement asks of https://sol-jira.atlassian.net/browse/DATAGO-81660

### How was this change implemented?

By changing the docker file 

- Created a user called `emauser` (Note: the username can be overiddeen by passing the arfument to the Dockerfile)
- `.terraformrc` file is copied to the `/home/emauser` directory
- switched to using non-root user `emauser` 


### How was this change tested?

Tested configpush and scan for : 
- self managed ema 
- cloud managed ema 

### Is there anything the reviewers should focus on/be aware of?

    ...
