### PR TITLE
DATAGO-89835: Public DC C-EMA config push

### DIFF
--- a/.github/workflows/deploy-managed-ema-image.yaml
+++ b/.github/workflows/deploy-managed-ema-image.yaml
@@ -59,8 +59,6 @@ jobs:
           export SKIP_FLAGS_NON_UNIT_TESTS="-Dcheckstyle.skip -Dpmd.skip -Dcpd.skip -Dfindbugs.skip -Dspotbugs.skip"
           echo "SKIP_FLAGS_NON_UNIT_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS" >> $GITHUB_ENV
           echo "SKIP_FLAGS_ALL_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS -Dmaven.test.skip=true" >> $GITHUB_ENV
-      - name: Static Code Analysis
-        run: mvn -B compile -Pmaas-static-code-analysis --file service/pom.xml
       - name: Generate Artifacts
         run: |
           mvn install $SKIP_FLAGS_ALL_TESTS --file service/pom.xml
@@ -69,7 +67,7 @@ jobs:
         working-directory: service/application/docker
         run: |
           ./buildEventManagementAgentDocker.sh -t ${{ github.event.inputs.releaseVersion }}
-          ECR_DEV_IMAGE="solace/${{ github.event.repository.name }}:${{ github.event.inputs.releaseVersion }}"
+          ECR_DEV_IMAGE="${{ github.event.repository.name }}:${{ github.event.inputs.releaseVersion }}"
           echo "ECR_DEV_IMAGE=$ECR_DEV_IMAGE" >> $GITHUB_ENV
       - name: ECR (Dev) - Pull Prod Ready Image Tag
         if: ${{ github.event.inputs.deployEnvironment != 'development' }}

--- a/.github/workflows/deploy-managed-ema-image.yaml
+++ b/.github/workflows/deploy-managed-ema-image.yaml
@@ -14,6 +14,10 @@ on:
           - development
           - staging
           - production
+      buildNewDevImage:
+        description: "true/false. If deploying to development, set to 'true' to build a new image, otherwise, we'll pull the 'main' image."
+        required: false
+        default: "true"
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -30,10 +34,17 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1.6.0
       - name: ECR (Dev) - Pull Main Image
-        if: ${{ github.event.inputs.deployEnvironment == 'development' }}
+        if: ${{ github.event.inputs.deployEnvironment == 'development' && github.event.inputs.buildNewDevImage == 'false' }}
         run: |
           ECR_DEV_IMAGE="${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:main"
           docker pull $ECR_DEV_IMAGE
+          echo "ECR_DEV_IMAGE=$ECR_DEV_IMAGE" >> $GITHUB_ENV
+      - name: ECR (Dev) - Build Image
+        if: ${{ github.event.inputs.deployEnvironment == 'development' && github.event.inputs.buildNewDevImage == 'true' }}
+        working-directory: service/application/docker
+        run: |
+          ./buildEventManagementAgentDocker.sh -t ${{ github.event.inputs.releaseVersion }}
+          ECR_DEV_IMAGE="solace/${{ github.event.repository.name }}:${{ github.event.inputs.releaseVersion }}"
           echo "ECR_DEV_IMAGE=$ECR_DEV_IMAGE" >> $GITHUB_ENV
       - name: ECR (Dev) - Pull Prod Ready Image Tag
         if: ${{ github.event.inputs.deployEnvironment != 'development' }}

--- a/.github/workflows/deploy-managed-ema-image.yaml
+++ b/.github/workflows/deploy-managed-ema-image.yaml
@@ -25,14 +25,14 @@ jobs:
 
     steps:
       - name: Configure AWS credentials
-        if: ${{ github.event.inputs.buildNewDevImage == 'false' }}
+        if: ${{ github.event.inputs.deployEnvironment != 'development' || github.event.inputs.buildNewDevImage == 'false' }}
         uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
       - name: Login to Amazon ECR
-        if: ${{ github.event.inputs.buildNewDevImage == 'false' }}
+        if: ${{ github.event.inputs.deployEnvironment != 'development' || github.event.inputs.buildNewDevImage == 'false' }}
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1.6.0
       - name: ECR (Dev) - Pull Main Image

