### PR TITLE
DATAGO-83325: Add x-b3-traceid to MDC

### DIFF
--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/scanManager/ScanManager.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/scanManager/ScanManager.java
@@ -67,6 +67,7 @@ public class ScanManager {
 
         MDC.put(RouteConstants.SCAN_ID, scanId);
         MDC.put(RouteConstants.TRACE_ID, traceId);
+        MDC.put(RouteConstants.X_B_3_TRACE_ID, traceId);
         MDC.put(RouteConstants.ACTOR_ID, actorId);
         MDC.put(RouteConstants.SCHEDULE_ID, groupId);
         MDC.put(RouteConstants.ORG_ID, scanRequestBO.getOrgId());

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ScanService.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ScanService.java
@@ -292,6 +292,7 @@ public class ScanService {
             MDC.put(RouteConstants.SCAN_ID, scanId);
             MDC.put(RouteConstants.ORG_ID, orgId);
             MDC.put(RouteConstants.TRACE_ID, traceId);
+            MDC.put(RouteConstants.X_B_3_TRACE_ID, traceId);
             MDC.put(RouteConstants.ACTOR_ID, actorId);
             MDC.put(RouteConstants.MESSAGING_SERVICE_ID, messagingServiceId);
 

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/BaseSolaceMessageHandler.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/BaseSolaceMessageHandler.java
@@ -46,6 +46,7 @@ public abstract class BaseSolaceMessageHandler {
 
         MDC.clear();
         MDC.put(RouteConstants.TRACE_ID, map.get("traceId"));
+        MDC.put(RouteConstants.X_B_3_TRACE_ID, map.get("traceId"));
         MDC.put(RouteConstants.ACTOR_ID, map.get("actorId"));
 
         if (scanClassNames.contains(receivedClassName)) {

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/constants/RouteConstants.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/constants/RouteConstants.java
@@ -11,6 +11,7 @@ public class RouteConstants {
     public static final String ORG_ID = "ORG_ID";
 
     public static final String TRACE_ID = "traceId";
+    public static final String X_B_3_TRACE_ID = "X-B3-TraceId";
 
     public static final String ACTOR_ID = "ACTOR_ID";
 

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/processor/logging/MDCProcessor.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/processor/logging/MDCProcessor.java
@@ -19,6 +19,9 @@ public class MDCProcessor implements Processor {
         MDC.put(RouteConstants.TRACE_ID,
                 exchange.getIn().getHeader(RouteConstants.TRACE_ID, String.class));
 
+        MDC.put(RouteConstants.X_B_3_TRACE_ID,
+                exchange.getIn().getHeader(RouteConstants.TRACE_ID, String.class));
+
         MDC.put(RouteConstants.ORG_ID,
                 exchange.getIn().getHeader(RouteConstants.ORG_ID, String.class));
 


### PR DESCRIPTION
### What is the purpose of this change?
To enhance the observability of C-EMA logging

### How was this change implemented?
Added X-B3-TraceId to MDC in EMA

### How was this change tested?
Built the EMA image and ran it as a C-EMA in ep-perf. Then observed the DD logs:
<img width="1489" alt="Screenshot 2025-04-26 at 18 35 21" src="https://github.com/user-attachments/assets/2f5d3ebb-55ed-4b12-8160-6dfce51476c1" />
<img width="1493" alt="Screenshot 2025-04-26 at 18 31 43" src="https://github.com/user-attachments/assets/0874995f-8fc9-4a22-85d4-754b7b7cbc15" />


### Is there anything the reviewers should focus on/be aware of?

    ...
