### PR TITLE
DATAGO-87115: upversion base image to address expat vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ where "/path/containing/terraform-provider-solacebroker" is replaced with the di
 
 ## Prerequisites
 
-* Java 17 (JDK 17.0.10_7+)
+* Java 17 (JDK 17.0.13_11+)
 * Maven
 
 ## Cloning the GitHub Event Management Agent Repository

--- a/service/application/docker/buildEventManagementAgentDocker.sh
+++ b/service/application/docker/buildEventManagementAgentDocker.sh
@@ -80,7 +80,7 @@ setup_colors
 
 msg "${GREEN}Building image:${YELLOW} event-management-agent:${IMAGE_TAG}\n${NOFORMAT}"
 
-export BASE_IMAGE=eclipse-temurin:17.0.10_7-jre-alpine
+export BASE_IMAGE=eclipse-temurin:17.0.13_11-jre-alpine
 export GITHASH=$(git rev-parse HEAD)
 export GITBRANCH=$(git branch --show-current)
 export BUILD_TIMESTAMP=$(date -u)


### PR DESCRIPTION
### What is the purpose of this change?
To get rid of expat vul.

### How was this change implemented?
Updated the base image

### How was this change tested?
We need to test configPush and scan for 3 scenarios:

1. C-EMA, done! things look good: 
![Screenshot 2024-10-28 at 11 46 10 AM](https://github.com/user-attachments/assets/6aad17c7-5502-4e11-ad0a-fa3327e6ce8e)

2. S-EMA / mac , done! looks good:
![Screenshot 2024-10-28 at 4 20 20 PM](https://github.com/user-attachments/assets/d027ddf5-819a-4c4c-8ffc-4ec5a1b89566)


3. S-EMA / windows , done! looks good:
![Screenshot 2024-10-28 163854](https://github.com/user-attachments/assets/32ad0459-c461-4a24-8374-9b66efb82709)

### Is there anything the reviewers should focus on/be aware of?

    ...
