### PR TITLE
DATAGO-99254: Fix SEMP delete when TLS verification is disabled

### DIFF
--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/CommandManager.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/CommandManager.java
@@ -73,7 +73,6 @@ public class CommandManager {
         this.commandMapper = commandMapper;
         this.commandPublisher = commandPublisher;
         this.messagingServiceDelegateService = messagingServiceDelegateService;
-        log.info("Crushton: CommandManager eventPortalProperties: {}", eventPortalProperties);
         this.eventPortalProperties = eventPortalProperties;
         this.meterRegistry = meterRegistry;
 
@@ -241,7 +240,6 @@ public class CommandManager {
             Validate.isTrue(command.getCommand().equals(SEMP_DELETE_OPERATION), "Command operation must be delete");
             // creating a new SempApiProviderImpl instance for each command execution
             // if this becomes a performance issue, we can consider caching the SempApiProviderImpl instance for each serviceId
-            log.info("Crushton: CommandManager creating SempApiProvicerImpl eventPortalProperties: {}", eventPortalProperties);
             sempDeleteCommandManager.execute(command, new SempApiProviderImpl(solaceClient, eventPortalProperties));
         } catch (Exception e) {
             log.error(ERROR_EXECUTING_COMMAND, e);

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/CommandManager.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/CommandManager.java
@@ -73,6 +73,7 @@ public class CommandManager {
         this.commandMapper = commandMapper;
         this.commandPublisher = commandPublisher;
         this.messagingServiceDelegateService = messagingServiceDelegateService;
+        log.info("Crushton: CommandManager eventPortalProperties: {}", eventPortalProperties);
         this.eventPortalProperties = eventPortalProperties;
         this.meterRegistry = meterRegistry;
 
@@ -240,6 +241,7 @@ public class CommandManager {
             Validate.isTrue(command.getCommand().equals(SEMP_DELETE_OPERATION), "Command operation must be delete");
             // creating a new SempApiProviderImpl instance for each command execution
             // if this becomes a performance issue, we can consider caching the SempApiProviderImpl instance for each serviceId
+            log.info("Crushton: CommandManager creating SempApiProvicerImpl eventPortalProperties: {}", eventPortalProperties);
             sempDeleteCommandManager.execute(command, new SempApiProviderImpl(solaceClient, eventPortalProperties));
         } catch (Exception e) {
             log.error(ERROR_EXECUTING_COMMAND, e);

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/semp/SempApiProviderImpl.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/semp/SempApiProviderImpl.java
@@ -16,7 +16,6 @@ import lombok.extern.slf4j.Slf4j;
 public class SempApiProviderImpl implements SempApiProvider {
 
     private final ApiClient apiClient;
-    private final EventPortalProperties eventPortalProperties;
     private AclProfileApi aclProfileApi;
     private AuthorizationGroupApi authorizationGroupApi;
     private ClientUsernameApi clientUsernameApi;
@@ -25,9 +24,7 @@ public class SempApiProviderImpl implements SempApiProvider {
 
     public SempApiProviderImpl(SolaceHttpSemp solaceClient,
                                EventPortalProperties eventPortalProperties) {
-        log.info("Crushton: SempApiProvider eventPortalProperties: {}", eventPortalProperties);
-        this.apiClient = setupApiClient(solaceClient);
-        this.eventPortalProperties = eventPortalProperties;
+        this.apiClient = setupApiClient(solaceClient, eventPortalProperties);
     }
 
     @Override
@@ -62,15 +59,15 @@ public class SempApiProviderImpl implements SempApiProvider {
         return queueApi;
     }
 
-    private ApiClient setupApiClient(SolaceHttpSemp solaceClient) {
+    private ApiClient setupApiClient(SolaceHttpSemp solaceClient, EventPortalProperties eventPortalProperties) {
         SempClient sempClient = solaceClient.getSempClient();
         ApiClient client = new ApiClient();
         client.setBasePath(sempClient.getConnectionUrl() + "/SEMP/v2/config");
         client.setUsername(sempClient.getUsername());
         client.setPassword(sempClient.getPassword());
-        boolean verifyTls = this.eventPortalProperties == null || !this.eventPortalProperties.getSkipTlsVerify();
+        boolean verifyTls = eventPortalProperties == null || !eventPortalProperties.getSkipTlsVerify();
         log.info("SetVerifyingSsl on SEMP client: {} (application properties skipTlsVerify: {})", verifyTls,
-                this.eventPortalProperties == null ? "false (null properties)" : this.eventPortalProperties.getSkipTlsVerify());
+                eventPortalProperties == null ? "false (null properties)" : eventPortalProperties.getSkipTlsVerify());
         client.setVerifyingSsl(verifyTls);
         return client;
     }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/semp/SempApiProviderImpl.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/semp/SempApiProviderImpl.java
@@ -68,8 +68,8 @@ public class SempApiProviderImpl implements SempApiProvider {
         client.setUsername(sempClient.getUsername());
         client.setPassword(sempClient.getPassword());
         boolean verifyTls = eventPortalProperties == null || !eventPortalProperties.getSkipTlsVerify();
-        log.debug("SetVerifyingSsl? {} (application properties skipTlsVerify: {})", verifyTls,
-                eventPortalProperties == null ? "false" : eventPortalProperties.getSkipTlsVerify());
+        log.info("SetVerifyingSsl on SEMP client: {} (application properties skipTlsVerify: {})", verifyTls,
+                eventPortalProperties == null ? "false (null properties)" : eventPortalProperties.getSkipTlsVerify());
         client.setVerifyingSsl(verifyTls);
         return client;
     }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/semp/SempApiProviderImpl.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/semp/SempApiProviderImpl.java
@@ -68,9 +68,9 @@ public class SempApiProviderImpl implements SempApiProvider {
         client.setBasePath(sempClient.getConnectionUrl() + "/SEMP/v2/config");
         client.setUsername(sempClient.getUsername());
         client.setPassword(sempClient.getPassword());
-        boolean verifyTls = eventPortalProperties == null || !eventPortalProperties.getSkipTlsVerify();
+        boolean verifyTls = this.eventPortalProperties == null || !this.eventPortalProperties.getSkipTlsVerify();
         log.info("SetVerifyingSsl on SEMP client: {} (application properties skipTlsVerify: {})", verifyTls,
-                eventPortalProperties == null ? "false (null properties)" : eventPortalProperties.getSkipTlsVerify());
+                this.eventPortalProperties == null ? "false (null properties)" : this.eventPortalProperties.getSkipTlsVerify());
         client.setVerifyingSsl(verifyTls);
         return client;
     }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/semp/SempApiProviderImpl.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/semp/SempApiProviderImpl.java
@@ -25,6 +25,7 @@ public class SempApiProviderImpl implements SempApiProvider {
 
     public SempApiProviderImpl(SolaceHttpSemp solaceClient,
                                EventPortalProperties eventPortalProperties) {
+        log.info("Crushton: SempApiProvider eventPortalProperties: {}", eventPortalProperties);
         this.apiClient = setupApiClient(solaceClient);
         this.eventPortalProperties = eventPortalProperties;
     }


### PR DESCRIPTION
### What is the purpose of this change?

Fix an issue where SEMP deletes were not working on brokers that have a certificate because we are not disabling verification properly.

### How was this change implemented?

Set the properties before setting up the client.

### How was this change tested?

Deploying and running the EMA in a dev environment. Doing a config push, scan, and config delete.

### Is there anything the reviewers should focus on/be aware of?

None
