### PR TITLE
[DATAGO-92511] add the tofu apk file again

### DIFF
--- a/service/application/docker/tofu_1.8.8_amd64.apk
+++ b/service/application/docker/tofu_1.8.8_amd64.apk
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4657f1f5b1cbb8824940a16b509eec4c35fba29a05b6a81d32cb5095e55a304b
+size 26720932


### PR DESCRIPTION
### What is the purpose of this change?
To add back the tofu_1.8.8_amd64.apk file.

### How was this change implemented?
Added back the file

### How was this change tested?
In a separate clone of the repo, I did a git pull from `main` and it didn't have the file. I then did a git checkout to this branch and the file is there with the right size:
![Screenshot 2025-01-17 at 1 40 37 PM](https://github.com/user-attachments/assets/3067d452-aa30-45eb-a4df-705ee563da6e)


### Is there anything the reviewers should focus on/be aware of?

    ...
