### PR TITLE
[DATAGO-78316] Upversion solace-messaging-client to a version that supports partitioned queues

### DIFF
--- a/service/plugin/pom.xml
+++ b/service/plugin/pom.xml
@@ -107,7 +107,12 @@
         <dependency>
             <groupId>com.solace</groupId>
             <artifactId>solace-messaging-client</artifactId>
-            <version>1.0.0</version>
+            <version>1.4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>com.solacesystems</groupId>

--- a/service/solace-plugin/pom.xml
+++ b/service/solace-plugin/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <solace-messaging-client.version>1.0.0</solace-messaging-client.version>
+        <solace-messaging-client.version>1.4.0</solace-messaging-client.version>
         <solclientj.version>10.0.0</solclientj.version>
         <spring-boot.version>3.2.7</spring-boot.version>
         <jupiter.version>5.10.2</jupiter.version>
@@ -39,6 +39,11 @@
             <groupId>com.solace</groupId>
             <artifactId>solace-messaging-client</artifactId>
             <version>${solace-messaging-client.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>com.solacesystems</groupId>


### PR DESCRIPTION
### What is the purpose of this change?
EMA must be able to bound to solace queue partitions on E-VMR.

### How was this change implemented?
Updated the version of solace-messaging-client to a version that supports partitioned queues

### How was this change tested?
Manually deployed the image to ep-perf-dev and confirmed both ConfigPush and Scan flows work.

The datacenter page deployment used to fail with the existing images after Queues became partitioned, they work now with this image!

![Screenshot 2024-08-12 at 3 33 33 PM](https://github.com/user-attachments/assets/d8a2047e-e236-4e9f-8722-19ea8893f74b)


### Is there anything the reviewers should focus on/be aware of?
Nope.
