### PR TITLE
DATAGO-85215: EMA generates its own client name based on hostname and runtime agent id

### DIFF
--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/config/SolaceConfiguration.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/config/SolaceConfiguration.java
@@ -62,9 +62,7 @@ public class SolaceConfiguration {
     @ConditionalOnMissingBean(EnableRtoCondition.class)
     @ConditionalOnProperty(name = "event-portal.gateway.messaging.standalone", havingValue = "false")
     public MessagingService messagingService() {
-        String clientName = "runtimeAgent-" + eventPortalProperties.getRuntimeAgentId();
-        vmrConfiguration.setProperty(SolaceProperties.ClientProperties.NAME, clientName);
-
+        String clientName = vmrConfiguration.getProperty(SolaceProperties.ClientProperties.NAME);
         log.info("Connecting to event portal using EMA client {}.", clientName);
         return MessagingService.builder(ConfigurationProfile.V1)
                 .fromProperties(vmrConfiguration)

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/applicationContextTests/ManagedAgentMessageHandlerBeansTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/applicationContextTests/ManagedAgentMessageHandlerBeansTests.java
@@ -82,7 +82,7 @@ class ManagedAgentMessageHandlerBeansTests {
     @Test
     void testClientNameIsGeneratedBasedOnHostNameAndAgentId() throws UnknownHostException {
         String hostnameHash = DigestUtils.sha256Hex(InetAddress.getLocalHost().getHostName());
-        assertThat(vmrProperties.getClientName()).isEqualTo("testManagedAgentId-" + hostnameHash);
+        assertThat(vmrProperties.getClientName()).isEqualTo("ema-testManagedAgentId-" + hostnameHash);
 
     }
 }

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/applicationContextTests/ManagedAgentMessageHandlerBeansTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/applicationContextTests/ManagedAgentMessageHandlerBeansTests.java
@@ -1,6 +1,8 @@
 package com.solace.maas.ep.event.management.agent.applicationContextTests;
 
+import com.solace.maas.ep.event.management.agent.plugin.config.VMRProperties;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,6 +10,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -20,12 +24,16 @@ import static org.assertj.core.api.Assertions.assertThat;
         "eventPortal.gateway.messaging.standalone=false",
         "eventPortal.managed=true",
         "eventPortal.incomingRequestQueueName = ep_core_ema_requests_123456_123123",
-        "event-portal.gateway.messaging.rto-session=false"
+        "event-portal.gateway.messaging.rto-session=false",
+        "event-portal.runtimeAgentId = testManagedAgentId",
 })
 class ManagedAgentMessageHandlerBeansTests {
 
     @Autowired
     private ApplicationContext applicationContext;
+
+    @Autowired
+    private VMRProperties vmrProperties;
 
     @Test
     void testPersistentMessageHandlerBeansAreLoaded() {
@@ -68,6 +76,13 @@ class ManagedAgentMessageHandlerBeansTests {
                         .map(StringUtils::lowerCase)
                         .collect(Collectors.toSet()))
                 .doesNotContain(StringUtils.lowerCase("commandLogStreamingProcessor"));
+
+    }
+
+    @Test
+    void testClientNameIsGeneratedBasedOnHostNameAndAgentId() throws UnknownHostException {
+        String hostnameHash = DigestUtils.sha256Hex(InetAddress.getLocalHost().getHostName());
+        assertThat(vmrProperties.getClientName()).isEqualTo("testManagedAgentId-" + hostnameHash);
 
     }
 }

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/applicationContextTests/SelfManagedAgentMessageHandlerBeansTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/applicationContextTests/SelfManagedAgentMessageHandlerBeansTests.java
@@ -77,7 +77,7 @@ class SelfManagedAgentMessageHandlerBeansTests {
     @Test
     void testClientNameIsGeneratedBasedOnHostNameAndAgentId() throws UnknownHostException {
         String hostnameHash = DigestUtils.sha256Hex(InetAddress.getLocalHost().getHostName());
-        assertThat(vmrProperties.getClientName()).isEqualTo("testSelfManagedAgentId-" + hostnameHash);
+        assertThat(vmrProperties.getClientName()).isEqualTo("ema-testSelfManagedAgentId-" + hostnameHash);
 
     }
 }

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/applicationContextTests/SelfManagedAgentMessageHandlerBeansTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/applicationContextTests/SelfManagedAgentMessageHandlerBeansTests.java
@@ -1,6 +1,8 @@
 package com.solace.maas.ep.event.management.agent.applicationContextTests;
 
