### PR TITLE
DATAGO-92511: tofu 1.9.0

### DIFF
--- a/service/application/docker/Dockerfile
+++ b/service/application/docker/Dockerfile
@@ -20,8 +20,8 @@ WORKDIR /opt/ema
 
 ARG PLATFORM=linux_amd64
 
-COPY tofu_1.8.8_amd64.apk /opt/ema/terraform
-RUN apk --update add --allow-untrusted /opt/ema/terraform/tofu_1.8.8_amd64.apk
+COPY tofu_1.9.0_amd64.apk /opt/ema/terraform
+RUN apk --update add --allow-untrusted /opt/ema/terraform/tofu_1.9.0_amd64.apk
 
 COPY .terraformrc $HOME/.terraformrc
 RUN printf '#!/bin/ash\ntofu $*' > /opt/ema/terraform/terraform

--- a/service/application/docker/tofu_1.8.8_amd64.apk
+++ b/service/application/docker/tofu_1.8.8_amd64.apk
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4657f1f5b1cbb8824940a16b509eec4c35fba29a05b6a81d32cb5095e55a304b
-size 26720932

--- a/service/application/docker/tofu_1.9.0_amd64.apk
+++ b/service/application/docker/tofu_1.9.0_amd64.apk
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e9eee6a2a01663132dd375151f4845a0caf34c5065783c0b634c9f7d543e1fa6
+size 26750410


### PR DESCRIPTION
### What is the purpose of this change?
Tofu 1.8.8 does not pass the prisma vulnerability. Let's try tofu 1.9.0

### How was this change implemented?
Replaced 1.8.8 tofu package with 1.9.0

### How was this change tested?
Tested manually both creating a new queue and removing it:
![Screenshot 2025-01-17 at 4 21 44 PM](https://github.com/user-attachments/assets/b3275397-eada-47ba-b642-8cbb674c5ea5)
![Screenshot 2025-01-17 at 4 22 22 PM](https://github.com/user-attachments/assets/b8c4f36b-5191-4eb8-8976-58cccb5f15a9)

### Is there anything the reviewers should focus on/be aware of?

    ...
