### PR TITLE
DATAGO-125682: vulnerability fix

### DIFF
--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -13,7 +13,7 @@
     <name>Solace Event Management Agent - Application</name>
     <description>Solace Event Management Agent - Application</description>
     <properties>
-        <spring-boot.version>3.5.8</spring-boot.version>
+        <spring-boot.version>3.5.11</spring-boot.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <spring-security-rsa.version>1.1.3</spring-security-rsa.version>
         <spring-kafka.version>3.3.6</spring-kafka.version>
@@ -31,14 +31,6 @@
     </repositories>
     <dependencyManagement>
         <dependencies>
-            <!-- Netty BOM for security fixes CVE-2025-55163, CVE-2025-58056, CVE-2025-58057 -->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-bom</artifactId>
-                <version>4.1.125.Final</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>

--- a/service/confluent-schema-registry-plugin/pom.xml
+++ b/service/confluent-schema-registry-plugin/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <spring-boot.version>3.5.8</spring-boot.version>
+        <spring-boot.version>3.5.11</spring-boot.version>
         <httpclient.version>4.5.14</httpclient.version>
         <mockwebserver.version>4.9.0</mockwebserver.version>
         <jupiter.version>5.10.2</jupiter.version>
@@ -18,19 +18,6 @@
         <jackson-dataformat-cbor.version>2.13.4</jackson-dataformat-cbor.version>
         <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
     </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <!-- CVE-2025-55163: Override Netty versions to secure 4.1.124.Final -->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-bom</artifactId>
-                <version>4.1.124.Final</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <dependencies>
         <dependency>

--- a/service/kafka-plugin/pom.xml
+++ b/service/kafka-plugin/pom.xml
@@ -33,6 +33,19 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- kafka-plugin has no Spring Boot parent, so Spring Boot does not manage Netty here.
+                 software.amazon.awssdk:netty-nio-client bundles its own Netty version (4.1.118.Final
+                 as of awssdk 2.30.17), which would be used without this pin.
+                 This BOM pin forces Netty to match the version Spring Boot 3.5.11 manages in all
+                 other EMA modules (via reactor-netty 1.2.15).
+                 Review when upgrading awssdk:netty-nio-client or when kafka-plugin gains a Spring Boot parent. -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>4.1.131.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/service/kafka-plugin/pom.xml
+++ b/service/kafka-plugin/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <spring-kafka.version>3.3.6</spring-kafka.version>
         <kafka-clients.version>3.9.1</kafka-clients.version>
-        <spring-boot.version>3.5.8</spring-boot.version>
+        <spring-boot.version>3.5.11</spring-boot.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <jupiter.version>5.10.2</jupiter.version>
         <camel.version>4.8.7</camel.version>
@@ -26,14 +26,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- Netty BOM for security fix CVE-2025-55163 -->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-bom</artifactId>
-                <version>4.1.124.Final</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>

--- a/service/local-storage-plugin/pom.xml
+++ b/service/local-storage-plugin/pom.xml
@@ -15,7 +15,7 @@
         <snakeyaml.version>2.0</snakeyaml.version>
         <jacksondatabind.version>2.13.4.2</jacksondatabind.version>
         <junit.version>4.13.2</junit.version>
-        <spring-boot.version>3.5.8</spring-boot.version>
+        <spring-boot.version>3.5.11</spring-boot.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <jupiter.version>5.10.2</jupiter.version>
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
@@ -28,14 +28,6 @@
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
                 <version>${jackson.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <!-- CVE-2025-55163: Override Netty versions to secure 4.1.124.Final -->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-bom</artifactId>
-                <version>4.1.124.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/service/plugin/pom.xml
+++ b/service/plugin/pom.xml
@@ -23,19 +23,11 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <snakeyaml.version>2.0</snakeyaml.version>
         <jackson.version>2.16.1</jackson.version>
-        <spring-boot.version>3.5.8</spring-boot.version>
+        <spring-boot.version>3.5.11</spring-boot.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
-            <!-- Netty BOM for security fix CVE-2025-55163 -->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-bom</artifactId>
-                <version>4.1.124.Final</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <!-- Jackson BOM for consistent Jackson versions -->
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.8</version>
+        <version>3.5.11</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.solace.maas</groupId>
@@ -46,14 +46,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- Netty BOM for security fixes CVE-2025-55163, CVE-2025-58056, CVE-2025-58057 -->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-bom</artifactId>
-                <version>4.1.125.Final</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <!-- logback/logstash integration -->
             <dependency>
                 <groupId>net.logstash.logback</groupId>

--- a/service/rabbitmq-plugin/pom.xml
+++ b/service/rabbitmq-plugin/pom.xml
@@ -11,20 +11,8 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
-        <spring-boot.version>3.5.8</spring-boot.version>
+        <spring-boot.version>3.5.11</spring-boot.version>
     </properties>
-    <dependencyManagement>
-        <dependencies>
-            <!-- Netty BOM to override vulnerable versions -->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-bom</artifactId>
-                <version>4.1.124.Final</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>com.rabbitmq</groupId>

--- a/service/solace-plugin/pom.xml
+++ b/service/solace-plugin/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <solace-messaging-client.version>1.4.0</solace-messaging-client.version>
         <solclientj.version>10.0.0</solclientj.version>
-        <spring-boot.version>3.5.8</spring-boot.version>
+        <spring-boot.version>3.5.11</spring-boot.version>
         <jupiter.version>5.12.2</jupiter.version>
         <camel.version>4.8.7</camel.version>
         <commons-collections4.version>4.4</commons-collections4.version>
@@ -28,14 +28,6 @@
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
                 <version>${jackson.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <!-- CVE-2025-55163: Override Netty versions to secure 4.1.124.Final -->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-bom</artifactId>
-                <version>4.1.124.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/service/terraform-plugin/pom.xml
+++ b/service/terraform-plugin/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <spring-boot.version>3.5.8</spring-boot.version>
+        <spring-boot.version>3.5.11</spring-boot.version>
         <jupiter.version>5.10.2</jupiter.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <snakeyaml.version>2.0</snakeyaml.version>
@@ -19,19 +19,6 @@
         <maas.jobs.version>2.0.11</maas.jobs.version>
         <jackson.version>2.16.1</jackson.version>
     </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <!-- CVE-2025-55163: Override Netty versions to secure 4.1.124.Final -->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-bom</artifactId>
-                <version>4.1.124.Final</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
### What is the purpose of this change?

Spring Boot version bump 3.5.8 → 3.5.11 across all 9 pom files
- tomcat: 10.1.49 -> 10.1.52
- netty: 4.1.124-4.1.125.Final -> 4.1.131.Final (removed all previous pinned versions except for kafka-plugin (see comments for details), as all `io.netty:*` artifacts resolve to 4.1.131.Final (via reactor-netty 1.2.15))

### How was this change implemented?

pom file

### How was this change tested?

- ITs
- build the image and tested manually

### Is there anything the reviewers should focus on/be aware of?

No