--- a/.github/workflows/deploy-managed-ema-image.yaml
+++ b/.github/workflows/deploy-managed-ema-image.yaml
@@ -25,12 +25,14 @@ jobs:
 
     steps:
       - name: Configure AWS credentials
+        if: ${{ github.event.inputs.buildNewDevImage == 'false' }}
         uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
       - name: Login to Amazon ECR
+        if: ${{ github.event.inputs.buildNewDevImage == 'false' }}
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1.6.0
       - name: ECR (Dev) - Pull Main Image
@@ -39,6 +41,29 @@ jobs:
           ECR_DEV_IMAGE="${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:main"
           docker pull $ECR_DEV_IMAGE
           echo "ECR_DEV_IMAGE=$ECR_DEV_IMAGE" >> $GITHUB_ENV
+      - name: "Checkout branch"
+        uses: actions/checkout@v3
+        if: ${{ github.event.inputs.deployEnvironment == 'development' && github.event.inputs.buildNewDevImage == 'true' }}
+        with:
+          fetch-depth: 0
+          lfs: true
+      - name: Set up JDK 17
+        if: ${{ github.event.inputs.deployEnvironment == 'development' && github.event.inputs.buildNewDevImage == 'true' }}
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Set Build Params
+        run: |
+          export SKIP_FLAGS_NON_UNIT_TESTS="-Dcheckstyle.skip -Dpmd.skip -Dcpd.skip -Dfindbugs.skip -Dspotbugs.skip"
+          echo "SKIP_FLAGS_NON_UNIT_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS" >> $GITHUB_ENV
+          echo "SKIP_FLAGS_ALL_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS -Dmaven.test.skip=true" >> $GITHUB_ENV
+      - name: Static Code Analysis
+        run: mvn -B compile -Pmaas-static-code-analysis --file service/pom.xml
+      - name: Generate Artifacts
+        run: |
+          mvn install $SKIP_FLAGS_ALL_TESTS --file service/pom.xml
       - name: ECR (Dev) - Build Image
         if: ${{ github.event.inputs.deployEnvironment == 'development' && github.event.inputs.buildNewDevImage == 'true' }}
         working-directory: service/application/docker

--- a/.github/workflows/deploy-managed-ema-image.yaml
+++ b/.github/workflows/deploy-managed-ema-image.yaml
@@ -14,10 +14,6 @@ on:
           - development
           - staging
           - production
-      buildNewDevImage:
-        description: "true/false. If deploying to development, set to 'true' to build a new image, otherwise, we'll pull the 'main' image."
-        required: false
-        default: "true"
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -25,49 +21,19 @@ jobs:
 
     steps:
       - name: Configure AWS credentials
-        if: ${{ github.event.inputs.deployEnvironment != 'development' || github.event.inputs.buildNewDevImage == 'false' }}
         uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
       - name: Login to Amazon ECR
-        if: ${{ github.event.inputs.deployEnvironment != 'development' || github.event.inputs.buildNewDevImage == 'false' }}
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1.6.0
       - name: ECR (Dev) - Pull Main Image
-        if: ${{ github.event.inputs.deployEnvironment == 'development' && github.event.inputs.buildNewDevImage == 'false' }}
+        if: ${{ github.event.inputs.deployEnvironment == 'development' }}
         run: |
           ECR_DEV_IMAGE="${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:main"
           docker pull $ECR_DEV_IMAGE
