### PR TITLE
DATAGO-105743: upversion tofu to 1.10.6 to address a vulnerability

### DIFF
--- a/service/application/docker/Dockerfile
+++ b/service/application/docker/Dockerfile
@@ -14,14 +14,14 @@ RUN adduser -D $USER && \
     mkdir -p /opt/ema/terraform && \
     chmod 777 /opt/ema/terraform && \
     chown -R $USER:$USER $HOME && \
-    chown -R $USER:$USER /opt/ema/    
+    chown -R $USER:$USER /opt/ema/
 
 WORKDIR /opt/ema
 
 ARG PLATFORM=linux_amd64
 
-COPY tofu_1.10.2_amd64.apk /opt/ema/terraform
-RUN apk --update add --allow-untrusted /opt/ema/terraform/tofu_1.10.2_amd64.apk
+COPY tofu_1.10.6_amd64.apk /opt/ema/terraform
+RUN apk --update add --allow-untrusted /opt/ema/terraform/tofu_1.10.6_amd64.apk
 
 COPY .terraformrc $HOME/.terraformrc
 RUN printf '#!/bin/ash\ntofu $*' > /opt/ema/terraform/terraform

--- a/service/application/docker/tofu_1.10.2_amd64.apk
+++ b/service/application/docker/tofu_1.10.2_amd64.apk
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:039f17b42e35900b77e10cf1329543ffc95a0379c5b9178db460f1747101d812
-size 27958880

--- a/service/application/docker/tofu_1.10.6_amd64.apk
+++ b/service/application/docker/tofu_1.10.6_amd64.apk
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0e55aebd5e817db8d0b64957f2da3869995bf0321c3cd812e02dbb5d67416c1
+size 28037909


### PR DESCRIPTION
### What is the purpose of this change?
upversion tofu to 1.10.6 to address a vulnerability

### How was this change implemented?
Updated dockerFile with a new version of openTofu

### How was this change tested?
Ran all m.e.a.t functional tests and manual scans to ensure the new docker image will be good:
<img width="445" height="829" alt="MEAT functional tests pass for the new docker image" src="https://github.com/user-attachments/assets/dc8af92d-9a68-40be-9abf-818e45247059" />


### Is there anything the reviewers should focus on/be aware of?

    ...
