### PR TITLE
DATAGO-83401: Upgrade spring boot to 3.3.4

### DIFF
--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -16,7 +16,7 @@
         <spring-boot.version>3.3.4</spring-boot.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <spring-security-rsa.version>1.1.3</spring-security-rsa.version>
-        <spring-kafka.version>3.0.10</spring-kafka.version>
+        <spring-kafka.version>3.2.4</spring-kafka.version>
         <kafka-clients.version>3.5.0</kafka-clients.version>
         <jackson.version>2.16.1</jackson.version>
         <dockerfile-maven.version>1.4.13</dockerfile-maven.version>
@@ -72,12 +72,12 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.4.12</version>
+            <version>1.5.8</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.4.14</version>
+            <version>1.5.8</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -13,7 +13,7 @@
     <name>Solace Event Management Agent - Application</name>
     <description>Solace Event Management Agent - Application</description>
     <properties>
-        <spring-boot.version>3.2.7</spring-boot.version>
+        <spring-boot.version>3.3.4</spring-boot.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <spring-security-rsa.version>1.1.3</spring-security-rsa.version>
         <spring-kafka.version>3.0.10</spring-kafka.version>

--- a/service/confluent-schema-registry-plugin/pom.xml
+++ b/service/confluent-schema-registry-plugin/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <spring-boot.version>3.2.7</spring-boot.version>
+        <spring-boot.version>3.3.4</spring-boot.version>
         <httpclient.version>4.5.14</httpclient.version>
         <mockwebserver.version>4.9.0</mockwebserver.version>
         <jupiter.version>5.10.2</jupiter.version>

--- a/service/kafka-plugin/pom.xml
+++ b/service/kafka-plugin/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <spring-kafka.version>3.1.4</spring-kafka.version>
         <kafka-clients.version>3.5.0</kafka-clients.version>
-        <spring-boot.version>3.2.7</spring-boot.version>
+        <spring-boot.version>3.3.4</spring-boot.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <jupiter.version>5.10.2</jupiter.version>
         <camel.version>4.5.0</camel.version>

--- a/service/kafka-plugin/pom.xml
+++ b/service/kafka-plugin/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <spring-kafka.version>3.1.4</spring-kafka.version>
+        <spring-kafka.version>3.2.4</spring-kafka.version>
         <kafka-clients.version>3.5.0</kafka-clients.version>
         <spring-boot.version>3.3.4</spring-boot.version>
         <commons-collections4.version>4.4</commons-collections4.version>

--- a/service/local-storage-plugin/pom.xml
+++ b/service/local-storage-plugin/pom.xml
@@ -15,7 +15,7 @@
         <snakeyaml.version>2.0</snakeyaml.version>
         <jacksondatabind.version>2.13.4.2</jacksondatabind.version>
         <junit.version>4.13.2</junit.version>
-        <spring-boot.version>3.2.7</spring-boot.version>
+        <spring-boot.version>3.3.4</spring-boot.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <jupiter.version>5.10.2</jupiter.version>
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>

--- a/service/plugin/pom.xml
+++ b/service/plugin/pom.xml
@@ -18,7 +18,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <snakeyaml.version>2.0</snakeyaml.version>
         <jackson.version>2.16.1</jackson.version>
-        <spring-boot.version>3.2.7</spring-boot.version>
+        <spring-boot.version>3.3.4</spring-boot.version>
     </properties>
 
     <dependencyManagement>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.7</version>
+        <version>3.3.4</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.solace.maas</groupId>

--- a/service/rabbitmq-plugin/pom.xml
+++ b/service/rabbitmq-plugin/pom.xml
@@ -11,7 +11,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
-        <spring-boot.version>3.2.7</spring-boot.version>
+        <spring-boot.version>3.3.4</spring-boot.version>
     </properties>
     <dependencies>
         <dependency>

--- a/service/solace-plugin/pom.xml
+++ b/service/solace-plugin/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <solace-messaging-client.version>1.4.0</solace-messaging-client.version>
         <solclientj.version>10.0.0</solclientj.version>
-        <spring-boot.version>3.2.7</spring-boot.version>
+        <spring-boot.version>3.3.4</spring-boot.version>
         <jupiter.version>5.10.2</jupiter.version>
         <camel.version>4.5.0</camel.version>
         <commons-collections4.version>4.4</commons-collections4.version>

--- a/service/terraform-plugin/pom.xml
+++ b/service/terraform-plugin/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <spring-boot.version>3.2.7</spring-boot.version>
+        <spring-boot.version>3.3.4</spring-boot.version>
         <jupiter.version>5.10.2</jupiter.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <snakeyaml.version>2.0</snakeyaml.version>


### PR DESCRIPTION
### What is the purpose of this change?

Upgrade spring boot version to 3.3.4 for EMA

### How was this change implemented?

Updated the root pom and the pom of each plugin/module

### How was this change tested?
- Unit tests are passing ✅ 
- Manual testing has been performed as outlined below ✅ 
-- Solace-broker-S_EMA-Mac 
![Solace-self-Mac](https://github.com/user-attachments/assets/ce978538-f9fd-4875-8a63-31fa23b7d71f)

-- Solace-broker-S_EMA-Windows
<img width="1612" alt="Solace-self-Win" src="https://github.com/user-attachments/assets/8646583a-6c28-4455-8b83-538f349dc159">

-- Kafka-self-Mac 
![Kafka-self-Mac](https://github.com/user-attachments/assets/fbf2912f-44d3-4e27-98b4-cb9fb53253c5)

-- Solace-broker-C_EMA
![solace-cloud-DD](https://github.com/user-attachments/assets/0d8083bc-4cc2-4d52-9afb-533c114ef773)
![solace-cloud-audit](https://github.com/user-attachments/assets/f8f48268-02ed-4cf0-afcc-4eccf2f9a890)



### Is there anything the reviewers should focus on/be aware of?
none yet