### PR TITLE
DATAGO-103122: Scan to federated accounts from the primary account

### DIFF
--- a/service/application/src/main/java/com/solace/maas/ep/common/messages/ScanCommandMessage.java
+++ b/service/application/src/main/java/com/solace/maas/ep/common/messages/ScanCommandMessage.java
@@ -22,7 +22,7 @@ public class ScanCommandMessage extends MOPMessage implements CommandMessageWith
     private List<ScanType> scanTypes;
     private List<ScanDestination> destinations;
     private List<EventBrokerResourceConfiguration> resources;
-
+    private String originOrgId;
 
     public ScanCommandMessage(String messagingServiceId,
                               String scanId,

--- a/service/application/src/main/java/com/solace/maas/ep/common/messages/ScanDataMessage.java
+++ b/service/application/src/main/java/com/solace/maas/ep/common/messages/ScanDataMessage.java
@@ -10,6 +10,8 @@ import lombok.Data;
 public class ScanDataMessage extends MOPMessage {
     private String orgId;
 
+    private String originOrgId;
+
     private String scanId;
 
     private String scanType;
@@ -19,6 +21,7 @@ public class ScanDataMessage extends MOPMessage {
     private String timestamp;
 
     public ScanDataMessage(String orgId,
+                           String originOrgId,
                            String scanId,
                            String traceId,
                            String actorId,
@@ -32,6 +35,7 @@ public class ScanDataMessage extends MOPMessage {
                 .withUhFlag(MOPUHFlag.ignore);
 
         this.orgId = orgId;
+        this.originOrgId = originOrgId;
         this.scanId = scanId;
         this.scanType = scanType;
         this.data = data;

--- a/service/application/src/main/java/com/solace/maas/ep/common/messages/ScanDataStatusMessage.java
+++ b/service/application/src/main/java/com/solace/maas/ep/common/messages/ScanDataStatusMessage.java
@@ -14,6 +14,8 @@ public class ScanDataStatusMessage extends MOPMessage {
 
     private String orgId;
 
+    private String originOrgId;
+
     private String scanId;
 
     private String status;
@@ -23,6 +25,7 @@ public class ScanDataStatusMessage extends MOPMessage {
     private String scanType;
 
     public ScanDataStatusMessage(String orgId,
+                                 String originOrgId,
                                  String scanId,
                                  String traceId,
                                  String actorId,
@@ -36,6 +39,7 @@ public class ScanDataStatusMessage extends MOPMessage {
                 .withUhFlag(MOPUHFlag.ignore);
 
         this.orgId = orgId;
+        this.originOrgId = originOrgId;
         this.scanId = scanId;
         this.status = status;
         this.description = description;

--- a/service/application/src/main/java/com/solace/maas/ep/common/messages/ScanLogMessage.java
+++ b/service/application/src/main/java/com/solace/maas/ep/common/messages/ScanLogMessage.java
@@ -10,6 +10,8 @@ import lombok.Data;
 public class ScanLogMessage extends MOPMessage {
     private String orgId;
 
+    private String originOrgId;
+
     private String scanId;
 
     private String level;
@@ -19,6 +21,7 @@ public class ScanLogMessage extends MOPMessage {
     private Long timestamp;
 
     public ScanLogMessage(String orgId,
+                          String originOrgId,
                           String scanId,
                           String traceId,
                           String actorId,
@@ -32,6 +35,7 @@ public class ScanLogMessage extends MOPMessage {
                 .withUhFlag(MOPUHFlag.ignore);
 
         this.orgId = orgId;
+        this.originOrgId = originOrgId;
         this.scanId = scanId;
         this.level = level;
         this.log = log;

--- a/service/application/src/main/java/com/solace/maas/ep/common/messages/ScanStatusMessage.java
+++ b/service/application/src/main/java/com/solace/maas/ep/common/messages/ScanStatusMessage.java
@@ -16,6 +16,8 @@ public class ScanStatusMessage extends MOPMessage {
 
     private String orgId;
 
+    private String originOrgId;
+
     private String scanId;
 
     private String status;
@@ -25,6 +27,7 @@ public class ScanStatusMessage extends MOPMessage {
     private List<String> scanTypes;
 
     public ScanStatusMessage(String orgId,
+                             String originOrgId,
                              String scanId,
                              String traceId,
                              String actorId,
@@ -38,6 +41,7 @@ public class ScanStatusMessage extends MOPMessage {
                 .withUhFlag(MOPUHFlag.ignore);
 
         this.orgId = orgId;
+        this.originOrgId = originOrgId;
         this.scanId = scanId;
         this.status = status;
         this.description = description;

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataProcessor.java
@@ -46,10 +46,12 @@ public class ScanDataProcessor implements Processor {
         String actorId = (String) properties.get(RouteConstants.ACTOR_ID);
         String scanType = (String) properties.get(RouteConstants.SCAN_TYPE);
         String orgId = ProcessorUtils.determineOrganizationId(eventPortalProperties, exchange);
+        String originOrgId = (String) properties.get(RouteConstants.ORIGIN_ORG_ID);
         Boolean isImportOp = (Boolean) properties.get(RouteConstants.IS_DATA_IMPORT);
 
         ScanDataMessage scanDataMessage = new ScanDataMessage(
                 orgId,
+                originOrgId,
                 scanId,
                 traceId,
                 actorId,

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanLogsProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanLogsProcessor.java
@@ -39,11 +39,18 @@ public class ScanLogsProcessor implements Processor {
         String scanId = (String) properties.get(RouteConstants.SCAN_ID);
         String traceId = (String) properties.get(RouteConstants.TRACE_ID);
         String orgId = ProcessorUtils.determineOrganizationId(eventPortalProperties, exchange);
+        String originOrgId = (String) properties.get(RouteConstants.ORIGIN_ORG_ID);
         String actorId = (String) properties.get(RouteConstants.ACTOR_ID);
         String messagingServiceId = (String) properties.get(RouteConstants.MESSAGING_SERVICE_ID);
 
-        ScanLogMessage logDataMessage = new ScanLogMessage(orgId, scanId, traceId, actorId, event.getLevel().toString(),
-                String.format("%s%s", event.getFormattedMessage(), "\n"), event.getTimeStamp());
+        ScanLogMessage logDataMessage = new ScanLogMessage(orgId,
+                originOrgId,
+                scanId,
+                traceId,
+                actorId,
+                event.getLevel().toString(),
+                String.format("%s%s", event.getFormattedMessage(), "\n"),
+                event.getTimeStamp());
 
         topicDetails.put("orgId", orgId);
         topicDetails.put("runtimeAgentId", eventPortalProperties.getRuntimeAgentId());

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusOverAllProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusOverAllProcessor.java
@@ -43,6 +43,7 @@ public class ScanStatusOverAllProcessor implements Processor {
         String actorId = (String) properties.get(RouteConstants.ACTOR_ID);
         ScanStatus status = (ScanStatus) properties.get(RouteConstants.SCAN_STATUS);
         String description = (String) properties.get(RouteConstants.SCAN_STATUS_DESC);
+        String originOrgId = (String) properties.get(RouteConstants.ORIGIN_ORG_ID);
 
         String scanType = (String) properties.get(RouteConstants.SCAN_TYPE);
         String orgId = ProcessorUtils.determineOrganizationId(eventPortalProperties, exchange);
@@ -56,7 +57,14 @@ public class ScanStatusOverAllProcessor implements Processor {
         topicDetails.put("scanType", scanType);
         topicDetails.put("status", status.name());
 
-        ScanStatusMessage generalStatusMessage = new ScanStatusMessage(orgId, scanId, traceId, actorId, status.name(), description, scanTypes);
+        ScanStatusMessage generalStatusMessage = new ScanStatusMessage(orgId,
+                originOrgId,
+                scanId,
+                traceId,
+                actorId,
+                status.name(),
+                description,
+                scanTypes);
 
         exchange.getIn().setHeader(RouteConstants.GENERAL_STATUS_MESSAGE, generalStatusMessage);
         exchange.getIn().setHeader(RouteConstants.TOPIC_DETAILS, topicDetails);

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusPerRouteProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusPerRouteProcessor.java
@@ -41,6 +41,7 @@ public class ScanStatusPerRouteProcessor implements Processor {
         ScanStatus status = (ScanStatus) properties.get(RouteConstants.SCAN_STATUS);
         String description = (String) properties.get(RouteConstants.SCAN_STATUS_DESC);
         String orgId = ProcessorUtils.determineOrganizationId(eventPortalProperties, exchange);
+        String originOrgId = (String) properties.get(RouteConstants.ORIGIN_ORG_ID);
         topicDetails.put("orgId", orgId);
         topicDetails.put("runtimeAgentId", eventPortalProperties.getRuntimeAgentId());
         topicDetails.put("messagingServiceId", messagingServiceId);
@@ -48,8 +49,14 @@ public class ScanStatusPerRouteProcessor implements Processor {
         topicDetails.put("status", status.name());
         topicDetails.put("scanDataType", scanType);
 
-        ScanDataStatusMessage scanDataStatusMessage = new ScanDataStatusMessage(orgId, scanId, traceId, actorId,
-                status.name(), description, scanType);
+        ScanDataStatusMessage scanDataStatusMessage = new ScanDataStatusMessage(orgId,
+                originOrgId,
+                scanId,
+                traceId,
+                actorId,
+                status.name(),
+                description,
+                scanType);
 
         exchange.getIn().setHeader(RouteConstants.SCAN_DATA_STATUS_MESSAGE, scanDataStatusMessage);
         exchange.getIn().setHeader(RouteConstants.TOPIC_DETAILS, topicDetails);

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/scanManager/ScanManager.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/scanManager/ScanManager.java
@@ -71,6 +71,7 @@ public class ScanManager {
         MDC.put(RouteConstants.ACTOR_ID, actorId);
         MDC.put(RouteConstants.SCHEDULE_ID, groupId);
         MDC.put(RouteConstants.ORG_ID, scanRequestBO.getOrgId());
+        MDC.put(RouteConstants.ORIGIN_ORG_ID, scanRequestBO.getOriginOrgId());
         MDC.put(RouteConstants.MESSAGING_SERVICE_ID, messagingServiceId);
 
         MessagingServiceEntity messagingServiceEntity = retrieveMessagingServiceEntity(messagingServiceId);
@@ -121,6 +122,7 @@ public class ScanManager {
                 SingleScanSpecification.builder()
                         .routeBundles(routes)
                         .orgId(scanRequestBO.getOrgId())
+                        .originOrgId(scanRequestBO.getOriginOrgId())
                         .groupId(groupId)
                         .scanId(scanId)
                         .traceId(traceId)
@@ -133,7 +135,7 @@ public class ScanManager {
 
     public void handleError(Exception e, ScanCommandMessage message) {
 
-        Validate.notBlank(message.getOrgId()," Organization ID cannot be null or empty");
+        Validate.notBlank(message.getOrgId(), " Organization ID cannot be null or empty");
         if (scanStatusPublisherOpt.isEmpty()) {
             return;
         }
@@ -143,6 +145,7 @@ public class ScanManager {
 
         ScanStatusMessage response = new ScanStatusMessage(
                 message.getOrgId(),
+                message.getOriginOrgId(),
                 message.getScanId(),
                 MDC.get(RouteConstants.TRACE_ID),
                 MDC.get(RouteConstants.ACTOR_ID),

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/scanManager/model/ScanRequestBO.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/scanManager/model/ScanRequestBO.java
@@ -19,6 +19,8 @@ public class ScanRequestBO extends AbstractBaseBO<String> {
 
     private String orgId;
 
+    private String originOrgId;
+
     private String messagingServiceId;
 
     private String scanId;

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/scanManager/model/SingleScanSpecification.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/scanManager/model/SingleScanSpecification.java
@@ -13,6 +13,7 @@ import java.util.List;
 @Builder
 public class SingleScanSpecification {
     private String orgId;
+    private String originOrgId;
     /**
      * The concept of a RouteBundle is introduced to make chaining routes easier
      * <p>

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ScanService.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ScanService.java
@@ -106,6 +106,7 @@ public class ScanService {
         String scanId = singleScanSpecification.getScanId();
         String traceId = singleScanSpecification.getTraceId();
         String orgId = singleScanSpecification.getOrgId();
+        String originOrgId = singleScanSpecification.getOriginOrgId();
         List<RouteBundle> routeBundles = singleScanSpecification.getRouteBundles();
         String actorId = singleScanSpecification.getActorId();
         MessagingServiceEntity messagingServiceEntity = singleScanSpecification.getMessagingServiceEntity();
@@ -124,8 +125,15 @@ public class ScanService {
         log.info("Scan request [{}], trace ID [{}]: Total of {} scan types to be retrieved: [{}].",
                 scanId, traceId, scanTypes.size(), StringUtils.join(scanTypes, ", "));
 
-        sendScanStatus(orgId, groupId, scanId, traceId, actorId, routeBundles.stream().findFirst().orElseThrow().getMessagingServiceId(),
-                StringUtils.join(scanTypes, ","), ScanStatus.IN_PROGRESS);
+        sendScanStatus(orgId,
+                originOrgId,
+                groupId,
+                scanId,
+                traceId,
+                actorId,
+                routeBundles.stream().findFirst().orElseThrow().getMessagingServiceId(),
+                StringUtils.join(scanTypes, ","),
+                ScanStatus.IN_PROGRESS);
 
         log.trace("RouteBundles to be processed: {}", routeBundles);
 
@@ -141,7 +149,14 @@ public class ScanService {
 
             updateScan(route, routeBundle, returnedScanEntity);
 
-            scanAsync(orgId, groupId, scanEntityId, traceId, actorId, route, routeBundle.getMessagingServiceId());
+            scanAsync(orgId,
+                    originOrgId,
+                    groupId,
+                    scanEntityId,
+                    traceId,
+                    actorId,
+                    route,
+                    routeBundle.getMessagingServiceId());
         }
 
         return scanId;
@@ -244,6 +259,7 @@ public class ScanService {
      * @param status             The status of scan.
      */
     public void sendScanStatus(String orgId,
+                               String originOrgId,
                                String groupId,
                                String scanId,
                                String traceId,
@@ -263,12 +279,19 @@ public class ScanService {
             exchange.getIn().setHeader(RouteConstants.SCAN_TYPE, scanTypes);
             exchange.getIn().setHeader(RouteConstants.SCAN_STATUS, status);
             exchange.getIn().setHeader(RouteConstants.SCAN_STATUS_DESC, "");
+            exchange.getIn().setHeader(RouteConstants.ORIGIN_ORG_ID, originOrgId);
         });
         meterRegistry.counter(MAAS_EMA_SCAN_EVENT_SENT, STATUS_TAG, status.name(), SCAN_ID_TAG, scanId).increment();
     }
 
-    protected CompletableFuture<Exchange> scanAsync(String orgId, String groupId, String scanId, String traceId, String actorId,
-                                                    RouteEntity route, String messagingServiceId) {
+    protected CompletableFuture<Exchange> scanAsync(String orgId,
+                                                    String originOrgId,
+                                                    String groupId,
+                                                    String scanId,
+                                                    String traceId,
+                                                    String actorId,
+                                                    RouteEntity route,
+                                                    String messagingServiceId) {
 
         Validate.notBlank(orgId, NULL_ORG_ID_ERROR_MSG);
         return producerTemplate.asyncSend("seda:" + route.getId(), exchange -> {
@@ -277,6 +300,7 @@ public class ScanService {
             exchange.getIn().setHeader(RouteConstants.SCAN_ID, scanId);
             exchange.getIn().setHeader(RouteConstants.TRACE_ID, traceId);
             exchange.getIn().setHeader(RouteConstants.ORG_ID, orgId);
+            exchange.getIn().setHeader(RouteConstants.ORIGIN_ORG_ID, originOrgId);
             exchange.getIn().setHeader(RouteConstants.ACTOR_ID, actorId);
             exchange.getIn().setHeader(RouteConstants.MESSAGING_SERVICE_ID, messagingServiceId);
             exchange.getIn().setHeader(RouteConstants.SCAN_STATUS_DESC, "");
@@ -434,7 +458,7 @@ public class ScanService {
     }
 
     public boolean isScanComplete(String scanId) {
-        if (ObjectUtils.isEmpty(scanId)){
+        if (ObjectUtils.isEmpty(scanId)) {
             throw new IllegalArgumentException("Scan ID cannot be null or empty");
         }
         Set<String> completeScanStatuses = Set.of(

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/messageProcessors/ScanCommandMessageProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/messageProcessors/ScanCommandMessageProcessor.java
@@ -86,6 +86,7 @@ public class ScanCommandMessageProcessor implements MessageProcessor<ScanCommand
                 .messagingServiceId(message.getMessagingServiceId())
                 .scanId(scanId)
                 .orgId(message.getOrgId())
+                .originOrgId(message.getOriginOrgId())
                 .traceId(message.getTraceId())
                 .actorId(message.getActorId())
                 .scanTypes(entityTypes)

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/ScanLogsPublisherRouteBuilderTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/ScanLogsPublisherRouteBuilderTests.java
@@ -87,6 +87,7 @@ public class ScanLogsPublisherRouteBuilderTests {
     public void testScanLogMessageMOPProtocol() {
         ScanLogMessage scanLogMessage = new ScanLogMessage(
                 "orgId",
+                "originOrgId",
                 "scanId",
                 "traceId",
                 "actorId",

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/processor/ScanDataProcessorTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/processor/ScanDataProcessorTests.java
@@ -62,6 +62,7 @@ public class ScanDataProcessorTests {
     public void testScanMessageMOPProtocol() {
         ScanDataMessage scanDataMessage = new ScanDataMessage(
                 "orgId",
+                "originOrgId",
                 "scanId",
                 "traceId",
                 "actorId",

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusOverAllProcessorTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusOverAllProcessorTests.java
@@ -67,6 +67,7 @@ public class ScanStatusOverAllProcessorTests {
     public void testScanStatusMessageProtocol() {
         ScanStatusMessage scanStatusMessage = new ScanStatusMessage(
                 null,
+                null,
                 "scan1",
                 "traceId",
                 "actorId",

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusPerRouteProcessorTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusPerRouteProcessorTests.java
@@ -67,6 +67,7 @@ public class ScanStatusPerRouteProcessorTests {
     public void testScanDataStatusMessageMOPProtocol() {
         ScanDataStatusMessage scanDataStatusMessage = new ScanDataStatusMessage(
                 null,
+                null,
                 "scan1",
                 "traceId",
                 "actorId",

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/scanManager/ScanManagerTest.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/scanManager/ScanManagerTest.java
@@ -77,36 +77,42 @@ class ScanManagerTest {
                         .build()
         )).thenReturn(Mockito.anyString());
 
-        ScanRequestBO scanRequestBO = new ScanRequestBO(
-                "orgId",
-                "id",
-                "scanId",
-                "traceId",
-                "actorId",
-                List.of("topics"),
-                List.of());
+        ScanRequestBO scanRequestBO = ScanRequestBO.builder()
+                .orgId("orgId")
+                .originOrgId("originOrgId")
+                .messagingServiceId("id")
+                .scanId("scanId")
+                .traceId("traceId")
+                .actorId("actorId")
+                .scanTypes(List.of("topics", "consumerGroups"))
+                .destinations(List.of())
+                .build();
 
         Assertions.assertThrows(NullPointerException.class, () -> scanManager.scan(scanRequestBO));
 
-        ScanRequestBO scanRequestBOTopics = new ScanRequestBO(
-                "orgId",
-                "id",
-                "scanId",
-                "traceId",
-                "actorId",
-                List.of("TEST_SCAN_1"),
-                List.of());
+        ScanRequestBO scanRequestBOTopics = ScanRequestBO.builder()
+                .orgId("orgId")
+                .originOrgId("originOrgId")
+                .messagingServiceId("id")
+                .scanId("scanId")
+                .traceId("traceId")
+                .actorId("actorId")
+                .scanTypes(List.of("TEST_SCAN_1"))
+                .destinations(List.of())
+                .build();
 
         Assertions.assertThrows(NullPointerException.class, () -> scanManager.scan(scanRequestBOTopics));
 
-        ScanRequestBO scanRequestBOConsumerGroups = new ScanRequestBO(
-                "orgId",
-                "id",
-                "scanId",
-                "traceId",
-                "actorId",
-                List.of("TEST_SCAN_2"),
-                List.of());
+        ScanRequestBO scanRequestBOConsumerGroups = ScanRequestBO.builder()
+                .orgId("orgId")
+                .originOrgId("originOrgId")
+                .messagingServiceId("id")
+                .scanId("scanId")
+                .traceId("traceId")
+                .actorId("actorId")
+                .scanTypes(List.of("TEST_SCAN_2"))
+                .destinations(List.of())
+                .build();
 
         Assertions.assertThrows(NullPointerException.class, () -> scanManager.scan(scanRequestBOConsumerGroups));
     }
@@ -117,11 +123,16 @@ class ScanManagerTest {
         String messagingServiceId = "messagingServiceId";
         String confluentSchemaRegistryId = "confluentId";
 
-        ScanRequestBO scanRequestBO = new ScanRequestBO(
-                "orgId",
-                messagingServiceId, "scanId", "traceId", "actorId",
-                List.of("KAFKA_ALL", "CONFLUENT_SCHEMA_REGISTRY_SCHEMA"),
-                List.of("FILE_WRITER"));
+        ScanRequestBO scanRequestBO = ScanRequestBO.builder()
+                .orgId("orgId")
+                .originOrgId("originOrgId")
+                .messagingServiceId(messagingServiceId)
+                .scanId("scanId")
+                .traceId("traceId")
+                .actorId("actorId")
+                .scanTypes(List.of("KAFKA_ALL", "CONFLUENT_SCHEMA_REGISTRY_SCHEMA"))
+                .destinations(List.of("FILE_WRITER"))
+                .build();
 
         MessagingServiceEntity messagingServiceEntity = MessagingServiceEntity.builder()
                 .id(messagingServiceId)

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/scanManager/mapper/ScanRequestMapperTest.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/scanManager/mapper/ScanRequestMapperTest.java
@@ -27,14 +27,16 @@ public class ScanRequestMapperTest {
         scanRequestMapper.map(scanRequestDTO);
         scanRequestMapper.map((ScanRequestDTO) null);
 
-        ScanRequestBO scanRequestBO = new ScanRequestBO(
-                "orgId",
-                "id",
-                "scanId",
-                "traceId",
-                "actorId",
-                List.of("TEST_SCAN"),
-                List.of());
+        ScanRequestBO scanRequestBO = ScanRequestBO.builder()
+                .orgId("orgId")
+                .originOrgId("originOrgId")
+                .messagingServiceId("id")
+                .scanId("scanId")
+                .traceId("traceId")
+                .actorId("actorId")
+                .scanTypes(List.of("TEST_SCAN"))
+                .destinations(List.of())
+                .build();
 
         scanRequestMapper.map(scanRequestBO);
         scanRequestMapper.map((ScanRequestBO) null);
@@ -45,14 +47,16 @@ public class ScanRequestMapperTest {
     @Test
     public void testMapperWithUser() {
         User user = new User("orgId", "userId");
-        ScanRequestBO scanRequestBO = new ScanRequestBO(
-                "orgId",
-                "id",
-                "scanId",
-                "traceId",
-                "actorId",
-                List.of("TEST_SCAN"),
-                List.of());
+        ScanRequestBO scanRequestBO = ScanRequestBO.builder()
+                .orgId("orgId")
+                .originOrgId("originOrgId")
+                .messagingServiceId("id")
+                .scanId("scanId")
+                .traceId("traceId")
+                .actorId("actorId")
+                .scanTypes(List.of("TEST_SCAN"))
+                .destinations(List.of())
+                .build();
 
         scanRequestMapper.map(scanRequestBO, user);
         scanRequestMapper.map(null, null);

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/scanManager/rest/EMAControllerTest.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/scanManager/rest/EMAControllerTest.java
@@ -41,14 +41,16 @@ public class EMAControllerTest {
         EventPortalProperties eventPortalProperties = mock(EventPortalProperties.class);
 
         ScanRequestDTO scanRequestDTO = new ScanRequestDTO(List.of("topics"), List.of());
-        ScanRequestBO scanRequestBO = new ScanRequestBO(
-                "orgId",
-                "id",
-                "scanConnected",
-                "traceId",
-                "actorId",
-                List.of("TEST_SCAN_TYPE"),
-                List.of());
+        ScanRequestBO scanRequestBO = ScanRequestBO.builder()
+                .orgId("orgId")
+                .originOrgId("originOrgId")
+                .messagingServiceId("id")
+                .scanId("scanConnected")
+                .traceId("traceId")
+                .actorId("actorId")
+                .scanTypes(List.of("TEST_SCAN_TYPE"))
+                .destinations(List.of())
+                .build();
 
         when(eventPortalProperties.getGateway())
                 .thenReturn(GatewayProperties.builder()
@@ -73,14 +75,16 @@ public class EMAControllerTest {
         EventPortalProperties eventPortalProperties = mock(EventPortalProperties.class);
 
         ScanRequestDTO scanRequestDTO = new ScanRequestDTO(List.of("topics"), List.of("EVENT_PORTAL"));
-        ScanRequestBO scanRequestBO = new ScanRequestBO(
-                "orgId",
-                "id",
-                "scanId",
-                "traceId",
-                "actorId",
-                List.of("TEST_SCAN"),
-                List.of("EVENT_PORTAL"));
+        ScanRequestBO scanRequestBO = ScanRequestBO.builder()
+                .orgId("orgId")
+                .originOrgId("originOrgId")
+                .messagingServiceId("id")
+                .scanId("scanId")
+                .traceId("traceId")
+                .actorId("actorId")
+                .scanTypes(List.of("TEST_SCAN"))
+                .destinations(List.of("EVENT_PORTAL"))
+                .build();
 
         when(eventPortalProperties.getGateway())
                 .thenReturn(GatewayProperties.builder()
@@ -104,14 +108,16 @@ public class EMAControllerTest {
         EventPortalProperties eventPortalProperties = mock(EventPortalProperties.class);
 
         ScanRequestDTO scanRequestDTO = new ScanRequestDTO(List.of("topics"), List.of());
-        ScanRequestBO scanRequestBO = new ScanRequestBO(
-                "orgId",
-                "id",
-                "scanId",
-                "traceId",
-                "actorId",
-                List.of("TEST_SCAN"),
-                List.of());
+        ScanRequestBO scanRequestBO = ScanRequestBO.builder()
+                .orgId("orgId")
+                .originOrgId("originOrgId")
+                .messagingServiceId("id")
+                .scanId("scanId")
+                .traceId("traceId")
+                .actorId("actorId")
+                .scanTypes(List.of("TEST_SCAN"))
+                .destinations(List.of())
+                .build();
 
         when(eventPortalProperties.getGateway())
                 .thenReturn(GatewayProperties.builder()

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/service/ScanServiceTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/service/ScanServiceTests.java
@@ -326,7 +326,7 @@ public class ScanServiceTests {
                 mock(ScanTypeRepository.class),
                 mock(ScanStatusRepository.class), mock(ScanRouteService.class), mock(RouteService.class),
                 template, idGenerator, meterRegistry);
-        service.sendScanStatus("orgId", "scanId", "groupId", "messagingServiceId", "traceId", "actorId",
+        service.sendScanStatus("orgId", "originOrgId", "scanId", "groupId", "messagingServiceId", "traceId", "actorId",
                 "queueListing", ScanStatus.IN_PROGRESS);
 
         assertThatNoException();

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/constants/RouteConstants.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/constants/RouteConstants.java
@@ -8,7 +8,9 @@ public class RouteConstants {
     public static final String SCHEDULE_ID = "SCHEDULE_ID";
 
     public static final String SCAN_ID = "SCAN_ID";
+
     public static final String ORG_ID = "ORG_ID";
+    public static final String ORIGIN_ORG_ID = "ORIGIN_ORG_ID";
 
     public static final String TRACE_ID = "traceId";
     public static final String X_B_3_TRACE_ID = "X-B3-TraceId";

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/processor/logging/MDCProcessor.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/processor/logging/MDCProcessor.java
@@ -25,6 +25,9 @@ public class MDCProcessor implements Processor {
         MDC.put(RouteConstants.ORG_ID,
                 exchange.getIn().getHeader(RouteConstants.ORG_ID, String.class));
 
+        MDC.put(RouteConstants.ORIGIN_ORG_ID,
+                exchange.getIn().getHeader(RouteConstants.ORIGIN_ORG_ID, String.class));
+
         MDC.put(RouteConstants.ACTOR_ID,
                 exchange.getIn().getHeader(RouteConstants.ACTOR_ID, String.class));
 


### PR DESCRIPTION
### What is the purpose of this change?
To support scan against federated brokers

### How was this change implemented?

Added originOrgId concept to all the scan messages and processors and other related places in EMA side.


### How was this change tested?
Ran both regular and federated borker scan jobs on a dev homeCloud solution:

- Old EMA and new ep-core: 
<img width="1219" alt="new-ep-core-old-ema-scan" src="https://github.com/user-attachments/assets/6f3eb85a-2731-4c37-8d8a-61a2a56146f0" />

- New EMA and old ep-core:
![old-ep-core-new-ema-scan](https://github.com/user-attachments/assets/cbbde5c8-a27c-4a47-a580-be553ff6a017)

- New EMA and new ep-core (federated broker in pvt DC):
![scan-federated-pvt-broker](https://github.com/user-attachments/assets/023b61e5-76e3-4b71-bfbd-ff01bd06b37a)

- New EMA and new ep-core (federated broker in pub DC):
![scan-federated-pub-broker](https://github.com/user-attachments/assets/c19532ec-e629-40fb-87b7-95a57634c3af)

- New EMA and new ep-core (scan standalone EMA):
![new-ep-core-new-ema-scan-offline1](https://github.com/user-attachments/assets/91aa0d2e-c80c-40b2-a7d7-5ac18437144d)

- New EMA and new ep-core (scan kafka broker):
![new-ep-core-new-ema-scan-kafka2](https://github.com/user-attachments/assets/59467072-c149-41ba-b1bf-3d2c75955d6e)



### Is there anything the reviewers should focus on/be aware of?
Here is a link to the sibling PR for ep-core side: https://github.com/SolaceDev/maas-ep-core/pull/3835