+import com.solace.maas.ep.event.management.agent.plugin.config.VMRProperties;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,6 +10,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -18,12 +22,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ActiveProfiles("TEST")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
         "eventPortal.gateway.messaging.standalone=false",
-        "eventPortal.managed=false"
+        "eventPortal.managed=false",
+        "event-portal.runtimeAgentId = testSelfManagedAgentId",
 })
 class SelfManagedAgentMessageHandlerBeansTests {
 
     @Autowired
     private ApplicationContext applicationContext;
+
+    @Autowired
+    private VMRProperties vmrProperties;
 
     @Test
     void testPersistentMessageHandlerBeansAreNotLoaded() {
@@ -63,6 +71,13 @@ class SelfManagedAgentMessageHandlerBeansTests {
                 Arrays.stream(allBeanNames)
                         .map(StringUtils::lowerCase)
                         .collect(Collectors.toSet())).contains(StringUtils.lowerCase("commandLogStreamingProcessor"));
+
+    }
+
+    @Test
+    void testClientNameIsGeneratedBasedOnHostNameAndAgentId() throws UnknownHostException {
+        String hostnameHash = DigestUtils.sha256Hex(InetAddress.getLocalHost().getHostName());
+        assertThat(vmrProperties.getClientName()).isEqualTo("testSelfManagedAgentId-" + hostnameHash);
 
     }
 }

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/config/VMRProperties.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/config/VMRProperties.java
@@ -144,7 +144,7 @@ public class VMRProperties {
         try {
             String hostName = InetAddress.getLocalHost().getHostName();
             String hostNameHash = DigestUtils.sha256Hex(hostName);
-            return String.format("%s-%s", eventPortalPluginProperties.getRuntimeAgentId(), hostNameHash);
+            return String.format("%s-%s-%s", "ema", eventPortalPluginProperties.getRuntimeAgentId(), hostNameHash);
         } catch (UnknownHostException e) {
             log.warn("Could not determine host name when determining client name.", e);
             return StringUtils.EMPTY;

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/config/VMRProperties.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/config/VMRProperties.java
@@ -9,10 +9,14 @@ import com.solace.messaging.config.SolaceProperties;
 import com.solacesystems.solclientj.core.handle.SessionHandle;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -86,7 +90,10 @@ public class VMRProperties {
             }
             username = messagingServiceUsersProperties.getUsername();
             password = messagingServiceUsersProperties.getPassword();
-            clientName = messagingServiceUsersProperties.getClientName();
+            String computedClientName = determineClientName();
+            clientName = StringUtils.isEmpty(computedClientName)
+                    ? messagingServiceUsersProperties.getClientName()
+                    : computedClientName;
         } catch (NoSuchElementException e) {
             log.error("An error occurred while connecting to EP gateway: {}", e.getMessage());
         }
@@ -131,5 +138,16 @@ public class VMRProperties {
         sessionProperties.add(trustStoreDir);
 
         return sessionProperties;
+    }
+
+    private String determineClientName() {
+        try {
+            String hostName = InetAddress.getLocalHost().getHostName();
+            String hostNameHash = DigestUtils.sha256Hex(hostName);
+            return String.format("%s-%s", eventPortalPluginProperties.getRuntimeAgentId(), hostNameHash);
+        } catch (UnknownHostException e) {
+            log.warn("Could not determine host name when determining client name.", e);
+            return StringUtils.EMPTY;
+        }
     }
 }


### PR DESCRIPTION
### What is the purpose of this change?

To support rolling update, we want each EMA instance to have its own unique `clientName`. Currently, the clientName is determined by only looking at the runtimeAgentId however, this becomes a problem for CEMA update scenario as, for a brief period, we can have more than 1 instance of CEMA with the same id online at the same time. Not to mention, this is also a problem if we decide to use multiple instances (replicaCount >1).

This PR introduces changes so that CEMA generates its own unique client name based on the hash of the host name and appending the runtime agent id. Format is : 

`{runtimeAgentId}-{hash(hostname)}`.

We are taking the hash to ensure that we are not going over the limit 
![image](https://github.com/user-attachments/assets/6d5f1456-167d-4193-8137-d884fe8251e2)


### How was this change implemented?

Java

### How was this change tested?

IT

### Is there anything the reviewers should focus on/be aware of?

    ...
