### PR TITLE
DATAGO-94923: address vulnerability for netty-common

### DIFF
--- a/service/plugin/pom.xml
+++ b/service/plugin/pom.xml
@@ -52,6 +52,14 @@
                     <groupId>io.projectreactor.netty</groupId>
                     <artifactId>reactor-netty-core</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-codec-http</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-codec-http2</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
### What is the purpose of this change?
To address a netty-common lib vulnerability

### How was this change implemented?
excluded some stuff that were pulling in netty-common 4.1.116

### How was this change tested?
Ran configPush and scan from a custom docker image and looks good!

<img width="1721" alt="Screenshot 2025-02-12 at 9 39 58 PM" src="https://github.com/user-attachments/assets/dd0a0a3e-25f7-4e65-923b-5c53426c72f7" />


### Is there anything the reviewers should focus on/be aware of?

    ...
