### PR TITLE
DATAGO-93766: scan cycle time metric

### DIFF
--- a/service/application/src/main/java/com/solace/maas/ep/common/metrics/ObservabilityConstants.java
+++ b/service/application/src/main/java/com/solace/maas/ep/common/metrics/ObservabilityConstants.java
@@ -9,6 +9,7 @@ public class ObservabilityConstants {
     public static final String MAAS_EMA_CONFIG_PUSH_EVENT_RECEIVED = "maas.ema.config_push_event.received";
 
     public static final String MAAS_EMA_CONFIG_PUSH_EVENT_CYCLE_TIME = "maas.ema.config_push_event.cycle_time";
+    public static final String MAAS_EMA_SCAN_EVENT_CYCLE_TIME = "maas.ema.scan_event.cycle_time";
 
     public static final String STATUS_TAG = "status";
     public static final String ORG_ID_TAG = "org_id";

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/RouteCompleteProcessorImpl.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/RouteCompleteProcessorImpl.java
@@ -44,9 +44,6 @@ public class RouteCompleteProcessorImpl extends RouteCompleteProcessor {
         String orgId = (String) exchange.getIn().getHeader(RouteConstants.ORG_ID);
         String scanType = getScanType(exchange);
 
-        // ToDo: remove this before merging the PR
-        log.info("will2 save scan status as complete for scanId {} orgId {} scanType {}", scanId, orgId, scanType);
-
         scanStatusService.save(scanType, scanId, ScanStatus.COMPLETE);
         if (Boolean.TRUE.equals(eventPortalProperties.getManaged()) && scanService.isScanComplete(scanId)) {
             registerScanCycleTime(scanId, orgId);
@@ -60,10 +57,6 @@ public class RouteCompleteProcessorImpl extends RouteCompleteProcessor {
                 .builder(MAAS_EMA_SCAN_EVENT_CYCLE_TIME)
                 .tag(ORG_ID_TAG, orgId)
                 .register(meterRegistry);
-
-        // ToDo: remove this before merging the PR
-        log.info("moodi2 xxx scanEntity {} now {} scanEntity.getCreatedAt().toEpochMilli() {} now-createdAt {}",
-                scanEntity, now, scanEntity.getCreatedAt().toEpochMilli(), now - scanEntity.getCreatedAt().toEpochMilli());
 
         jobCycleTime.record(now - scanEntity.getCreatedAt().toEpochMilli(), TimeUnit.MILLISECONDS);
     }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/RouteCompleteProcessorImpl.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/RouteCompleteProcessorImpl.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.concurrent.TimeUnit;
 
-import static com.solace.maas.ep.common.metrics.ObservabilityConstants.MAAS_EMA_CONFIG_PUSH_EVENT_CYCLE_TIME;
+import static com.solace.maas.ep.common.metrics.ObservabilityConstants.MAAS_EMA_SCAN_EVENT_CYCLE_TIME;
 import static com.solace.maas.ep.common.metrics.ObservabilityConstants.ORG_ID_TAG;
 
 @Slf4j
@@ -43,6 +43,10 @@ public class RouteCompleteProcessorImpl extends RouteCompleteProcessor {
         String scanId = (String) exchange.getIn().getHeader(RouteConstants.SCAN_ID);
         String orgId = (String) exchange.getIn().getHeader(RouteConstants.ORG_ID);
         String scanType = getScanType(exchange);
+
+        // ToDo: remove this before merging the PR
+        log.info("will2 save scan status as complete for scanId {} orgId {} scanType {}", scanId, orgId, scanType);
+
         scanStatusService.save(scanType, scanId, ScanStatus.COMPLETE);
         if (Boolean.TRUE.equals(eventPortalProperties.getManaged()) && scanService.isScanComplete(scanId)) {
             registerScanCycleTime(scanId, orgId);
@@ -53,12 +57,12 @@ public class RouteCompleteProcessorImpl extends RouteCompleteProcessor {
         ScanEntity scanEntity = scanService.getById(scanId);
         long now = System.currentTimeMillis();
         Timer jobCycleTime = Timer
-                .builder(MAAS_EMA_CONFIG_PUSH_EVENT_CYCLE_TIME)
+                .builder(MAAS_EMA_SCAN_EVENT_CYCLE_TIME)
                 .tag(ORG_ID_TAG, orgId)
                 .register(meterRegistry);
 
         // ToDo: remove this before merging the PR
-        log.debug("moodi xxx scanEntity {} now {} scanEntity.getCreatedAt().toEpochMilli() {} now-createdAt {}",
+        log.info("moodi2 xxx scanEntity {} now {} scanEntity.getCreatedAt().toEpochMilli() {} now-createdAt {}",
                 scanEntity, now, scanEntity.getCreatedAt().toEpochMilli(), now - scanEntity.getCreatedAt().toEpochMilli());
 
         jobCycleTime.record(now - scanEntity.getCreatedAt().toEpochMilli(), TimeUnit.MILLISECONDS);

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/RouteCompleteProcessorImpl.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/RouteCompleteProcessorImpl.java
@@ -1,28 +1,66 @@
 package com.solace.maas.ep.event.management.agent.processor;
 
+import com.solace.maas.ep.event.management.agent.config.eventPortal.EventPortalProperties;
 import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
 import com.solace.maas.ep.event.management.agent.plugin.constants.ScanStatus;
 import com.solace.maas.ep.event.management.agent.plugin.processor.RouteCompleteProcessor;
+import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanEntity;
+import com.solace.maas.ep.event.management.agent.service.ScanService;
 import com.solace.maas.ep.event.management.agent.service.ScanStatusService;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.Exchange;
 import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.solace.maas.ep.common.metrics.ObservabilityConstants.MAAS_EMA_CONFIG_PUSH_EVENT_CYCLE_TIME;
+import static com.solace.maas.ep.common.metrics.ObservabilityConstants.ORG_ID_TAG;
 
 @Slf4j
 @Component
 public class RouteCompleteProcessorImpl extends RouteCompleteProcessor {
     private final ScanStatusService scanStatusService;
+    private final ScanService scanService;
+    private final MeterRegistry meterRegistry;
+    private final EventPortalProperties eventPortalProperties;
 
-    public RouteCompleteProcessorImpl(ScanStatusService scanStatusService) {
+    public RouteCompleteProcessorImpl(ScanStatusService scanStatusService,
+                                      ScanService scanService,
+                                      MeterRegistry meterRegistry,
+                                      EventPortalProperties eventPortalProperties) {
         super();
         this.scanStatusService = scanStatusService;
+        this.scanService = scanService;
+        this.meterRegistry = meterRegistry;
+        this.eventPortalProperties = eventPortalProperties;
     }
 
     @Override
     public void process(Exchange exchange) throws Exception {
         exchange.getIn().setHeader(RouteConstants.SCAN_STATUS, ScanStatus.COMPLETE);
         String scanId = (String) exchange.getIn().getHeader(RouteConstants.SCAN_ID);
+        String orgId = (String) exchange.getIn().getHeader(RouteConstants.ORG_ID);
         String scanType = getScanType(exchange);
         scanStatusService.save(scanType, scanId, ScanStatus.COMPLETE);
+        if (Boolean.TRUE.equals(eventPortalProperties.getManaged()) && scanService.isScanComplete(scanId)) {
+            registerScanCycleTime(scanId, orgId);
+        }
+    }
+
+    private void registerScanCycleTime(String scanId, String orgId) {
+        ScanEntity scanEntity = scanService.getById(scanId);
+        long now = System.currentTimeMillis();
+        Timer jobCycleTime = Timer
+                .builder(MAAS_EMA_CONFIG_PUSH_EVENT_CYCLE_TIME)
+                .tag(ORG_ID_TAG, orgId)
+                .register(meterRegistry);
+
+        // ToDo: remove this before merging the PR
+        log.debug("moodi xxx scanEntity {} now {} scanEntity.getCreatedAt().toEpochMilli() {} now-createdAt {}",
+                scanEntity, now, scanEntity.getCreatedAt().toEpochMilli(), now - scanEntity.getCreatedAt().toEpochMilli());
+
+        jobCycleTime.record(now - scanEntity.getCreatedAt().toEpochMilli(), TimeUnit.MILLISECONDS);
     }
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ScanService.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ScanService.java
@@ -315,6 +315,16 @@ public class ScanService {
         return repository.save(scanEntity);
     }
 
+    /**
+     * Get information pertaining to a Messaging Service scan.
+     *
+     * @param scanId The information of the Messaging Service scan.
+     * @return The saved Messaging Service scan details.
+     */
+    public ScanEntity getById(String scanId) {
+        return repository.findById(scanId).orElse(null);
+    }
+
     protected ScanRecipientHierarchyEntity save(RouteBundleHierarchyStore routeBundleHierarchy, String scanId) {
         ScanRecipientHierarchyEntity scanRecipientHierarchyEntity =
                 ScanRecipientHierarchyEntity.builder()

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/processor/RouteCompleteProcessorTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/processor/RouteCompleteProcessorTests.java
@@ -1,6 +1,7 @@
 package com.solace.maas.ep.event.management.agent.processor;
 
 import com.solace.maas.ep.event.management.agent.TestConfig;
+import com.solace.maas.ep.event.management.agent.config.eventPortal.EventPortalProperties;
 import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
 import com.solace.maas.ep.event.management.agent.plugin.constants.ScanStatus;
 import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanStatusEntity;
@@ -39,6 +40,9 @@ public class RouteCompleteProcessorTests {
 
     @Mock
     ProducerTemplate producerTemplate;
+
+    @Mock
+    EventPortalProperties eventPortalProperties;
 
     @InjectMocks
     RouteCompleteProcessorImpl routeCompleteProcessor;


### PR DESCRIPTION
### What is the purpose of this change?
Add a new metric regarding scan cycle time

### How was this change implemented?
After persisting each scan Complete for a scanType, we check if all existing ones are complete (for managed EMAs only), and then we register a metric value for the difference between now and created time of the scan.

### How was this change tested?
Manually, you can see it in [this slack thread demo](https://solacedotcom.slack.com/archives/C012V9XLFQQ/p1738785231217649)

### Is there anything the reviewers should focus on/be aware of?
Nada
