### PR TITLE
Update the dev workflow to be more concise when choosing between building a new image or pulling main 

### DIFF
--- a/.github/workflows/deploy-dev-managed-ema-image.yaml
+++ b/.github/workflows/deploy-dev-managed-ema-image.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment: prod
+    environment: development
 
     steps:
       - name: Configure AWS credentials

--- a/.github/workflows/deploy-dev-managed-ema-image.yaml
+++ b/.github/workflows/deploy-dev-managed-ema-image.yaml
@@ -7,9 +7,10 @@ on:
         required: true
         default: "A.B.C"
       buildNewDevImage:
-        description: "true/false. Set to 'true' to build a new image, otherwise, we'll pull the 'main' image from ECR."
-        required: false
-        default: "false"
+        description: "Set to 'true' to build a new image, otherwise, we'll pull the 'main' image from ECR."
+        required: true
+        type: boolean
+        default: false
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -17,7 +18,7 @@ jobs:
 
     steps:
       - name: Configure AWS credentials
-        if: ${{ github.event.inputs.buildNewDevImage == 'false' }}
+        if: ${{ github.event.inputs.buildNewDevImage == false}}
         uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/deploy-dev-managed-ema-image.yaml
+++ b/.github/workflows/deploy-dev-managed-ema-image.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment: development
+    environment: prod
 
     steps:
       - name: Configure AWS credentials

--- a/.github/workflows/deploy-dev-managed-ema-image.yaml
+++ b/.github/workflows/deploy-dev-managed-ema-image.yaml
@@ -7,8 +7,8 @@ on:
         required: true
         default: "A.B.C"
       buildNewDevImage:
-        description: "Set to 'true' to build a new image, otherwise, we'll pull the 'main' image from ECR."
-        required: true
+        description: "Check to build a new image from the current code, otherwise, we'll pull the 'main' image from ECR used in releases."
+        required: false
         type: boolean
         default: false
 jobs:

--- a/.github/workflows/deploy-dev-managed-ema-image.yaml
+++ b/.github/workflows/deploy-dev-managed-ema-image.yaml
@@ -18,30 +18,30 @@ jobs:
 
     steps:
       - name: Configure AWS credentials
-        if: ${{ !github.event.inputs.buildNewDevImage}}
+        if: ${{ github.event.inputs.buildNewDevImage == 'false' }}
         uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
       - name: Login to Amazon ECR
-        if: ${{ !github.event.inputs.buildNewDevImage }}
+        if: ${{ github.event.inputs.buildNewDevImage == 'false' }}
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1.6.0
       - name: ECR (Dev) - Pull Main Image
-        if: ${{ !github.event.inputs.buildNewDevImage }}
+        if: ${{ github.event.inputs.buildNewDevImage == 'false' }}
         run: |
           ECR_DEV_IMAGE="${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:main"
           docker pull $ECR_DEV_IMAGE
           echo "ECR_DEV_IMAGE=$ECR_DEV_IMAGE" >> $GITHUB_ENV
       - name: "Checkout branch"
         uses: actions/checkout@v3
-        if: ${{ github.event.inputs.buildNewDevImage }}
+        if: ${{ github.event.inputs.buildNewDevImage == 'true' }}
         with:
           fetch-depth: 0
           lfs: true
       - name: Set up JDK 17
-        if: ${{ github.event.inputs.buildNewDevImage }}
+        if: ${{ github.event.inputs.buildNewDevImage == 'true' }}
         uses: actions/setup-java@v3
         with:
           java-version: 17
@@ -56,7 +56,7 @@ jobs:
         run: |
           mvn install $SKIP_FLAGS_ALL_TESTS --file service/pom.xml
       - name: ECR (Dev) - Build Image
-        if: ${{ github.event.inputs.buildNewDevImage }}
+        if: ${{ github.event.inputs.buildNewDevImage == 'true' }}
         working-directory: service/application/docker
         run: |
           ./buildEventManagementAgentDocker.sh -t ${{ github.event.inputs.releaseVersion }}

--- a/.github/workflows/deploy-dev-managed-ema-image.yaml
+++ b/.github/workflows/deploy-dev-managed-ema-image.yaml
@@ -18,30 +18,30 @@ jobs:
 
     steps:
       - name: Configure AWS credentials
-        if: ${{ github.event.inputs.buildNewDevImage == false}}
+        if: ${{ !github.event.inputs.buildNewDevImage}}
         uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
       - name: Login to Amazon ECR
-        if: ${{ github.event.inputs.buildNewDevImage == 'false' }}
+        if: ${{ !github.event.inputs.buildNewDevImage }}
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1.6.0
       - name: ECR (Dev) - Pull Main Image
-        if: ${{ github.event.inputs.buildNewDevImage == 'false' }}
+        if: ${{ !github.event.inputs.buildNewDevImage }}
         run: |
           ECR_DEV_IMAGE="${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:main"
           docker pull $ECR_DEV_IMAGE
           echo "ECR_DEV_IMAGE=$ECR_DEV_IMAGE" >> $GITHUB_ENV
       - name: "Checkout branch"
         uses: actions/checkout@v3
-        if: ${{ github.event.inputs.buildNewDevImage == 'true' }}
+        if: ${{ github.event.inputs.buildNewDevImage }}
         with:
           fetch-depth: 0
           lfs: true
       - name: Set up JDK 17
-        if: ${{ github.event.inputs.buildNewDevImage == 'true' }}
+        if: ${{ github.event.inputs.buildNewDevImage }}
         uses: actions/setup-java@v3
         with:
           java-version: 17
@@ -56,7 +56,7 @@ jobs:
         run: |
           mvn install $SKIP_FLAGS_ALL_TESTS --file service/pom.xml
       - name: ECR (Dev) - Build Image
-        if: ${{ github.event.inputs.buildNewDevImage == 'true' }}
+        if: ${{ github.event.inputs.buildNewDevImage }}
         working-directory: service/application/docker
         run: |
           ./buildEventManagementAgentDocker.sh -t ${{ github.event.inputs.releaseVersion }}


### PR DESCRIPTION
### What is the purpose of this change?

Update the dev workflow to be more concise when choosing between building a new image or pulling main.

### How was this change implemented?

Use a checkbox instead of typing out the true or false by hand.

### How was this change tested?

By running the workflow to deploy the different types of images.

### Is there anything the reviewers should focus on/be aware of?

 Pulling main doesn't work due to some environment secrets issue, but clearly, the right path is being executed.
