### PR TITLE
DATAGO-93783: Fix cfg push cycle time bug by putting back the setting of the createdTime

### DIFF
--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/CommandManager.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/CommandManager.java
@@ -27,6 +27,7 @@ import org.springframework.stereotype.Service;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -91,6 +92,7 @@ public class CommandManager {
         Validate.notEmpty(request.getCommandBundles(), "CommandBundles must not be empty");
         Validate.notEmpty(request.getCommandBundles().get(0).getCommands(), "At least one command must be present");
         CommandRequest requestBO = commandMapper.map(request);
+        requestBO.setCreatedTime(Instant.now());
         configPush(requestBO);
     }
 

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/config/eventPortal/EventPortalProperties.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/config/eventPortal/EventPortalProperties.java
@@ -25,7 +25,7 @@ public class EventPortalProperties {
     private String incomingRequestQueueName;
 
     private int waitAckScanCompleteTimeoutSec = 300;
-    private int waitAckScanCompletePollIntervalSec = 10;
+    private int waitAckScanCompletePollIntervalSec = 3;
 
     private GatewayProperties gateway
             = new GatewayProperties("standalone", "standalone", new GatewayMessagingProperties(true, false, List.of()));

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/RouteCompleteProcessorImpl.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/RouteCompleteProcessorImpl.java
@@ -1,63 +1,30 @@
 package com.solace.maas.ep.event.management.agent.processor;
 
-import com.solace.maas.ep.event.management.agent.config.eventPortal.EventPortalProperties;
 import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
 import com.solace.maas.ep.event.management.agent.plugin.constants.ScanStatus;
 import com.solace.maas.ep.event.management.agent.plugin.processor.RouteCompleteProcessor;
-import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanEntity;
-import com.solace.maas.ep.event.management.agent.service.ScanService;
 import com.solace.maas.ep.event.management.agent.service.ScanStatusService;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.Exchange;
 import org.springframework.stereotype.Component;
 
-import java.util.concurrent.TimeUnit;
-
-import static com.solace.maas.ep.common.metrics.ObservabilityConstants.MAAS_EMA_SCAN_EVENT_CYCLE_TIME;
-import static com.solace.maas.ep.common.metrics.ObservabilityConstants.ORG_ID_TAG;
 
 @Slf4j
 @Component
 public class RouteCompleteProcessorImpl extends RouteCompleteProcessor {
     private final ScanStatusService scanStatusService;
-    private final ScanService scanService;
-    private final MeterRegistry meterRegistry;
-    private final EventPortalProperties eventPortalProperties;
 
-    public RouteCompleteProcessorImpl(ScanStatusService scanStatusService,
-                                      ScanService scanService,
-                                      MeterRegistry meterRegistry,
-                                      EventPortalProperties eventPortalProperties) {
+    public RouteCompleteProcessorImpl(ScanStatusService scanStatusService) {
         super();
         this.scanStatusService = scanStatusService;
-        this.scanService = scanService;
-        this.meterRegistry = meterRegistry;
-        this.eventPortalProperties = eventPortalProperties;
     }
 
     @Override
     public void process(Exchange exchange) throws Exception {
         exchange.getIn().setHeader(RouteConstants.SCAN_STATUS, ScanStatus.COMPLETE);
         String scanId = (String) exchange.getIn().getHeader(RouteConstants.SCAN_ID);
-        String orgId = (String) exchange.getIn().getHeader(RouteConstants.ORG_ID);
         String scanType = getScanType(exchange);
 
         scanStatusService.save(scanType, scanId, ScanStatus.COMPLETE);
-        if (Boolean.TRUE.equals(eventPortalProperties.getManaged()) && scanService.isScanComplete(scanId)) {
-            registerScanCycleTime(scanId, orgId);
-        }
-    }
-
-    private void registerScanCycleTime(String scanId, String orgId) {
-        ScanEntity scanEntity = scanService.getById(scanId);
-        long now = System.currentTimeMillis();
-        Timer jobCycleTime = Timer
-                .builder(MAAS_EMA_SCAN_EVENT_CYCLE_TIME)
-                .tag(ORG_ID_TAG, orgId)
-                .register(meterRegistry);
-
-        jobCycleTime.record(now - scanEntity.getCreatedAt().toEpochMilli(), TimeUnit.MILLISECONDS);
     }
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/SolacePersistentMessageHandler.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/SolacePersistentMessageHandler.java
@@ -1,6 +1,7 @@
 package com.solace.maas.ep.event.management.agent.subscriber;
 
 import com.solace.maas.ep.event.management.agent.config.eventPortal.EventPortalProperties;
+import com.solace.maas.ep.event.management.agent.plugin.command.model.JobStatus;
 import com.solace.maas.ep.event.management.agent.plugin.mop.MOPConstants;
 import com.solace.maas.ep.event.management.agent.subscriber.messageProcessors.MessageProcessor;
 import com.solace.maas.ep.event.management.agent.util.MdcTaskDecorator;
@@ -12,6 +13,7 @@ import com.solace.messaging.resources.Queue;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -85,7 +87,7 @@ public class SolacePersistentMessageHandler extends BaseSolaceMessageHandler imp
         String mopMessageSubclass = "";
         MessageProcessor processor = null;
         Object message = null;
-        Boolean isFailed = false;
+        String status = JobStatus.success.name();
         Instant startTime = Instant.now();
         try {
             mopMessageSubclass = inboundMessage.getProperty(MOPConstants.MOP_MSG_META_DECODER);
@@ -104,12 +106,12 @@ public class SolacePersistentMessageHandler extends BaseSolaceMessageHandler imp
                 notifyPersistentMessageHandlerObserver(PersistentMessageHandlerObserverPhase.PROCESSOR_COMPLETED,inboundMessage);
             }
         } catch (Exception e) {
-            isFailed = true;
+            status = JobStatus.error.name();
             handleProcessingError(mopMessageSubclass, processor, message, e);
             notifyPersistentMessageHandlerObserver(PersistentMessageHandlerObserverPhase.FAILED,inboundMessage);
         } finally {
-            if(!isFailed){
-                processor.sendCycleTimeMetric(startTime, processor.castToMessageClass(message));
+            if(ObjectUtils.isNotEmpty(processor)) {
+                processor.sendCycleTimeMetric(startTime, processor.castToMessageClass(message), status);
             }
             // for testing purposes, we want to be able to stop processing the message and simulate a failure leading to not acknowledging the message
             if (notifyPersistentMessageHandlerObserver(PersistentMessageHandlerObserverPhase.PRE_ACKNOWLEDGED,inboundMessage)) {

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/messageProcessors/CommandMessageProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/messageProcessors/CommandMessageProcessor.java
@@ -78,12 +78,13 @@ public class CommandMessageProcessor implements MessageProcessor<CommandMessage>
     }
 
     @Override
-    public void sendCycleTimeMetric(Instant startTime, CommandMessage message) {
+    public void sendCycleTimeMetric(Instant startTime, CommandMessage message, String status) {
         Instant endTime = Instant.now();
         long duration = endTime.toEpochMilli() - startTime.toEpochMilli();
         Timer jobCycleTime = Timer
                 .builder(MAAS_EMA_CONFIG_PUSH_EVENT_CYCLE_TIME)
                 .tag(ORG_ID_TAG, message.getOrgId())
+                .tag(STATUS_TAG, status)
                 .register(meterRegistry);
         jobCycleTime.record(duration, TimeUnit.MILLISECONDS);
     }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/messageProcessors/MessageProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/messageProcessors/MessageProcessor.java
@@ -14,5 +14,5 @@ public interface MessageProcessor<T extends MOPMessage> {
 
     void onFailure(Exception e, T message);
 
-    void sendCycleTimeMetric(Instant startTime, T message);
+    void sendCycleTimeMetric(Instant startTime, T message, String status);
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/messageProcessors/MessageProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/messageProcessors/MessageProcessor.java
@@ -2,6 +2,8 @@ package com.solace.maas.ep.event.management.agent.subscriber.messageProcessors;
 
 import com.solace.maas.ep.event.management.agent.plugin.mop.MOPMessage;
 
+import java.time.Instant;
+
 public interface MessageProcessor<T extends MOPMessage> {
 
     void processMessage(T message);
@@ -11,4 +13,6 @@ public interface MessageProcessor<T extends MOPMessage> {
     T castToMessageClass(Object message);
 
     void onFailure(Exception e, T message);
+
+    void sendCycleTimeMetric(Instant startTime, T message);
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/messageProcessors/ScanCommandMessageProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/messageProcessors/ScanCommandMessageProcessor.java
@@ -25,6 +25,7 @@ import static com.solace.maas.ep.common.metrics.ObservabilityConstants.MAAS_EMA_
 import static com.solace.maas.ep.common.metrics.ObservabilityConstants.MAAS_EMA_SCAN_EVENT_RECEIVED;
 import static com.solace.maas.ep.common.metrics.ObservabilityConstants.ORG_ID_TAG;
 import static com.solace.maas.ep.common.metrics.ObservabilityConstants.SCAN_ID_TAG;
+import static com.solace.maas.ep.common.metrics.ObservabilityConstants.STATUS_TAG;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 
@@ -142,12 +143,13 @@ public class ScanCommandMessageProcessor implements MessageProcessor<ScanCommand
     }
 
     @Override
-    public void sendCycleTimeMetric(Instant startTime, ScanCommandMessage message) {
+    public void sendCycleTimeMetric(Instant startTime, ScanCommandMessage message, String status) {
         Instant endTime = Instant.now();
         long duration = endTime.toEpochMilli() - startTime.toEpochMilli();
         Timer jobCycleTime = Timer
                 .builder(MAAS_EMA_SCAN_EVENT_CYCLE_TIME)
                 .tag(ORG_ID_TAG, message.getOrgId())
+                .tag(STATUS_TAG, status)
                 .register(meterRegistry);
         jobCycleTime.record(duration, TimeUnit.MILLISECONDS);
     }

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/subscriber/PersistentMessageHandlerTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/subscriber/PersistentMessageHandlerTests.java
@@ -129,7 +129,7 @@ public class PersistentMessageHandlerTests {
         // Wait for the executor to process the message
         await().atMost(5, SECONDS).until(() -> messageHandlerObserver.hasInitiatedMessageProcessing(inboundMessage));
 
-        verify(commandMessageProcessor, times(1)).castToMessageClass(any());
+        verify(commandMessageProcessor, times(2)).castToMessageClass(any());
         verify(commandMessageProcessor, times(1)).processMessage(any());
 
         // There must be no interaction with scanCommandMessageProcessor


### PR DESCRIPTION
### What is the purpose of this change?
To fix a bug that prevented reporting configPush cycle time

### How was this change implemented?
There was a change in [this PR](https://github.com/SolaceProducts/event-management-agent/pull/199/files)
![Screenshot 2025-02-10 at 2 50 29 PM](https://github.com/user-attachments/assets/e4f9c535-0fa6-445c-85de-5e58727a6ba5)

Which was removed as part of this [later PR](https://github.com/SolaceProducts/event-management-agent/pull/211/files) 
![Screenshot 2025-02-10 at 2 51 21 PM](https://github.com/user-attachments/assets/5ed261b1-8151-4d14-9595-35af11c4e91e)

### How was this change tested?
Manually by validating DD metric values showing up: 
![Screenshot 2025-02-10 at 2 48 02 PM](https://github.com/user-attachments/assets/284d0aed-a230-4128-8af7-3bcafa15ae18)



### Is there anything the reviewers should focus on/be aware of?

    ...
