### PR TITLE
DATAGO-101453: Implement SEMP GET command and Pre-Flight validation (WIP)

### DIFF
--- a/service/application/src/main/java/com/solace/maas/ep/common/model/SempClientProfileValidationRequest.java
+++ b/service/application/src/main/java/com/solace/maas/ep/common/model/SempClientProfileValidationRequest.java
@@ -1,0 +1,11 @@
+package com.solace.maas.ep.common.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class SempClientProfileValidationRequest {
+    private String msgVpn;
+    private String clientProfileName;
+}

--- a/service/application/src/main/java/com/solace/maas/ep/common/model/SempEntityType.java
+++ b/service/application/src/main/java/com/solace/maas/ep/common/model/SempEntityType.java
@@ -13,6 +13,7 @@ public enum SempEntityType {
     solaceAclPublishTopicException("solaceAclPublishTopicException"),
     solaceClientUsername("solaceClientUsername"),
     solaceClientCertificateUsername("solaceClientCertificateUsername"),
+    solaceClientProfile("solaceClientProfile"),
     solaceAuthorizationGroup("solaceAuthorizationGroup"),
     solaceQueueSubscriptionTopic("solaceQueueSubscriptionTopic");
     private final String value;

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/AbstractSempCommandManager.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/AbstractSempCommandManager.java
@@ -40,7 +40,7 @@ public abstract class AbstractSempCommandManager {
     protected abstract void executeSempCommand(Command command, SempApiProvider sempApiProvider) throws Exception;
 
 
-    private void validate(Command command, SempApiProvider sempApiProvider) {
+    public void validate(Command command, SempApiProvider sempApiProvider) {
         Validate.isTrue(command.getCommand().equals(supportedSempCommand()), "Command must be " + supportedSempCommand());
         Validate.isTrue(command.getCommandType().equals(CommandType.semp), "Command type must be semp");
         Validate.notNull(sempApiProvider, "SempApiProvider must not be null");

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/SempGetCommandManager.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/SempGetCommandManager.java
@@ -1,0 +1,150 @@
+package com.solace.maas.ep.event.management.agent.command;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.solace.client.sempv2.ApiException;
+import com.solace.client.sempv2.api.ClientProfileApi;
+import com.solace.maas.ep.common.model.SempClientProfileValidationRequest;
+import com.solace.maas.ep.common.model.SempEntityType;
+import com.solace.maas.ep.event.management.agent.command.semp.SempApiProvider;
+import com.solace.maas.ep.event.management.agent.plugin.command.model.Command;
+import com.solace.maas.ep.event.management.agent.plugin.command.model.CommandResult;
+import com.solace.maas.ep.event.management.agent.plugin.command.model.FailureSeverity;
+import com.solace.maas.ep.event.management.agent.plugin.command.model.JobStatus;
+import com.solace.maas.ep.event.management.agent.plugin.command.model.SempCommandConstants;
+import lombok.extern.slf4j.Slf4j;
+import net.logstash.logback.encoder.org.apache.commons.lang3.Validate;
+import org.springframework.stereotype.Service;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static com.solace.maas.ep.event.management.agent.plugin.terraform.manager.TerraformUtils.setCommandError;
+
+@Service
+@Slf4j
+public class SempGetCommandManager extends AbstractSempCommandManager {
+    private final ObjectMapper objectMapper;
+
+    public SempGetCommandManager(ObjectMapper objectMapper) {
+        super();
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public String supportedSempCommand() {
+        return SempCommandConstants.SEMP_GET_OPERATION;
+    }
+
+    /**
+     * Overrides the execute method to handle the pre-flight check with special logic for warnings
+     */
+    @Override
+    public void execute(Command command, SempApiProvider sempApiProvider) {
+        try {
+            validate(command, sempApiProvider);
+            executeSempCommand(command, sempApiProvider);
+            // If we get here, the get operation was successful
+            command.setResult(CommandResult.builder()
+                    .status(JobStatus.success)
+                    .logs(List.of(Map.of(
+                            "message", "Resource found",
+                            "level", "INFO",
+                            "timestamp", OffsetDateTime.now()
+                    )))
+                    .build());
+        } catch (ApiException e) {
+            // For 404 errors in a pre-flight check, use warning instead of error when appropriate
+            if (e.getCode() == 404 || (e.getCode() == 400 && e.getResponseBody().contains("NOT_FOUND"))) {
+                if (Boolean.TRUE.equals(command.getIsPreFlightCheck()) &&
+                        command.getFailureSeverity() == FailureSeverity.WARNING) {
+                    // Extract client profile name for better error messaging
+                    String resourceName = extractResourceName(command);
+                    log.warn("Pre-flight check: Resource not found: {}", resourceName);
+                    command.setResult(CommandResult.builder()
+                            .status(JobStatus.warning)
+                            .logs(List.of(Map.of(
+                                    "message", "Required resource not found: " + resourceName,
+                                    "level", "WARN",
+                                    "timestamp", OffsetDateTime.now()
+                            )))
+                            .build());
+                    return;
+                }
+            }
+            log.error("SEMP {} command not executed successfully", supportedSempCommand(), e);
+            // Set error for all other API exceptions
+            setCommandError(command, e);
+        } catch (Exception e) {
+            log.error("SEMP {} command not executed successfully", supportedSempCommand(), e);
+            setCommandError(command, e);
+        }
+    }
+
+    /**
+     * Extracts the resource name from the command for better error messages
+     */
+    private String extractResourceName(Command command) {
+        try {
+            Object data = command.getParameters().get(SempCommandConstants.SEMP_COMMAND_DATA);
+            if (data != null) {
+                // Convert to string and parse as SempClientProfileValidationRequest
+                SempClientProfileValidationRequest request = objectMapper.readValue(
+                        objectMapper.writeValueAsString(data),
+                        SempClientProfileValidationRequest.class);
+                return request.getClientProfileName();
+            }
+        } catch (Exception e) {
+            log.warn("Failed to extract resource name from command", e);
+        }
+        return "unknown";
+    }
+
+    @Override
+    protected void executeSempCommand(Command command, SempApiProvider sempApiProvider) throws Exception {
+        String entityType = (String) command.getParameters().get(SempCommandConstants.SEMP_COMMAND_ENTITY_TYPE);
+        SempEntityType getEntityType;
+
+        if (entityType == null) {
+            throw new IllegalArgumentException("Entity type of a SEMP get command must not be null");
+        }
+
+        try {
+            getEntityType = SempEntityType.valueOf(entityType);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Unsupported SEMP get entity type: " + entityType);
+        }
+
+        switch (getEntityType) {
+            case solaceClientProfile:
+                executeGetClientProfile(command, sempApiProvider);
+                break;
+            default:
+                throw new UnsupportedOperationException("Unsupported entity type for get: " + getEntityType);
+        }
+    }
+
+    private void executeGetClientProfile(Command command, SempApiProvider sempApiProvider) throws ApiException, JsonProcessingException {
+        ClientProfileApi clientProfileApi = sempApiProvider.getClientProfileApi();
+
+        SempClientProfileValidationRequest request = objectMapper.readValue(
+                objectMapper.writeValueAsString(command.getParameters().get(SempCommandConstants.SEMP_COMMAND_DATA)),
+                SempClientProfileValidationRequest.class);
+
+        Validate.notEmpty(request.getMsgVpn(), MSG_VPN_EMPTY_ERROR_MSG);
+        Validate.notEmpty(request.getClientProfileName(), "Client profile name must not be empty");
+
+        log.info("SEMP get: Checking client profile existence");
+
+        // This will throw ApiException if the client profile doesn't exist
+        clientProfileApi.getMsgVpnClientProfile(
+                request.getMsgVpn(),
+                request.getClientProfileName(),
+                null,  // select
+                null   // opaquePassword
+        );
+
+        // If we get here, the client profile exists
+    }
+}

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/semp/SempApiProvider.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/semp/SempApiProvider.java
@@ -2,6 +2,7 @@ package com.solace.maas.ep.event.management.agent.command.semp;
 
 import com.solace.client.sempv2.api.AclProfileApi;
 import com.solace.client.sempv2.api.AuthorizationGroupApi;
+import com.solace.client.sempv2.api.ClientProfileApi;
 import com.solace.client.sempv2.api.ClientUsernameApi;
 import com.solace.client.sempv2.api.QueueApi;
 import com.solace.client.sempv2.api.RestDeliveryPointApi;
@@ -9,9 +10,15 @@ import com.solace.client.sempv2.api.RestDeliveryPointApi;
 public interface SempApiProvider {
 
     AclProfileApi getAclProfileApi();
+
     AuthorizationGroupApi getAuthorizationGroupApi();
+
     ClientUsernameApi getClientUsernameApi();
+
     QueueApi getQueueApi();
+
     RestDeliveryPointApi getRestDeliveryPointApi();
+
+    ClientProfileApi getClientProfileApi();
 
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/semp/SempApiProviderImpl.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/semp/SempApiProviderImpl.java
@@ -3,6 +3,7 @@ package com.solace.maas.ep.event.management.agent.command.semp;
 import com.solace.client.sempv2.ApiClient;
 import com.solace.client.sempv2.api.AclProfileApi;
 import com.solace.client.sempv2.api.AuthorizationGroupApi;
+import com.solace.client.sempv2.api.ClientProfileApi;
 import com.solace.client.sempv2.api.ClientUsernameApi;
 import com.solace.client.sempv2.api.QueueApi;
 import com.solace.client.sempv2.api.RestDeliveryPointApi;
@@ -21,10 +22,11 @@ public class SempApiProviderImpl implements SempApiProvider {
     private ClientUsernameApi clientUsernameApi;
     private QueueApi queueApi;
     private RestDeliveryPointApi restDeliveryPointApi;
+    private ClientProfileApi clientProfileApi;
 
     public SempApiProviderImpl(SolaceHttpSemp solaceClient,
                                EventPortalProperties eventPortalProperties) {
-        this.apiClient = setupApiClient(solaceClient, eventPortalProperties);
+        apiClient = setupApiClient(solaceClient, eventPortalProperties);
     }
 
     @Override
@@ -57,6 +59,14 @@ public class SempApiProviderImpl implements SempApiProvider {
             queueApi = new QueueApi(apiClient);
         }
         return queueApi;
+    }
+
+    @Override
+    public ClientProfileApi getClientProfileApi() {
+        if (clientProfileApi == null) {
+            clientProfileApi = new ClientProfileApi(apiClient);
+        }
+        return clientProfileApi;
     }
 
     private ApiClient setupApiClient(SolaceHttpSemp solaceClient, EventPortalProperties eventPortalProperties) {

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/TestConfig.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/TestConfig.java
@@ -2,6 +2,7 @@ package com.solace.maas.ep.event.management.agent;
 
 import com.solace.maas.ep.event.management.agent.command.CommandManager;
 import com.solace.maas.ep.event.management.agent.command.SempDeleteCommandManager;
+import com.solace.maas.ep.event.management.agent.command.SempGetCommandManager;
 import com.solace.maas.ep.event.management.agent.command.SempPatchCommandManager;
 import com.solace.maas.ep.event.management.agent.command.mapper.CommandMapper;
 import com.solace.maas.ep.event.management.agent.config.SolaceConfiguration;
@@ -175,7 +176,8 @@ public class TestConfig {
                                             MeterRegistry meterRegistry,
                                             SempDeleteCommandManager sempDeleteCommandManager,
                                             TerraformLogProcessingService terraformLogProcessingService,
-                                            SempPatchCommandManager sempPatchCommandManager) {
+                                            SempPatchCommandManager sempPatchCommandManager,
+                                            SempGetCommandManager sempGetCommandManager) {
         return new CommandManager(
                 terraformManager,
                 commandMapper,
@@ -186,8 +188,8 @@ public class TestConfig {
                 meterRegistry,
                 sempDeleteCommandManager,
                 terraformLogProcessingService,
-                sempPatchCommandManager
-
+                sempPatchCommandManager,
+                sempGetCommandManager
         );
     }
 

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/command/model/Command.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/command/model/Command.java
@@ -19,6 +19,9 @@ public class Command {
     private Map<String, Object> parameters;
     private Boolean ignoreResult;
     private CommandResult result;
+    private Boolean isPreFlightCheck = false;
+    private PreFlightCheckType preFlightCheckType;
+    private FailureSeverity failureSeverity = FailureSeverity.ERROR;
 
     public boolean hasSignificantErrorResult() {
         if (!Boolean.TRUE.equals(ignoreResult) && result != null) {

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/command/model/CommandBundle.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/command/model/CommandBundle.java
@@ -15,4 +15,5 @@ public class CommandBundle {
     private ExecutionType executionType;
     private Boolean exitOnFailure;
     private List<Command> commands;
+    private Boolean isPreFlightBundle = false;
 }

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/command/model/FailureSeverity.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/command/model/FailureSeverity.java
@@ -1,0 +1,6 @@
+package com.solace.maas.ep.event.management.agent.plugin.command.model;
+
+public enum FailureSeverity {
+    ERROR, // Default, will abort the job
+    WARNING // Will log a warning but allow the job to continue -> TODO: should also abort the job
+}

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/command/model/JobStatus.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/command/model/JobStatus.java
@@ -4,7 +4,9 @@ public enum JobStatus {
     in_progress,
     error,
     validation_error,
+    warning,
     success;
+
 
     JobStatus() {
     }

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/command/model/PreFlightCheckType.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/command/model/PreFlightCheckType.java
@@ -1,0 +1,6 @@
+package com.solace.maas.ep.event.management.agent.plugin.command.model;
+
+public enum PreFlightCheckType {
+    CLIENT_PROFILE_EXISTENCE,
+    // Add other types as needed
+}

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/command/model/SempCommandConstants.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/command/model/SempCommandConstants.java
@@ -5,4 +5,5 @@ public class SempCommandConstants {
     public static final String SEMP_COMMAND_DATA = "data";
     public static final String SEMP_DELETE_OPERATION = "delete";
     public static final String SEMP_PATCH_OPERATION = "patch";
+    public static final String SEMP_GET_OPERATION = "get";
 }

--- a/service/terraform-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/terraform/manager/TerraformUtils.java
+++ b/service/terraform-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/terraform/manager/TerraformUtils.java
@@ -30,6 +30,7 @@ public class TerraformUtils {
     private static final Object lock = new Object(); // A lock object for synchronization
 
     public static final String LOG_LEVEL_ERROR = "ERROR";
+    public static final String LOG_LEVEL_WARN = "WARN";
     private static final String DEFAULT_TF_CONFIG_FILENAME = "config.tf";
     public static final String CONTENT_ENCODING = "Content-Encoding";
 
@@ -60,6 +61,17 @@ public class TerraformUtils {
                         Map.of("message", e.getMessage(),
                                 "errorType", e.getClass().getName(),
                                 "level", LOG_LEVEL_ERROR,
+                                "timestamp", OffsetDateTime.now())))
+                .build());
+    }
+
+    public static void setPreFlightCheckWarning(Command command, Exception e) {
+        command.setResult(CommandResult.builder()
+                .status(JobStatus.warning)
+                .logs(List.of(
+                        Map.of("message", e.getMessage(),
+                                "errorType", e.getClass().getName(),
+                                "level", LOG_LEVEL_WARN,
                                 "timestamp", OffsetDateTime.now())))
                 .build());
     }


### PR DESCRIPTION
### What is the purpose of this change?

Introduce SEMP GET command and Pre-Flight validation on client profile

### How was this change implemented?

  - Added SempClientProfileValidationRequest model for client profile validation.
  - Introduced SempGetCommandManager to handle SEMP GET operations.
  - Updated CommandManager to support new SEMP GET operation.
  - Enhanced SempApiProvider and SempApiProviderImpl to include ClientProfileApi.
  - Added pre-flight check handling in TerraformManager and TerraformLogProcessingService.
  - Introduced FailureSeverity and PreFlightCheckType enums for better error handling.
  - Updated Command and CommandBundle models to support pre-flight checks.

### How was this change tested?

IT & manual (WIP)

### Is there anything the reviewers should focus on/be aware of?

not yet
