### PR TITLE
Pull a certain image tag when going to anywhere but dev

### DIFF
--- a/.github/workflows/deploy-managed-ema-image.yaml
+++ b/.github/workflows/deploy-managed-ema-image.yaml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       releaseVersion:
-        description: "The tag of the image to push. We'll pull the main image and re-tag it with this."
+        description: "The tag of the image to push. For dev, we'll pull the 'main' image and for all other environments, we'll pull image A.B.C, then we push the image with tag A.B.C to where it needs to go."
         required: true
         default: "A.B.C"
       deployEnvironment:
@@ -29,9 +29,16 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1.6.0
-      - name: ECR (Dev) - Pull Image
+      - name: ECR (Dev) - Pull Main Image
+        if: ${{ github.event.inputs.deployEnvironment == 'development' }}
         run: |
           ECR_DEV_IMAGE="${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:main"
+          docker pull $ECR_DEV_IMAGE
+          echo "ECR_DEV_IMAGE=$ECR_DEV_IMAGE" >> $GITHUB_ENV
+      - name: ECR (Dev) - Pull Prod Ready Image Tag
+        if: ${{ github.event.inputs.deployEnvironment != 'development' }}
+        run: |
+          ECR_DEV_IMAGE="${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:${{ github.event.inputs.releaseVersion }}"
           docker pull $ECR_DEV_IMAGE
           echo "ECR_DEV_IMAGE=$ECR_DEV_IMAGE" >> $GITHUB_ENV
       - name: GCR (Dev) - Login


### PR DESCRIPTION
### What is the purpose of this change?

There's a scenario where we want to deploy version X.Y.Z.
We need to run different deploy scripts to go to dev, staging, then prod. This may take several days for testing in between.
In each case, we pull the image tagged with main which is whatever is in the main branch.
For dev, this is good. For staging and production, we only want to deploy the version we said we would, so the version we deploy is also the image we pull.

If we deployed to dev tagged as 1.14, then committed a new change and made the latest release 1.15, the next time we deploy to staging and prod will pull the image tagged with main which is 1.15 and then tagged with 1.14. This is confusing. 

### How was this change implemented?

Grab the correct image version instead of main when no deploying to development.

### How was this change tested?

We're testing on the fly.

### Is there anything the reviewers should focus on/be aware of?

None
