### PR TITLE
DATAGO-94921: upgrade netty to 4.1.118

### DIFF
--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>io.projectreactor.netty</groupId>
             <artifactId>reactor-netty-http</artifactId>
-            <version>1.1.22</version>
+            <version>1.1.27</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/service/kafka-plugin/pom.xml
+++ b/service/kafka-plugin/pom.xml
@@ -103,7 +103,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>netty-nio-client</artifactId>
-            <version>2.28.1</version>
+            <version>2.30.17</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.msk</groupId>

--- a/service/plugin/pom.xml
+++ b/service/plugin/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>io.projectreactor.netty</groupId>
             <artifactId>reactor-netty-http</artifactId>
-            <version>1.1.22</version>
+            <version>1.1.27</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
### What is the purpose of this change?
Fix a netty vulnerability

### How was this change implemented?
Updated the related dependencies

### How was this change tested?
Ran a scan and configPush from a locally built docker image and looks good!
![Screenshot 2025-02-12 at 11 43 36 AM](https://github.com/user-attachments/assets/5b9418d2-f17d-4bd0-bd20-4ab39def7345)


### Is there anything the reviewers should focus on/be aware of?

    ...
