### PR TITLE
DATAGO-97981: Config Push of solaceClientCertificateUsername

### DIFF
--- a/service/application/src/main/java/com/solace/maas/ep/common/model/SempEntityType.java
+++ b/service/application/src/main/java/com/solace/maas/ep/common/model/SempEntityType.java
@@ -6,6 +6,7 @@ public enum SempEntityType {
     solaceAclSubscribeTopicException,
     solaceAclPublishTopicException,
     solaceClientUsername,
+    solaceClientCertificateUsername,
     solaceAuthorizationGroup,
     solaceQueueSubscriptionTopic
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/SempDeleteCommandManager.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/SempDeleteCommandManager.java
@@ -78,7 +78,7 @@ public class SempDeleteCommandManager {
             case solaceQueueSubscriptionTopic:
                 executeDeleteSolaceQueueTopicSubscription(command, sempApiProvider);
                 break;
-            case solaceClientUsername:
+            case solaceClientUsername, solaceClientCertificateUsername:
                 executeDeleteClientUsername(command, sempApiProvider);
                 break;
             case solaceAuthorizationGroup:

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/SempDeleteCommandManager.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/SempDeleteCommandManager.java
@@ -78,7 +78,8 @@ public class SempDeleteCommandManager {
             case solaceQueueSubscriptionTopic:
                 executeDeleteSolaceQueueTopicSubscription(command, sempApiProvider);
                 break;
-            case solaceClientUsername, solaceClientCertificateUsername:
+            case solaceClientUsername:
+            case solaceClientCertificateUsername:
                 executeDeleteClientUsername(command, sempApiProvider);
                 break;
             case solaceAuthorizationGroup:


### PR DESCRIPTION
### What is the purpose of this change?

To add support for config pushing a `solaceClientCertificateUsername` entity type

### How was this change implemented?

    ...

### How was this change tested?

IT tests + manually

### Is there anything the reviewers should focus on/be aware of?

This change is related to https://github.com/SolaceDev/maas-ep-core/pull/3612
