### PR TITLE
DATAGO-92826: Build failure installing opentofu

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,6 +32,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+          lfs: true
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
### What is the purpose of this change?

Enable LFS in checkout. This fixes the following build error
```
 > [ 5/11] RUN apk --update add --allow-untrusted /opt/ema/terraform/tofu_1.8.8_amd64.apk:
0.201 fetch https://dl-cdn.alpinelinux.org/alpine/v3.20/main/x86_64/APKINDEX.tar.gz
0.805 fetch https://dl-cdn.alpinelinux.org/alpine/v3.20/community/x86_64/APKINDEX.tar.gz
1.668 ERROR: /opt/ema/terraform/tofu_1.8.8_amd64.apk: IO ERROR
```

Without LFS, we only checkout a pointer, similar to 
```
version https://git-lfs.github.com/spec/v1
oid sha256:4b6124b8b01d601fa20b47f5be14e1be2ea7759838c1aac8f36df4859164e4de
size 21647
```
which can't be installed.

### How was this change implemented?

    ...

### How was this change tested?

    ...

### Is there anything the reviewers should focus on/be aware of?

    ...
