### PR TITLE
DATAGO-100834: webProxyEnabled tag for EMA metrics

### DIFF
--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/config/MetricsConfig.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/config/MetricsConfig.java
@@ -1,0 +1,31 @@
+package com.solace.maas.ep.event.management.agent.config;
+
+import com.solace.maas.ep.event.management.agent.plugin.jacoco.ExcludeFromJacocoGeneratedReport;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Slf4j
+@ExcludeFromJacocoGeneratedReport
+@Configuration
+@Profile("!TEST")
+@ConditionalOnProperty(name = "event-portal.gateway.messaging.standalone", havingValue = "false")
+public class MetricsConfig {
+
+    private final SolaceConfiguration solaceConfiguration;
+
+    @Autowired
+    public MetricsConfig(SolaceConfiguration solaceConfiguration) {
+        this.solaceConfiguration = solaceConfiguration;
+    }
+
+    @Bean
+    public MeterRegistryCustomizer<MeterRegistry> metricsCommonTags() {
+        return registry -> registry.config().commonTags("ema_web_proxy_enabled", String.valueOf(solaceConfiguration.isProxyEnabled()));
+    }
+}

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/config/SolaceConfiguration.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/config/SolaceConfiguration.java
@@ -73,7 +73,7 @@ public class SolaceConfiguration {
         String clientName = vmrConfiguration.getProperty(SolaceProperties.ClientProperties.NAME);
         String message = isProxyEnabled() ?
                 "Connecting to event portal using EMA client {} via web proxy." :
-                "Connecting to event portal using EMA client {} without proxy.";
+                "Connecting to event portal using EMA client {} without web proxy.";
         log.info(message, clientName);
         return MessagingService.builder(ConfigurationProfile.V1)
                 .fromProperties(vmrConfiguration)
@@ -123,13 +123,17 @@ public class SolaceConfiguration {
                 directMessagePublisher());
     }
 
-    private boolean isProxyEnabled() {
+    public boolean isProxyEnabled() {
         MessagingServiceConnectionProperties gatewayConnection = eventPortalProperties.getGateway().getMessaging().getConnections().stream()
                 .filter(c -> "eventPortalGateway".equals(c.getName()))
                 .findFirst()
                 .orElseThrow(() -> new NoSuchElementException("Event Portal gateway connection properties not found."));
 
         return (Boolean.TRUE.equals(gatewayConnection.getProxyEnabled()));
+    }
+
+    public String getRuntimeAgentId() {
+        return eventPortalProperties.getRuntimeAgentId();
     }
 
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/config/SolaceConfiguration.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/config/SolaceConfiguration.java
@@ -131,9 +131,4 @@ public class SolaceConfiguration {
 
         return (Boolean.TRUE.equals(gatewayConnection.getProxyEnabled()));
     }
-
-    public String getRuntimeAgentId() {
-        return eventPortalProperties.getRuntimeAgentId();
-    }
-
 }


### PR DESCRIPTION
### What is the purpose of this change?
To introduce new tag for webProxyEnabled and enhance our C-EMA observability dashboard.

### How was this change implemented?
- Added new tag webProxyEnabled
- Added some tags to the MAAS_EMA_HEARTBEAT_EVENT_SENT metrics so we can merge it with an ep-core metric regarding the EP connectivity to C-EMAs.

### How was this change tested?
on the DD dev account I verified the changes.
Screenshots are mentioned in this [maas-monitoring-agent PR](https://github.com/SolaceDev/maas-monitoring-agent/pull/558) 

### Is there anything the reviewers should focus on/be aware of?
Nope
