### PR TITLE
DATAGO-92511: upgrade tofu

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.apk filter=lfs diff=lfs merge=lfs -text

--- a/service/application/docker/Dockerfile
+++ b/service/application/docker/Dockerfile
@@ -20,7 +20,7 @@ WORKDIR /opt/ema
 
 ARG PLATFORM=linux_amd64
 
-COPY tofu_1.8.7_amd64.apk /opt/ema/terraform
+COPY tofu_1.8.8_amd64.apk /opt/ema/terraform
 RUN apk --update add --allow-untrusted /opt/ema/terraform/tofu_1.8.7_amd64.apk
 
 COPY .terraformrc $HOME/.terraformrc

--- a/service/application/docker/Dockerfile
+++ b/service/application/docker/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /opt/ema
 ARG PLATFORM=linux_amd64
 
 COPY tofu_1.8.8_amd64.apk /opt/ema/terraform
-RUN apk --update add --allow-untrusted /opt/ema/terraform/tofu_1.8.7_amd64.apk
+RUN apk --update add --allow-untrusted /opt/ema/terraform/tofu_1.8.8_amd64.apk
 
 COPY .terraformrc $HOME/.terraformrc
 RUN printf '#!/bin/ash\ntofu $*' > /opt/ema/terraform/terraform

--- a/service/application/docker/tofu_1.8.8_amd64.apk
+++ b/service/application/docker/tofu_1.8.8_amd64.apk
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4657f1f5b1cbb8824940a16b509eec4c35fba29a05b6a81d32cb5095e55a304b
+size 26720932


### PR DESCRIPTION
### What is the purpose of this change?
We need the new tofu 1.8.8

### How was this change implemented?
updated tofu from 1.8.7 to 1.8.8

### How was this change tested?
Both S-EMA and C-EMA configPush jobs work as expected!
<img width="1289" alt="Screenshot 2025-01-16 at 10 49 27 PM" src="https://github.com/user-attachments/assets/0630abb3-00fe-4a37-8507-81839ea83726" />


### Is there anything the reviewers should focus on/be aware of?

    ...
