### PR TITLE
DATAGO-99254: Improve TLS logging

### DIFF
--- a/.github/workflows/deploy-dev-managed-ema-image.yaml
+++ b/.github/workflows/deploy-dev-managed-ema-image.yaml
@@ -7,9 +7,12 @@ on:
         required: true
         default: "A.B.C"
       buildNewDevImage:
-        description: "true/false. Set to 'true' to build a new image, otherwise, we'll pull the 'main' image from ECR."
-        required: false
-        default: "false"
+        description: "Set to 'true' to build a new image, otherwise, we'll pull the 'main' image from ECR."
+        required: true
+        type: choice
+        options:
+          - "false"
+          - "true"
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/CommandManager.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/CommandManager.java
@@ -121,6 +121,10 @@ public class CommandManager {
             // It will delete all files in the directory of this context
             terraformManager.deleteTerraformState(request);
 
+            if (Boolean.TRUE.equals(eventPortalProperties.getSkipTlsVerify())) {
+                log.info("Skipping TLS verification for config push to serviceId {}.", request.getServiceId());
+            }
+
             for (CommandBundle bundle : request.getCommandBundles()) {
                 boolean exitEarlyOnFailedCommand = bundle.getExitOnFailure();
                 // For now everything is run serially

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/semp/SempApiProviderImpl.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/semp/SempApiProviderImpl.java
@@ -65,10 +65,7 @@ public class SempApiProviderImpl implements SempApiProvider {
         client.setBasePath(sempClient.getConnectionUrl() + "/SEMP/v2/config");
         client.setUsername(sempClient.getUsername());
         client.setPassword(sempClient.getPassword());
-        boolean verifyTls = eventPortalProperties == null || !eventPortalProperties.getSkipTlsVerify();
-        log.info("SetVerifyingSsl on SEMP client: {} (application properties skipTlsVerify: {})", verifyTls,
-                eventPortalProperties == null ? "false (null properties)" : eventPortalProperties.getSkipTlsVerify());
-        client.setVerifyingSsl(verifyTls);
+        client.setVerifyingSsl(eventPortalProperties == null || !eventPortalProperties.getSkipTlsVerify());
         return client;
     }
 

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/messageProcessors/ScanCommandMessageProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/messageProcessors/ScanCommandMessageProcessor.java
@@ -93,6 +93,9 @@ public class ScanCommandMessageProcessor implements MessageProcessor<ScanCommand
                 .build();
 
         log.info("Received scan request {}. Request details: {}", scanRequestBO.getScanId(), scanRequestBO);
+        if (Boolean.TRUE.equals(eventPortalProperties.getSkipTlsVerify())) {
+            log.info("Skipping TLS verification for scan request {}.", scanRequestBO.getScanId());
+        }
 
         scanManager.scan(scanRequestBO);
         //if managed, wait for scan to complete

--- a/service/solace-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/solace/manager/client/SolaceSempClientManagerImpl.java
+++ b/service/solace-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/solace/manager/client/SolaceSempClientManagerImpl.java
@@ -39,7 +39,7 @@ public class SolaceSempClientManagerImpl implements MessagingServiceClientManage
                         });
         WebClient.Builder webClient = WebClient.builder();
         if (Boolean.TRUE.equals(connectionDetailsEvent.getSkipTlsVerify())) {
-            log.info("Skipping TLS verification for Solace SEMP client.");
+            log.info("Skipping TLS verification for new Solace SEMP client.");
             webClient.clientConnector(new ReactorClientHttpConnector(HttpClient.create().secure(t -> {
                         try {
                             t.sslContext(SslContextBuilder.forClient()


### PR DESCRIPTION
### What is the purpose of this change?

Improve logging when TLS is disabled.

### How was this change implemented?

Remove lower level logs on client creation except for scans when a new client is created for the first time since EMA startup. There is only one log for config push and one for scan + the new client creation log.
Internal discussion with practical examples can be found here https://solacedotcom.slack.com/archives/C012V9XLFQQ/p1744818751134579

### How was this change tested?

By deploying the EMA to a dev environment and running config push and scan + config push with SEMP deletes.

### Is there anything the reviewers should focus on/be aware of?

None
