### PR TITLE
DATAGO-102788: Accept broker URLs with extended SempUri path

### DIFF
--- a/service/solace-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/solace/processor/semp/SolaceHttpSemp.java
+++ b/service/solace-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/solace/processor/semp/SolaceHttpSemp.java
@@ -125,14 +125,14 @@ public class SolaceHttpSemp {
         return sempObject;
     }
 
-    private Function<UriBuilder, URI> createUriBuilderFunction(String uriPath,
-                                                               Map<String, String> substitutionMap,
-                                                               String selectFields) {
+    public Function<UriBuilder, URI> createUriBuilderFunction(String uriPath,
+                                                              Map<String, String> substitutionMap,
+                                                              String selectFields) {
         URI sempUri = getSempUri();
 
         if (StringUtils.isNotEmpty(selectFields)) {
             return (uriBuilder) -> uriBuilder
-                    .path(uriPath)
+                    .path(sempUri.getPath() + uriPath)
                     .queryParam("select", selectFields)
                     .host(sempUri.getHost())
                     .port(sempUri.getPort())
@@ -142,7 +142,7 @@ public class SolaceHttpSemp {
         }
 
         return (uriBuilder) -> uriBuilder
-                .path(uriPath)
+                .path(sempUri.getPath() + uriPath)
                 .host(sempUri.getHost())
                 .port(sempUri.getPort())
                 .scheme(sempUri.getScheme())

--- a/service/solace-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/solace/processor/SolaceHttpSempTest.java
+++ b/service/solace-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/solace/processor/SolaceHttpSempTest.java
@@ -1,0 +1,56 @@
+package com.solace.maas.ep.event.management.agent.plugin.solace.processor;
+
+import com.solace.maas.ep.event.management.agent.plugin.solace.processor.semp.SempClient;
+import com.solace.maas.ep.event.management.agent.plugin.solace.processor.semp.SolaceHttpSemp;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.web.util.UriBuilder;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SolaceHttpSempTest {
+
+    @ParameterizedTest
+    @MethodSource("uriBuilderFunctionTestCases")
+    void testCreateUriBuilderFunction(String connectionUrl, String expectedUri) {
+        // Arrange
+        String uriPath = "/SEMP/v2/config/msgVpns/{msgvpn}/queues";
+        String selectFields = "queueName";
+        Map<String, String> substitutionMap = Map.of("msgvpn", "testVpn");
+        SolaceHttpSemp solaceHttpSemp = new SolaceHttpSemp(
+                SempClient.builder()
+                        .username("myUsername")
+                        .password("myPassword")
+                        .connectionUrl(connectionUrl)
+                        .msgVpn("testVpn")
+                        .build());
+
+        // Act
+        Function<UriBuilder, URI> uriBuilderFunction = solaceHttpSemp.createUriBuilderFunction(uriPath, substitutionMap, selectFields);
+        URI resultUri = uriBuilderFunction.apply(UriComponentsBuilder.newInstance());
+
+        // Assert
+        assertEquals(expectedUri, resultUri.toString());
+    }
+
+    static Stream<Arguments> uriBuilderFunctionTestCases() {
+        return Stream.of(
+                Arguments.of(
+                        "https://ews-emea.api.foo.com:943",
+                        "https://ews-emea.api.foo.com:943/SEMP/v2/config/msgVpns/testVpn/queues?select=queueName&count=100"
+                ),
+                Arguments.of(
+                        "https://ews-emea.api.foo.com:943/it/technology/foobar/enterprise-foobar-bus/siOfoobar449-AsyncAPl/dq",
+                        "https://ews-emea.api.foo.com:943/it/technology/foobar/enterprise-foobar-bus/siOfoobar449-AsyncAPl/dq/SEMP/v2/config/msgVpns/testVpn" +
+                                "/queues?select=queueName&count=100"
+                )
+        );
+    }
+}


### PR DESCRIPTION
### What is the purpose of this change?
To unblock customers with extended sempUri path for their broker URL.

### How was this change implemented?
Updated the SolaceHttpSemp logic

### How was this change tested?
Added UntiTest coverage.

Also, ran the EMA as S-EMA docker container and observed the following:

- Things work as expected for customers with simple broker URLs: 

![regular URL](https://github.com/user-attachments/assets/caccffb8-6556-4f34-9e5d-e07bc985ec98)
![regular URl - docker logs](https://github.com/user-attachments/assets/55252ea3-63a5-46d3-a3a7-a6cc2960a403)

- If we provide extended URL, all of it is taken into account and we don't ignore the provided path:

![new URL](https://github.com/user-attachments/assets/325b896f-b9fd-4c5e-8187-75a53c849757)
![new URl - docker logs](https://github.com/user-attachments/assets/44d0a27c-ec2d-4f0e-9399-b146fee276f5)


### Is there anything the reviewers should focus on/be aware of?

    ...
