### PR TITLE
DATAGO-93817: Create and SEMP delete RDP queue bindings and queue binding request headers

### DIFF
--- a/service/application/src/main/java/com/solace/maas/ep/common/model/SempRdpQueueBindingDeletionRequest.java
+++ b/service/application/src/main/java/com/solace/maas/ep/common/model/SempRdpQueueBindingDeletionRequest.java
@@ -1,0 +1,12 @@
+package com.solace.maas.ep.common.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class SempRdpQueueBindingDeletionRequest {
+    private String rdpName;
+    private String msgVpn;
+    private String queueBindingName;
+}

--- a/service/application/src/main/java/com/solace/maas/ep/common/model/SempRdpQueueBindingRequestHeaderDeletionRequest.java
+++ b/service/application/src/main/java/com/solace/maas/ep/common/model/SempRdpQueueBindingRequestHeaderDeletionRequest.java
@@ -1,0 +1,14 @@
+package com.solace.maas.ep.common.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class SempRdpQueueBindingRequestHeaderDeletionRequest {
+    private String rdpName;
+    private String msgVpn;
+    private String queueBindingName;
+    private String headerName;
+    boolean isProtected;
+}

--- a/service/application/src/main/java/com/solace/maas/ep/common/model/SempRdpQueueBindingRequestHeaderDeletionRequest.java
+++ b/service/application/src/main/java/com/solace/maas/ep/common/model/SempRdpQueueBindingRequestHeaderDeletionRequest.java
@@ -10,5 +10,5 @@ public class SempRdpQueueBindingRequestHeaderDeletionRequest {
     private String msgVpn;
     private String queueBindingName;
     private String headerName;
-    boolean isProtected;
+    private boolean isProtected;
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/SempDeleteCommandManager.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/SempDeleteCommandManager.java
@@ -101,7 +101,8 @@ public class SempDeleteCommandManager {
             case solaceRdpQueueBinding:
                 executeRdpQueueBinding(command, sempApiProvider);
                 break;
-            case solaceRdpQueueBindingProtectedRequestHeader, solaceRdpQueueBindingRequestHeader:
+            case solaceRdpQueueBindingProtectedRequestHeader:
+            case solaceRdpQueueBindingRequestHeader:
                 executeRdpQueueBindingRequestHeader(command, sempApiProvider);
                 break;
             case solaceAclPublishTopicException:

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/SempDeleteCommandManager.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/SempDeleteCommandManager.java
@@ -17,6 +17,8 @@ import com.solace.maas.ep.common.model.SempEntityType;
 import com.solace.maas.ep.common.model.SempQueueDeletionRequest;
 import com.solace.maas.ep.common.model.SempQueueTopicSubscriptionDeletionRequest;
 import com.solace.maas.ep.common.model.SempRdpDeletionRequest;
+import com.solace.maas.ep.common.model.SempRdpQueueBindingDeletionRequest;
+import com.solace.maas.ep.common.model.SempRdpQueueBindingRequestHeaderDeletionRequest;
 import com.solace.maas.ep.common.model.SempRdpRestConsumerDeletionRequest;
 import com.solace.maas.ep.event.management.agent.command.semp.SempApiProvider;
 import com.solace.maas.ep.event.management.agent.plugin.command.model.Command;
@@ -95,6 +97,12 @@ public class SempDeleteCommandManager {
                 break;
             case solaceRDPRestConsumer:
                 executeDeleteRdpRestConsumer(command, sempApiProvider);
+                break;
+            case solaceRdpQueueBinding:
+                executeRdpQueueBinding(command, sempApiProvider);
+                break;
+            case solaceRdpQueueBindingProtectedRequestHeader, solaceRdpQueueBindingRequestHeader:
+                executeRdpQueueBindingRequestHeader(command, sempApiProvider);
                 break;
             case solaceAclPublishTopicException:
                 executeDeleteAclPublishTopicException(command, sempApiProvider);
@@ -281,5 +289,49 @@ public class SempDeleteCommandManager {
         }
     }
 
+    private void executeRdpQueueBinding(Command command, SempApiProvider sempApiProvider) throws ApiException, JsonProcessingException {
+        RestDeliveryPointApi restDeliveryPointApi = sempApiProvider.getRestDeliveryPointApi();
+        SempRdpQueueBindingDeletionRequest request = objectMapper.readValue(
+                objectMapper.writeValueAsString(command.getParameters().get(SEMP_DELETE_DATA)),
+                SempRdpQueueBindingDeletionRequest.class);
 
+        Validate.notEmpty(request.getMsgVpn(), "Msg VPN must not be empty");
+        Validate.notEmpty(request.getRdpName(), "RDP name must not be empty");
+        Validate.notEmpty(request.getQueueBindingName(), "Queue binding name must not be empty");
+        log.info("SEMP delete: Deleting Queue Binding");
+        try {
+            restDeliveryPointApi.deleteMsgVpnRestDeliveryPointQueueBinding(request.getMsgVpn(), request.getRdpName(), request.getQueueBindingName());
+        } catch (ApiException e) {
+            handleSempApiDeleteException(e, "Queue Binding", request.getRdpName());
+        }
+    }
+
+    private void executeRdpQueueBindingRequestHeader(Command command, SempApiProvider sempApiProvider) throws ApiException, JsonProcessingException {
+        RestDeliveryPointApi restDeliveryPointApi = sempApiProvider.getRestDeliveryPointApi();
+        SempRdpQueueBindingRequestHeaderDeletionRequest request = objectMapper.readValue(
+                objectMapper.writeValueAsString(command.getParameters().get(SEMP_DELETE_DATA)),
+                SempRdpQueueBindingRequestHeaderDeletionRequest.class);
+
+        Validate.notEmpty(request.getMsgVpn(), "Msg VPN must not be empty");
+        Validate.notEmpty(request.getRdpName(), "RDP name must not be empty");
+        Validate.notEmpty(request.getQueueBindingName(), "Queue binding name must not be empty");
+        if (request.isProtected()) {
+            log.info("SEMP delete: Deleting protected request header");
+            try {
+                restDeliveryPointApi.deleteMsgVpnRestDeliveryPointQueueBindingProtectedRequestHeader(request.getMsgVpn(), request.getRdpName(),
+                        request.getQueueBindingName(), request.getHeaderName());
+            } catch (ApiException e) {
+                handleSempApiDeleteException(e, "Protected Request Header", request.getHeaderName());
+            }
+        } else {
+            log.info("SEMP delete: Deleting request header");
+            try {
+                restDeliveryPointApi.deleteMsgVpnRestDeliveryPointQueueBindingRequestHeader(request.getMsgVpn(), request.getRdpName(),
+                        request.getQueueBindingName(), request.getHeaderName());
+            } catch (ApiException e) {
+                handleSempApiDeleteException(e, "Request Header", request.getHeaderName());
+            }
+        }
+
+    }
 }

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/commandManager/SempDeleteCommandManagerTest.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/commandManager/SempDeleteCommandManagerTest.java
@@ -37,6 +37,9 @@ import static com.solace.maas.ep.common.model.SempEntityType.solaceQueue;
 import static com.solace.maas.ep.common.model.SempEntityType.solaceQueueSubscriptionTopic;
 import static com.solace.maas.ep.common.model.SempEntityType.solaceRDP;
 import static com.solace.maas.ep.common.model.SempEntityType.solaceRDPRestConsumer;
+import static com.solace.maas.ep.common.model.SempEntityType.solaceRdpQueueBinding;
+import static com.solace.maas.ep.common.model.SempEntityType.solaceRdpQueueBindingProtectedRequestHeader;
+import static com.solace.maas.ep.common.model.SempEntityType.solaceRdpQueueBindingRequestHeader;
 import static com.solace.maas.ep.event.management.agent.plugin.command.model.SempDeleteCommandConstants.SEMP_DELETE_DATA;
 import static com.solace.maas.ep.event.management.agent.plugin.command.model.SempDeleteCommandConstants.SEMP_DELETE_ENTITY_TYPE;
 import static com.solace.maas.ep.event.management.agent.plugin.command.model.SempDeleteCommandConstants.SEMP_DELETE_OPERATION;
@@ -622,6 +625,189 @@ public class SempDeleteCommandManagerTest {
         assertThat(cmd.getResult().getStatus()).isEqualTo(JobStatus.success);
     }
 
+    // test DeleteRdpQueueBinding
+    @Test
+    void testDeleteRdpQueueBindingHappyPath() throws ApiException {
+        RestDeliveryPointApi rdpApi = Mockito.mock(RestDeliveryPointApi.class);
+        when(sempApiProvider.getRestDeliveryPointApi()).thenReturn(rdpApi);
+        when((rdpApi).deleteMsgVpnRestDeliveryPointQueueBinding(any(), any(), any())).thenReturn(new SempMetaOnlyResponse());
+        Command cmd = Command.builder()
+                .commandType(CommandType.semp)
+                .command(SEMP_DELETE_OPERATION)
+                .parameters(createDeleteRdpQueueBindingParameters(true))
+                .build();
+        sempDeleteCommandManager.execute(cmd, sempApiProvider);
+        verify(rdpApi).deleteMsgVpnRestDeliveryPointQueueBinding("default", "someRdp", "someQueueBindingName");
+        assertThat(cmd.getResult().getStatus()).isEqualTo(JobStatus.success);
+    }
+
+    @Test
+    void testDeleteRdpQueueBindingWithValidationException() throws ApiException {
+        RestDeliveryPointApi rdpApi = Mockito.mock(RestDeliveryPointApi.class);
+        when(sempApiProvider.getRestDeliveryPointApi()).thenReturn(rdpApi);
+        when((rdpApi).deleteMsgVpnRestDeliveryPointQueueBinding(any(), any(), any())).thenReturn(new SempMetaOnlyResponse());
+        Command cmd = Command.builder()
+                .commandType(CommandType.semp)
+                .command(SEMP_DELETE_OPERATION)
+                .parameters(createDeleteRdpQueueBindingParameters(false))
+                .build();
+        sempDeleteCommandManager.execute(cmd, sempApiProvider);
+        verifyNoInteractions(rdpApi);
+        assertThat(cmd.getResult().getStatus()).isEqualTo(JobStatus.error);
+    }
+
+    @Test
+    void testDeleteRdpQueueBindingWithException() throws ApiException {
+        RestDeliveryPointApi rdpApi = Mockito.mock(RestDeliveryPointApi.class);
+        when(sempApiProvider.getRestDeliveryPointApi()).thenReturn(rdpApi);
+        when((rdpApi).deleteMsgVpnRestDeliveryPointQueueBinding(any(), any(), any())).thenThrow(createaServerErrorApiException());
+        Command cmd = Command.builder()
+                .commandType(CommandType.semp)
+                .command(SEMP_DELETE_OPERATION)
+                .parameters(createDeleteRdpQueueBindingParameters(true))
+                .build();
+        sempDeleteCommandManager.execute(cmd, sempApiProvider);
+        verify(rdpApi).deleteMsgVpnRestDeliveryPointQueueBinding("default", "someRdp", "someQueueBindingName");
+        assertThat(cmd.getResult().getStatus()).isEqualTo(JobStatus.error);
+    }
+
+    @Test
+    void testNotFoundDeleteRdpQueueBinding() throws ApiException {
+        RestDeliveryPointApi rdpApi = Mockito.mock(RestDeliveryPointApi.class);
+        when(sempApiProvider.getRestDeliveryPointApi()).thenReturn(rdpApi);
+        when((rdpApi).deleteMsgVpnRestDeliveryPointQueueBinding(any(), any(), any())).thenThrow(createaNotFoundApiException(SEMP_RESPONSE_MISSING_RESOURCE));
+        Command cmd = Command.builder()
+                .commandType(CommandType.semp)
+                .command(SEMP_DELETE_OPERATION)
+                .parameters(createDeleteRdpQueueBindingParameters(true))
+                .build();
+        sempDeleteCommandManager.execute(cmd, sempApiProvider);
+        verify(rdpApi).deleteMsgVpnRestDeliveryPointQueueBinding("default", "someRdp", "someQueueBindingName");
+        assertThat(cmd.getResult().getStatus()).isEqualTo(JobStatus.success);
+    }
+
+    // test DeleteRdpQueueBindingRequestHeader
+    @Test
+    void testDeleteRdpQueueBindingRequestHeaderHappyPath() throws ApiException {
+        RestDeliveryPointApi rdpApi = Mockito.mock(RestDeliveryPointApi.class);
+        when(sempApiProvider.getRestDeliveryPointApi()).thenReturn(rdpApi);
+        when((rdpApi).deleteMsgVpnRestDeliveryPointQueueBindingRequestHeader(any(), any(), any(), any())).thenReturn(new SempMetaOnlyResponse());
+        Command cmd = Command.builder()
+                .commandType(CommandType.semp)
+                .command(SEMP_DELETE_OPERATION)
+                .parameters(createDeleteRdpQueueBindingRequestHeaderParameters(true, false))
+                .build();
+        sempDeleteCommandManager.execute(cmd, sempApiProvider);
+        verify(rdpApi).deleteMsgVpnRestDeliveryPointQueueBindingRequestHeader("default", "someRdp", "someQueueBindingName", "someHeaderName");
+        assertThat(cmd.getResult().getStatus()).isEqualTo(JobStatus.success);
+    }
+
+    @Test
+    void testDeleteRdpQueueBindingRequestHeaderWithValidationException() throws ApiException {
+        RestDeliveryPointApi rdpApi = Mockito.mock(RestDeliveryPointApi.class);
+        when(sempApiProvider.getRestDeliveryPointApi()).thenReturn(rdpApi);
+        when((rdpApi).deleteMsgVpnRestDeliveryPointQueueBindingRequestHeader(any(), any(), any(), any())).thenReturn(new SempMetaOnlyResponse());
+        Command cmd = Command.builder()
+                .commandType(CommandType.semp)
+                .command(SEMP_DELETE_OPERATION)
+                .parameters(createDeleteRdpQueueBindingRequestHeaderParameters(false, false))
+                .build();
+        sempDeleteCommandManager.execute(cmd, sempApiProvider);
+        verifyNoInteractions(rdpApi);
+        assertThat(cmd.getResult().getStatus()).isEqualTo(JobStatus.error);
+    }
+
+    @Test
+    void testDeleteRdpQueueBindingRequestHeaderWithException() throws ApiException {
+        RestDeliveryPointApi rdpApi = Mockito.mock(RestDeliveryPointApi.class);
+        when(sempApiProvider.getRestDeliveryPointApi()).thenReturn(rdpApi);
+        when((rdpApi).deleteMsgVpnRestDeliveryPointQueueBindingRequestHeader(any(), any(), any(), any())).thenThrow(createaServerErrorApiException());
+        Command cmd = Command.builder()
+                .commandType(CommandType.semp)
+                .command(SEMP_DELETE_OPERATION)
+                .parameters(createDeleteRdpQueueBindingRequestHeaderParameters(true, false))
+                .build();
+        sempDeleteCommandManager.execute(cmd, sempApiProvider);
+        verify(rdpApi).deleteMsgVpnRestDeliveryPointQueueBindingRequestHeader("default", "someRdp", "someQueueBindingName", "someHeaderName");
+        assertThat(cmd.getResult().getStatus()).isEqualTo(JobStatus.error);
+    }
+
+    @Test
+    void testNotFoundDeleteRdpQueueBindingRequestHeader() throws ApiException {
+        RestDeliveryPointApi rdpApi = Mockito.mock(RestDeliveryPointApi.class);
+        when(sempApiProvider.getRestDeliveryPointApi()).thenReturn(rdpApi);
+        when((rdpApi).deleteMsgVpnRestDeliveryPointQueueBindingRequestHeader(any(), any(), any(), any())).thenThrow(createaNotFoundApiException(SEMP_RESPONSE_MISSING_RESOURCE));
+        Command cmd = Command.builder()
+                .commandType(CommandType.semp)
+                .command(SEMP_DELETE_OPERATION)
+                .parameters(createDeleteRdpQueueBindingRequestHeaderParameters(true, false))
+                .build();
+        sempDeleteCommandManager.execute(cmd, sempApiProvider);
+        verify(rdpApi).deleteMsgVpnRestDeliveryPointQueueBindingRequestHeader("default", "someRdp", "someQueueBindingName", "someHeaderName");
+        assertThat(cmd.getResult().getStatus()).isEqualTo(JobStatus.success);
+    }
+
+    // test DeleteRdpQueueBindingProtectedRequestHeader
+    @Test
+    void testDeleteRdpQueueBindingProtectedRequestHeaderHappyPath() throws ApiException {
+        RestDeliveryPointApi rdpApi = Mockito.mock(RestDeliveryPointApi.class);
+        when(sempApiProvider.getRestDeliveryPointApi()).thenReturn(rdpApi);
+        when((rdpApi).deleteMsgVpnRestDeliveryPointQueueBindingProtectedRequestHeader(any(), any(), any(), any())).thenReturn(new SempMetaOnlyResponse());
+        Command cmd = Command.builder()
+                .commandType(CommandType.semp)
+                .command(SEMP_DELETE_OPERATION)
+                .parameters(createDeleteRdpQueueBindingRequestHeaderParameters(true, true))
+                .build();
+        sempDeleteCommandManager.execute(cmd, sempApiProvider);
+        verify(rdpApi).deleteMsgVpnRestDeliveryPointQueueBindingProtectedRequestHeader("default", "someRdp", "someQueueBindingName", "someHeaderName");
+        assertThat(cmd.getResult().getStatus()).isEqualTo(JobStatus.success);
+    }
+
+    @Test
+    void testDeleteRdpQueueBindingProtectedRequestHeaderWithValidationException() throws ApiException {
+        RestDeliveryPointApi rdpApi = Mockito.mock(RestDeliveryPointApi.class);
+        when(sempApiProvider.getRestDeliveryPointApi()).thenReturn(rdpApi);
+        when((rdpApi).deleteMsgVpnRestDeliveryPointQueueBindingProtectedRequestHeader(any(), any(), any(), any())).thenReturn(new SempMetaOnlyResponse());
+        Command cmd = Command.builder()
+                .commandType(CommandType.semp)
+                .command(SEMP_DELETE_OPERATION)
+                .parameters(createDeleteRdpQueueBindingRequestHeaderParameters(false, true))
+                .build();
+        sempDeleteCommandManager.execute(cmd, sempApiProvider);
+        verifyNoInteractions(rdpApi);
+        assertThat(cmd.getResult().getStatus()).isEqualTo(JobStatus.error);
+    }
+
+    @Test
+    void testDeleteRdpQueueBindingProtectedRequestHeaderWithException() throws ApiException {
+        RestDeliveryPointApi rdpApi = Mockito.mock(RestDeliveryPointApi.class);
+        when(sempApiProvider.getRestDeliveryPointApi()).thenReturn(rdpApi);
+        when((rdpApi).deleteMsgVpnRestDeliveryPointQueueBindingProtectedRequestHeader(any(), any(), any(), any())).thenThrow(createaServerErrorApiException());
+        Command cmd = Command.builder()
+                .commandType(CommandType.semp)
+                .command(SEMP_DELETE_OPERATION)
+                .parameters(createDeleteRdpQueueBindingRequestHeaderParameters(true, true))
+                .build();
+        sempDeleteCommandManager.execute(cmd, sempApiProvider);
+        verify(rdpApi).deleteMsgVpnRestDeliveryPointQueueBindingProtectedRequestHeader("default", "someRdp", "someQueueBindingName", "someHeaderName");
+        assertThat(cmd.getResult().getStatus()).isEqualTo(JobStatus.error);
+    }
+
+    @Test
+    void testNotFoundDeleteRdpQueueBindingProtectedRequestHeader() throws ApiException {
+        RestDeliveryPointApi rdpApi = Mockito.mock(RestDeliveryPointApi.class);
+        when(sempApiProvider.getRestDeliveryPointApi()).thenReturn(rdpApi);
+        when((rdpApi).deleteMsgVpnRestDeliveryPointQueueBindingProtectedRequestHeader(any(), any(), any(), any())).thenThrow(createaNotFoundApiException(SEMP_RESPONSE_MISSING_RESOURCE));
+        Command cmd = Command.builder()
+                .commandType(CommandType.semp)
+                .command(SEMP_DELETE_OPERATION)
+                .parameters(createDeleteRdpQueueBindingRequestHeaderParameters(true, true))
+                .build();
+        sempDeleteCommandManager.execute(cmd, sempApiProvider);
+        verify(rdpApi).deleteMsgVpnRestDeliveryPointQueueBindingProtectedRequestHeader("default", "someRdp", "someQueueBindingName", "someHeaderName");
+        assertThat(cmd.getResult().getStatus()).isEqualTo(JobStatus.success);
+    }
+
     // helpers
 
     private Map<String, Object> createDeleteQueueSubscriptionParameters(boolean valid) {
@@ -673,6 +859,36 @@ public class SempDeleteCommandManagerTest {
         data.put("rdpName", "someRdp");
         if (valid) {
             data.put("restConsumerName", "someRestConsumerName");
+        }
+        parameters.put(SEMP_DELETE_DATA, data);
+        return parameters;
+    }
+
+    private Map<String, Object> createDeleteRdpQueueBindingParameters(boolean valid) {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(SEMP_DELETE_ENTITY_TYPE, solaceRdpQueueBinding.name());
+
+        Map<String, String> data = new HashMap<>();
+        data.put("msgVpn", "default");
+        data.put("rdpName", "someRdp");
+        if (valid) {
+            data.put("queueBindingName", "someQueueBindingName");
+        }
+        parameters.put(SEMP_DELETE_DATA, data);
+        return parameters;
+    }
+
+    private Map<String, Object> createDeleteRdpQueueBindingRequestHeaderParameters(boolean valid, boolean isProtected) {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(SEMP_DELETE_ENTITY_TYPE, isProtected ? solaceRdpQueueBindingProtectedRequestHeader.name() : solaceRdpQueueBindingRequestHeader.name());
+
+        Map<String, String> data = new HashMap<>();
+        data.put("msgVpn", "default");
+        data.put("rdpName", "someRdp");
+        if (valid) {
+            data.put("queueBindingName", "someQueueBindingName");
+            data.put("headerName", "someHeaderName");
+            data.put("isProtected", isProtected ? "true" : "false");
         }
         parameters.put(SEMP_DELETE_DATA, data);
         return parameters;

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/commandManager/SempDeleteCommandManagerTest.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/commandManager/SempDeleteCommandManagerTest.java
@@ -736,7 +736,8 @@ public class SempDeleteCommandManagerTest {
     void testNotFoundDeleteRdpQueueBindingRequestHeader() throws ApiException {
         RestDeliveryPointApi rdpApi = Mockito.mock(RestDeliveryPointApi.class);
         when(sempApiProvider.getRestDeliveryPointApi()).thenReturn(rdpApi);
-        when((rdpApi).deleteMsgVpnRestDeliveryPointQueueBindingRequestHeader(any(), any(), any(), any())).thenThrow(createaNotFoundApiException(SEMP_RESPONSE_MISSING_RESOURCE));
+        when((rdpApi).deleteMsgVpnRestDeliveryPointQueueBindingRequestHeader(any(), any(), any(), any()))
+                .thenThrow(createaNotFoundApiException(SEMP_RESPONSE_MISSING_RESOURCE));
         Command cmd = Command.builder()
                 .commandType(CommandType.semp)
                 .command(SEMP_DELETE_OPERATION)
@@ -797,7 +798,8 @@ public class SempDeleteCommandManagerTest {
     void testNotFoundDeleteRdpQueueBindingProtectedRequestHeader() throws ApiException {
         RestDeliveryPointApi rdpApi = Mockito.mock(RestDeliveryPointApi.class);
         when(sempApiProvider.getRestDeliveryPointApi()).thenReturn(rdpApi);
-        when((rdpApi).deleteMsgVpnRestDeliveryPointQueueBindingProtectedRequestHeader(any(), any(), any(), any())).thenThrow(createaNotFoundApiException(SEMP_RESPONSE_MISSING_RESOURCE));
+        when((rdpApi).deleteMsgVpnRestDeliveryPointQueueBindingProtectedRequestHeader(any(), any(), any(), any()))
+                .thenThrow(createaNotFoundApiException(SEMP_RESPONSE_MISSING_RESOURCE));
         Command cmd = Command.builder()
                 .commandType(CommandType.semp)
                 .command(SEMP_DELETE_OPERATION)


### PR DESCRIPTION
### What is the purpose of this change?

SEMP delete RDP queue bindings and queue binding request headers & protected request headers.

### How was this change implemented?

When a SEMP delete command comes into the EMA, if the type is a queue binding or request header, we pick out the data that identifies the broker resource and pass that along to the SEMP API to delete the resource.

### How was this change tested?

Unit tests in the PR: validating exceptions thrown and validating that the SEMP API is called with the right parameters when the command is given.
Practical testing locally with an S-EMA and deployed brokers.

### Is there anything the reviewers should focus on/be aware of?

None