-          echo "ECR_DEV_IMAGE=$ECR_DEV_IMAGE" >> $GITHUB_ENV
-      - name: "Checkout branch"
-        uses: actions/checkout@v3
-        if: ${{ github.event.inputs.deployEnvironment == 'development' && github.event.inputs.buildNewDevImage == 'true' }}
-        with:
-          fetch-depth: 0
-          lfs: true
-      - name: Set up JDK 17
-        if: ${{ github.event.inputs.deployEnvironment == 'development' && github.event.inputs.buildNewDevImage == 'true' }}
-        uses: actions/setup-java@v3
-        with:
-          java-version: 17
-          distribution: 'temurin'
-          cache: 'maven'
-      - name: Set Build Params
-        run: |
-          export SKIP_FLAGS_NON_UNIT_TESTS="-Dcheckstyle.skip -Dpmd.skip -Dcpd.skip -Dfindbugs.skip -Dspotbugs.skip"
-          echo "SKIP_FLAGS_NON_UNIT_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS" >> $GITHUB_ENV
-          echo "SKIP_FLAGS_ALL_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS -Dmaven.test.skip=true" >> $GITHUB_ENV
-      - name: Generate Artifacts
-        run: |
-          mvn install $SKIP_FLAGS_ALL_TESTS --file service/pom.xml
-      - name: ECR (Dev) - Build Image
-        if: ${{ github.event.inputs.deployEnvironment == 'development' && github.event.inputs.buildNewDevImage == 'true' }}
-        working-directory: service/application/docker
-        run: |
-          ./buildEventManagementAgentDocker.sh -t ${{ github.event.inputs.releaseVersion }}
-          ECR_DEV_IMAGE="${{ github.event.repository.name }}:${{ github.event.inputs.releaseVersion }}"
           echo "ECR_DEV_IMAGE=$ECR_DEV_IMAGE" >> $GITHUB_ENV
       - name: ECR (Dev) - Pull Prod Ready Image Tag
         if: ${{ github.event.inputs.deployEnvironment != 'development' }}

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/CommandManager.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/CommandManager.java
@@ -110,7 +110,7 @@ public class CommandManager {
     @SuppressWarnings("PMD")
     private void configPush(CommandRequest request) {
         List<Path> executionLogFilesToClean = new ArrayList<>();
-        boolean attacheErrorToTerraformCommand = false;
+        boolean attachErrorToTerraformCommand = false;
         try {
             // if the serviceId is not found, messagingServiceDelegateService will most likely throw an exception (which is not guaranteed
             // based on the interface definition) and we need to catch it here.
@@ -129,11 +129,11 @@ public class CommandManager {
                 boolean exitEarlyOnFailedCommand = bundle.getExitOnFailure();
                 // For now everything is run serially
                 for (Command command : bundle.getCommands()) {
-                    attacheErrorToTerraformCommand = false;
+                    attachErrorToTerraformCommand = false;
                     if (command.getCommandType() == semp) {
                         executeSempCommand(command, solaceClient);
                     } else if (command.getCommandType() == terraform) {
-                        attacheErrorToTerraformCommand = true;
+                        attachErrorToTerraformCommand = true;
                         Path executionLog = executeTerraformCommand(request, command, envVars);
                         if (executionLog != null) {
                             if (commandLogStreamingProcessorOpt.isPresent()) {
@@ -152,7 +152,7 @@ public class CommandManager {
             }
         } catch (Exception e) {
             log.error("ConfigPush command not executed successfully", e);
-            attachErrorLogToCommand(attacheErrorToTerraformCommand, e, request);
+            attachErrorLogToCommand(attachErrorToTerraformCommand, e, request);
         } finally {
             try {
                 finalizeAndSendResponse(request);
@@ -211,6 +211,7 @@ public class CommandManager {
                 "runtimeAgentId", eventPortalProperties.getRuntimeAgentId(),
                 COMMAND_CORRELATION_ID, requestBO.getCommandCorrelationId()
         );
+        log.info("TEST LOG: orgId of requestBO: {}", requestBO.getOrgId());
         CommandMessage response = new CommandMessage(requestBO.getServiceId(),
                 requestBO.getCommandCorrelationId(),
                 requestBO.getContext(),

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/CommandManager.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/CommandManager.java
@@ -136,6 +136,7 @@ public class CommandManager {
                         attachErrorToTerraformCommand = true;
                         Path executionLog = executeTerraformCommand(request, command, envVars);
                         if (executionLog != null) {
+                            // Only stream logs for self-managed EMAs not in standalone mode
                             if (commandLogStreamingProcessorOpt.isPresent()) {
                                 streamCommandExecutionLogToEpCore(request, command, executionLog);
                             }
@@ -211,7 +212,6 @@ public class CommandManager {
                 "runtimeAgentId", eventPortalProperties.getRuntimeAgentId(),
                 COMMAND_CORRELATION_ID, requestBO.getCommandCorrelationId()
         );
-        log.info("TEST LOG: orgId of requestBO: {}", requestBO.getOrgId());
         CommandMessage response = new CommandMessage(requestBO.getServiceId(),
                 requestBO.getCommandCorrelationId(),
                 requestBO.getContext(),

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/CommandManager.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/CommandManager.java
@@ -204,19 +204,19 @@ public class CommandManager {
         }
     }
 
-    private void finalizeAndSendResponse(CommandRequest request) {
-        request.determineStatus();
+    private void finalizeAndSendResponse(CommandRequest requestBO) {
+        requestBO.determineStatus();
         Map<String, String> topicVars = Map.of(
-                "orgId", eventPortalProperties.getOrganizationId(),
+                "orgId", requestBO.getOrgId(),
                 "runtimeAgentId", eventPortalProperties.getRuntimeAgentId(),
-                COMMAND_CORRELATION_ID, request.getCommandCorrelationId()
+                COMMAND_CORRELATION_ID, requestBO.getCommandCorrelationId()
         );
-        CommandMessage response = new CommandMessage(request.getServiceId(),
-                request.getCommandCorrelationId(),
-                request.getContext(),
-                request.getStatus(),
-                request.getCommandBundles());
-        response.setOrgId(eventPortalProperties.getOrganizationId());
+        CommandMessage response = new CommandMessage(requestBO.getServiceId(),
+                requestBO.getCommandCorrelationId(),
+                requestBO.getContext(),
+                requestBO.getStatus(),
+                requestBO.getCommandBundles());
+        response.setOrgId(requestBO.getOrgId());
         response.setTraceId(MDC.get(TRACE_ID));
         response.setActorId(MDC.get(ACTOR_ID));
         commandPublisher.sendCommandResponse(response, topicVars);
@@ -225,9 +225,9 @@ public class CommandManager {
         Timer jobCycleTime = Timer
                 .builder(MAAS_EMA_CONFIG_PUSH_EVENT_CYCLE_TIME)
                 .tag(ORG_ID_TAG, response.getOrgId())
-                .tag(STATUS_TAG, request.getStatus().name())
+                .tag(STATUS_TAG, requestBO.getStatus().name())
                 .register(meterRegistry);
-        jobCycleTime.record(request.getLifetime(ChronoUnit.MILLIS), TimeUnit.MILLISECONDS);
+        jobCycleTime.record(requestBO.getLifetime(ChronoUnit.MILLIS), TimeUnit.MILLISECONDS);
     }
 
     private Path executeTerraformCommand(CommandRequest request, Command command, Map<String, String> envVars) {

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/CommandManager.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/CommandManager.java
@@ -231,7 +231,6 @@ public class CommandManager {
     }
 
     private Path executeTerraformCommand(CommandRequest request, Command command, Map<String, String> envVars) {
-        Path executionLog = null;
         try {
             Validate.isTrue(command.getCommandType().equals(terraform), "Command type must be terraform");
             return terraformManager.execute(request, command, envVars);
@@ -240,7 +239,7 @@ public class CommandManager {
             setCommandError(command, e);
 
         }
-        return executionLog;
+        return null;
     }
 
     private void executeSempCommand(Command command, SolaceHttpSemp solaceClient) {

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/config/SolaceConfiguration.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/config/SolaceConfiguration.java
@@ -14,6 +14,7 @@ import com.solace.messaging.config.profile.ConfigurationProfile;
 import com.solace.messaging.publisher.DirectMessagePublisher;
 import com.solace.messaging.publisher.OutboundMessageBuilder;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -46,6 +47,20 @@ public class SolaceConfiguration {
         vmrConfiguration = vmrConfig;
         sessionConfiguration = sessionConfig;
         this.eventPortalProperties = eventPortalProperties;
+    }
+
+    public String getTopicPrefix(String orgId) {
+        if (StringUtils.isEmpty(orgId)) {
+            log.warn("Attempted to get topic prefix with empty orgId. Defaulting to application properties org ID {}",
+                    eventPortalProperties.getOrganizationId());
+            orgId = eventPortalProperties.getOrganizationId();
+        }
+        if (topicPrefix == null) {
+            topicPrefix = String.format(TOPIC_PREFIX_FORMAT,
+                    orgId,
+                    eventPortalProperties.getRuntimeAgentId());
+        }
+        return topicPrefix;
     }
 
     public String getTopicPrefix() {

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/config/SolaceConfiguration.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/config/SolaceConfiguration.java
@@ -51,26 +51,17 @@ public class SolaceConfiguration {
 
     public String getTopicPrefix(String orgId) {
         if (StringUtils.isEmpty(orgId)) {
-            log.warn("Attempted to get topic prefix with empty orgId. Defaulting to application properties org ID {}",
+            log.debug("Attempted to get topic prefix with empty orgId. Defaulting to application properties org ID {}",
                     eventPortalProperties.getOrganizationId());
             orgId = eventPortalProperties.getOrganizationId();
         }
-        if (topicPrefix == null) {
-            topicPrefix = String.format(TOPIC_PREFIX_FORMAT,
-                    orgId,
-                    eventPortalProperties.getRuntimeAgentId());
-        }
-        return topicPrefix;
+        return String.format(TOPIC_PREFIX_FORMAT,
+                orgId,
+                eventPortalProperties.getRuntimeAgentId());
     }
 
     public String getTopicPrefix() {
-
-        if (topicPrefix == null) {
-            topicPrefix = String.format(TOPIC_PREFIX_FORMAT,
-                    eventPortalProperties.getOrganizationId(),
-                    eventPortalProperties.getRuntimeAgentId());
-        }
-        return topicPrefix;
+        return getTopicPrefix(null);
     }
 
     @Bean

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/CommandLogStreamingProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/CommandLogStreamingProcessor.java
@@ -48,9 +48,8 @@ public class CommandLogStreamingProcessor {
         this.objectMapper = objectMapper;
     }
 
-
     public void streamLogsToEP(CommandRequest request, Command executedCommand, Path commandExecutionLog) {
-        log.debug("Streaming logs to EP for command {} with commandCorrelationId {} for orgId {}", executedCommand.getCommand(),
+        log.info("Streaming logs to EP for command {} with commandCorrelationId {} for orgId {}", executedCommand.getCommand(),
                 request.getCommandCorrelationId(), request.getOrgId());
         if (executedCommand.getIgnoreResult()) {
             log.debug("Skipping log streaming to ep for command {} with commandCorrelationId {} as ignoreResult is set to true",
@@ -82,7 +81,7 @@ public class CommandLogStreamingProcessor {
 
                 })
                 .map(strLog -> toCommandLogMessage(
-                        eventPortalProperties.getOrganizationId(),
+                        request.getOrgId(),
                         strLog,
                         request.getCommandCorrelationId(),
                         eventPortalProperties.getRuntimeAgentId()

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/CommandLogStreamingProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/CommandLogStreamingProcessor.java
@@ -50,7 +50,8 @@ public class CommandLogStreamingProcessor {
 
 
     public void streamLogsToEP(CommandRequest request, Command executedCommand, Path commandExecutionLog) {
-
+        log.debug("Streaming logs to EP for command {} with commandCorrelationId {} for orgId {}", executedCommand.getCommand(),
+                request.getCommandCorrelationId(), request.getOrgId());
         if (executedCommand.getIgnoreResult()) {
             log.debug("Skipping log streaming to ep for command {} with commandCorrelationId {} as ignoreResult is set to true",
                     executedCommand.getCommand(), request.getCommandCorrelationId());
@@ -92,7 +93,8 @@ public class CommandLogStreamingProcessor {
                         log -> sendLogToEpCore(
                                 log,
                                 request.getCommandCorrelationId(),
-                                request.getServiceId()
+                                request.getServiceId(),
+                                request.getOrgId()
                         )
                 );
     }
@@ -111,10 +113,11 @@ public class CommandLogStreamingProcessor {
 
     private void sendLogToEpCore(CommandLogMessage logDataMessage,
                                  String commandCorrelationId,
-                                 String messagingServiceId) {
+                                 String messagingServiceId,
+                                 String organizationId) {
         try {
             Map<String, String> topicDetails = new HashMap<>();
-            topicDetails.put("orgId", eventPortalProperties.getOrganizationId());
+            topicDetails.put("orgId", organizationId);
             topicDetails.put("runtimeAgentId", eventPortalProperties.getRuntimeAgentId());
             topicDetails.put("messagingServiceId", messagingServiceId);
             topicDetails.put(COMMAND_CORRELATION_ID, commandCorrelationId);

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/publisher/CommandLogsPublisher.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/publisher/CommandLogsPublisher.java
@@ -28,7 +28,6 @@ public class CommandLogsPublisher {
     public void sendCommandLogData(CommandLogMessage message, Map<String, String> topicDetails) {
         String topicString = solaceConfiguration.getTopicPrefix(topicDetails.get("orgId")) +
                 String.format("commandLogs/v1/%s", topicDetails.get(Command.COMMAND_CORRELATION_ID));
-        log.info("Sending command log data to topic: {}", topicString);
         solacePublisher.publish(message, topicString);
     }
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/publisher/CommandLogsPublisher.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/publisher/CommandLogsPublisher.java
@@ -28,7 +28,7 @@ public class CommandLogsPublisher {
     public void sendCommandLogData(CommandLogMessage message, Map<String, String> topicDetails) {
         String topicString = solaceConfiguration.getTopicPrefix(topicDetails.get("orgId")) +
                 String.format("commandLogs/v1/%s", topicDetails.get(Command.COMMAND_CORRELATION_ID));
-        log.debug("Sending command log data to topic: {}", topicString);
+        log.info("Sending command log data to topic: {}", topicString);
         solacePublisher.publish(message, topicString);
     }
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/publisher/CommandLogsPublisher.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/publisher/CommandLogsPublisher.java
@@ -26,9 +26,9 @@ public class CommandLogsPublisher {
     }
 
     public void sendCommandLogData(CommandLogMessage message, Map<String, String> topicDetails) {
-        String topicString = solaceConfiguration.getTopicPrefix() +
+        String topicString = solaceConfiguration.getTopicPrefix(topicDetails.get("orgId")) +
                 String.format("commandLogs/v1/%s", topicDetails.get(Command.COMMAND_CORRELATION_ID));
-
+        log.debug("Sending command log data to topic: {}", topicString);
         solacePublisher.publish(message, topicString);
     }
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/publisher/CommandPublisher.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/publisher/CommandPublisher.java
@@ -31,7 +31,6 @@ public class CommandPublisher {
      */
 
     public void sendCommandResponse(MOPMessage message, Map<String, String> topicDetails) {
-
         String topicString =
                 String.format("%scommandResponse/v1/%s",
                         solaceConfiguration.getTopicPrefix(topicDetails.get("orgId")),

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/publisher/CommandPublisher.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/publisher/CommandPublisher.java
@@ -4,11 +4,13 @@ import com.solace.maas.ep.event.management.agent.config.SolaceConfiguration;
 import com.solace.maas.ep.event.management.agent.constants.Command;
 import com.solace.maas.ep.event.management.agent.plugin.mop.MOPMessage;
 import com.solace.maas.ep.event.management.agent.plugin.publisher.SolacePublisher;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
 
+@Slf4j
 @Component
 @ConditionalOnProperty(name = "event-portal.gateway.messaging.standalone", havingValue = "false")
 public class CommandPublisher {
@@ -32,9 +34,9 @@ public class CommandPublisher {
 
         String topicString =
                 String.format("%scommandResponse/v1/%s",
-                        solaceConfiguration.getTopicPrefix(),
+                        solaceConfiguration.getTopicPrefix(topicDetails.get("orgId")),
                         topicDetails.get(Command.COMMAND_CORRELATION_ID));
-
+        log.debug("Sending config push response to topic: {}", topicString);
         solacePublisher.publish(message, topicString);
     }
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/publisher/CommandPublisher.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/publisher/CommandPublisher.java
@@ -36,7 +36,7 @@ public class CommandPublisher {
                 String.format("%scommandResponse/v1/%s",
                         solaceConfiguration.getTopicPrefix(topicDetails.get("orgId")),
                         topicDetails.get(Command.COMMAND_CORRELATION_ID));
-        log.debug("Sending config push response to topic: {}", topicString);
+        log.info("Sending config push response to topic: {}", topicString);
         solacePublisher.publish(message, topicString);
     }
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/publisher/CommandPublisher.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/publisher/CommandPublisher.java
@@ -29,13 +29,11 @@ public class CommandPublisher {
      * The topic for command response:
      * sc/ep/runtime/{orgId}/{runtimeAgentId}/commandResponse/v1/{commandCorrelationId}
      */
-
     public void sendCommandResponse(MOPMessage message, Map<String, String> topicDetails) {
         String topicString =
                 String.format("%scommandResponse/v1/%s",
                         solaceConfiguration.getTopicPrefix(topicDetails.get("orgId")),
                         topicDetails.get(Command.COMMAND_CORRELATION_ID));
-        log.info("Sending config push response to topic: {}", topicString);
         solacePublisher.publish(message, topicString);
     }
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/CommandMessageHandler.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/CommandMessageHandler.java
@@ -19,6 +19,7 @@ public class CommandMessageHandler extends SolaceDirectMessageHandler<CommandMes
             SolaceSubscriber solaceSubscriber,
             CommandMessageProcessor commandMessageProcessor) {
         super(solaceConfiguration.getTopicPrefix() + "command/v1/>", solaceSubscriber);
+        log.info("CommandMessageHandler created with subscription {}", getTopicString());
         this.commandMessageProcessor = commandMessageProcessor;
     }
 

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/CommandMessageHandler.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/CommandMessageHandler.java
@@ -19,7 +19,7 @@ public class CommandMessageHandler extends SolaceDirectMessageHandler<CommandMes
             SolaceSubscriber solaceSubscriber,
             CommandMessageProcessor commandMessageProcessor) {
         super(solaceConfiguration.getTopicPrefix() + "command/v1/>", solaceSubscriber);
-        log.info("CommandMessageHandler created with subscription {}", getTopicString());
+        log.debug("CommandMessageHandler created with subscription {}", getTopicString());
         this.commandMessageProcessor = commandMessageProcessor;
     }
 

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/messageProcessors/CommandMessageProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/messageProcessors/CommandMessageProcessor.java
@@ -38,7 +38,8 @@ public class CommandMessageProcessor implements MessageProcessor<CommandMessage>
 
     @Override
     public void processMessage(CommandMessage message) {
-        log.info("Config push command processor started. context={} actorId={} ", message.getContext(), message.getActorId());
+        log.info("Config push command processor started. context={} orgId={} actorId={} ",
+                message.getContext(), message.getOrgId(), message.getActorId());
         logConfigPushMetric(message);
         if (CollectionUtils.isNotEmpty(message.getResources())) {
             dynamicResourceConfigurationHelper.loadSolaceBrokerResourceConfigurations(message.getResources());

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/command/model/CommandRequest.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/command/model/CommandRequest.java
@@ -22,6 +22,7 @@ public class CommandRequest {
     private List<CommandBundle> commandBundles;
     private Instant createdTime;
     private Instant updatedTime;
+    private String orgId;
 
     public long getLifetime(TemporalUnit timeUnit) {
         if (createdTime == null) {


### PR DESCRIPTION
### What is the purpose of this change?

Config push must be able to be performed by several different organizations sharing an EMA.

### How was this change implemented?

Use the orgId from the mop message instead of getting it from the app properties to support multi tenancy better.

### How was this change tested?

Manually by running the EMA locally and verifying in the debugger that the org ID was set as expected.

### Is there anything the reviewers should focus on/be aware of?

None
