### PR TITLE
DATAGO-82533: Release EMA dev images and run cypress test against them

### DIFF
--- a/.github/workflows/deploy-managed-ema-image.yaml
+++ b/.github/workflows/deploy-managed-ema-image.yaml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       releaseVersion:
-        description: "The image tag in ECR to push to a new environment."
+        description: "The tag of the image to push. We'll pull the main image and re-tag it with this."
         required: true
         default: "A.B.C"
       deployEnvironment:
@@ -45,7 +45,7 @@ jobs:
         if: ${{ github.event.inputs.deployEnvironment == 'development' }}
         run: |
           GCR_IMAGE_TAGS_TO_PUSH=(
-          "${{ github.event.inputs.releaseVersion }}" "latest"
+          "${{ github.event.inputs.releaseVersion }}"
           )
           GCR_DEV_IMAGE_REPO="gcr.io/${{ secrets.DEV_GCP_PROJECT_ID }}/${{ github.event.repository.name }}"
           for current_tag in ${GCR_IMAGE_TAGS_TO_PUSH[@]}
@@ -64,7 +64,7 @@ jobs:
         if: ${{ github.event.inputs.deployEnvironment == 'staging' }}
         run: |
           GCR_IMAGE_TAGS_TO_PUSH=(
-          "${{ github.event.inputs.releaseVersion }}" "latest"
+          "${{ github.event.inputs.releaseVersion }}"
           )
           GCR_STAGING_IMAGE_REPO="gcr.io/${{ secrets.STAGING_GCP_PROJECT_ID }}/${{ github.event.repository.name }}"
           for current_tag in ${GCR_IMAGE_TAGS_TO_PUSH[@]}
@@ -83,7 +83,7 @@ jobs:
         if: ${{ github.event.inputs.deployEnvironment == 'production' }}
         run: |
           GCR_IMAGE_TAGS_TO_PUSH=(
-          "${{ github.event.inputs.releaseVersion }}" "latest"
+          "${{ github.event.inputs.releaseVersion }}"
           )
           GCR_PROD_IMAGE_REPO="gcr.io/${{ secrets.PROD_GCP_PROJECT_ID }}/${{ github.event.repository.name }}"
           for current_tag in ${GCR_IMAGE_TAGS_TO_PUSH[@]}
@@ -102,7 +102,7 @@ jobs:
         if: ${{ github.event.inputs.deployEnvironment == 'production' }}
         run: |
           IMAGE_TAGS_TO_PUSH=(
-          "${{ github.event.inputs.releaseVersion }}" "latest"
+          "${{ github.event.inputs.releaseVersion }}"
           )
           PROD_IMAGE_REPO="${{ secrets.AZURE_CHINA_PROD_HOSTNAME }}/${{ github.event.repository.name }}"
           for current_tag in ${IMAGE_TAGS_TO_PUSH[@]}


### PR DESCRIPTION
### What is the purpose of this change?

We don't care that there's a 'latest' image tag because the ema version notifier will sort out what is latest.

### How was this change implemented?

- Removed the 'latest' tag on deployment to the different image repos.
- Reworded the image tag description to make more sense.

### How was this change tested?

It was not. There shouldn't be a need to test this for this PR. It will be tested after merging.

### Is there anything the reviewers should focus on/be aware of?

None
