### PR TITLE
DATAGO-109137: Upversion netty and spring-boot

### DIFF
--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -13,7 +13,7 @@
     <name>Solace Event Management Agent - Application</name>
     <description>Solace Event Management Agent - Application</description>
     <properties>
-        <spring-boot.version>3.4.7</spring-boot.version>
+        <spring-boot.version>3.4.8</spring-boot.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <spring-security-rsa.version>1.1.3</spring-security-rsa.version>
         <spring-kafka.version>3.3.4</spring-kafka.version>
@@ -22,7 +22,6 @@
         <awaitility.version>4.2.0</awaitility.version>
         <dockerfile-maven.version>1.4.13</dockerfile-maven.version>
         <swagger-codegen-maven-plugin.version>2.4.43</swagger-codegen-maven-plugin.version>
-        <netty.version>4.1.118.Final</netty.version>
     </properties>
     <repositories>
         <repository>
@@ -35,7 +34,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.118.Final</version>
+                <version>4.1.124.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/service/confluent-schema-registry-plugin/pom.xml
+++ b/service/confluent-schema-registry-plugin/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <spring-boot.version>3.4.7</spring-boot.version>
+        <spring-boot.version>3.4.8</spring-boot.version>
         <httpclient.version>4.5.14</httpclient.version>
         <mockwebserver.version>4.9.0</mockwebserver.version>
         <jupiter.version>5.10.2</jupiter.version>
@@ -18,6 +18,20 @@
         <jackson-dataformat-cbor.version>2.13.4</jackson-dataformat-cbor.version>
         <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- CVE-2025-55163: Override Netty versions to secure 4.1.124.Final -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>4.1.124.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>com.solace.maas</groupId>

--- a/service/kafka-plugin/pom.xml
+++ b/service/kafka-plugin/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <spring-kafka.version>3.3.4</spring-kafka.version>
         <kafka-clients.version>3.8.1</kafka-clients.version>
-        <spring-boot.version>3.4.7</spring-boot.version>
+        <spring-boot.version>3.4.8</spring-boot.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <jupiter.version>5.10.2</jupiter.version>
         <camel.version>4.8.7</camel.version>
@@ -26,6 +26,14 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Netty BOM for security fix CVE-2025-55163 -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>4.1.124.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>

--- a/service/local-storage-plugin/pom.xml
+++ b/service/local-storage-plugin/pom.xml
@@ -15,7 +15,7 @@
         <snakeyaml.version>2.0</snakeyaml.version>
         <jacksondatabind.version>2.13.4.2</jacksondatabind.version>
         <junit.version>4.13.2</junit.version>
-        <spring-boot.version>3.4.7</spring-boot.version>
+        <spring-boot.version>3.4.8</spring-boot.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <jupiter.version>5.10.2</jupiter.version>
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
@@ -28,6 +28,14 @@
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
                 <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- CVE-2025-55163: Override Netty versions to secure 4.1.124.Final -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>4.1.124.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/service/plugin/pom.xml
+++ b/service/plugin/pom.xml
@@ -23,11 +23,19 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <snakeyaml.version>2.0</snakeyaml.version>
         <jackson.version>2.16.1</jackson.version>
-        <spring-boot.version>3.4.7</spring-boot.version>
+        <spring-boot.version>3.4.8</spring-boot.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <!-- Netty BOM for security fix CVE-2025-55163 -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>4.1.124.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- Jackson BOM for consistent Jackson versions -->
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.7</version>
+        <version>3.4.8</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.solace.maas</groupId>
@@ -46,6 +46,14 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Netty BOM for security fix CVE-2025-55163 -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>4.1.124.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- logback/logstash integration -->
             <dependency>
                 <groupId>net.logstash.logback</groupId>

--- a/service/rabbitmq-plugin/pom.xml
+++ b/service/rabbitmq-plugin/pom.xml
@@ -11,8 +11,20 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
-        <spring-boot.version>3.4.7</spring-boot.version>
+        <spring-boot.version>3.4.8</spring-boot.version>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <!-- Netty BOM to override vulnerable versions -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>4.1.124.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>com.rabbitmq</groupId>

--- a/service/solace-plugin/pom.xml
+++ b/service/solace-plugin/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <solace-messaging-client.version>1.4.0</solace-messaging-client.version>
         <solclientj.version>10.0.0</solclientj.version>
-        <spring-boot.version>3.4.7</spring-boot.version>
+        <spring-boot.version>3.4.8</spring-boot.version>
         <jupiter.version>5.12.2</jupiter.version>
         <camel.version>4.8.7</camel.version>
         <commons-collections4.version>4.4</commons-collections4.version>
@@ -28,6 +28,14 @@
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
                 <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- CVE-2025-55163: Override Netty versions to secure 4.1.124.Final -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>4.1.124.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/service/terraform-plugin/pom.xml
+++ b/service/terraform-plugin/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <spring-boot.version>3.4.7</spring-boot.version>
+        <spring-boot.version>3.4.8</spring-boot.version>
         <jupiter.version>5.10.2</jupiter.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <snakeyaml.version>2.0</snakeyaml.version>
@@ -19,6 +19,20 @@
         <maas.jobs.version>2.0.11</maas.jobs.version>
         <jackson.version>2.16.1</jackson.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- CVE-2025-55163: Override Netty versions to secure 4.1.124.Final -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>4.1.124.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
### What is the purpose of this change?
To address Netty vulenarability for versions under `4.1.124`

### How was this change implemented?
Updated springBoot version and added an explicit netty-bom version to every pom file so we don't have to guess which version of netty will be used.

### How was this change tested?

#### Manual scan and configPush jobs in ep-perf:
<img width="2125" height="516" alt="scan and configPush worked for netty upgrade" src="https://github.com/user-attachments/assets/0f373b6c-2bc3-48ec-a9b7-cfa08ae51d2b" />

#### m.e.a.t functional test results:
<img width="757" height="730" alt="meat passed for netty upgrade" src="https://github.com/user-attachments/assets/d04b3d55-262e-412c-a51f-0de14b538966" />


### Is there anything the reviewers should focus on/be aware of?
Nope.
