### PR TITLE
chore(ci): remove whitesource from release workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,16 +58,13 @@ jobs:
           echo "$GITHUB_REF_NAME"
           echo "$GITHUB_EVENT_NAME"
           if [[ $GITHUB_REF_NAME == "main" ]]; then
-            export WHITESOURCE_SCAN=true
             export GITHUB_PACKAGES_DEPLOY=true
             export DOCKER_PUSH=true
           else
-            export WHITESOURCE_SCAN=false
             export GITHUB_PACKAGES_DEPLOY=false
             export DOCKER_PUSH=false
           fi
           echo "DOCKER_PUSH=$DOCKER_PUSH" >> $GITHUB_ENV
-          echo "WHITESOURCE_SCAN=$WHITESOURCE_SCAN" >> $GITHUB_ENV
           echo "GITHUB_PACKAGES_DEPLOY=$GITHUB_PACKAGES_DEPLOY" >> $GITHUB_ENV
       - name: Static Code Analysis
         run: mvn -B compile -Pmaas-static-code-analysis --file service/pom.xml
@@ -84,36 +81,6 @@ jobs:
           mvn -B $SKIP_FLAGS_ALL_TESTS \
             org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=SolaceProducts_event-management-agent \
             --file service/pom.xml
-      - name: WhiteSource Scan
-        if: env.WHITESOURCE_SCAN=='true'
-        env:
-          unified_agent_url: "https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar"
-          unified_agent_sha_url: "https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar.sha256"
-          WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
-          WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
-          TARGET_DIR: "service/application/target/lib"
-          WS_EXCLUDES: "local-storage-plugin*.jar,plugin*.jar,kafka-plugin*.jar,confluent-schema-registry-plugin*.jar"
-        run: |
-          echo "Whitesource- Downloading and verifying latest Agent"
-
-          curl -LJOs ${{ env.unified_agent_url }}
-          sha_from_jar=$(sha256sum  wss-unified-agent.jar | awk '{print $1}')
-          curl -LJOs ${{ env.unified_agent_sha_url }}
-          sha_from_file=$(cat wss-unified-agent.jar.sha256 | awk '{print $1}')
-          if [[ "$sha_from_file" == "$sha_from_jar" ]]; then
-              echo "Integrity of the wss-unified-agent.jar file verified .."
-          else
-              echo "Integrity check of wss-unified-agent.jar file failed .."
-              echo "sha_from_jar: $sha_from_jar"
-              echo "sha_from_file: $sha_from_file"
-              exit 1
-          fi
-
-          echo "Whitesource- Copying Maven Dependencies"
-          mvn dependency:copy-dependencies -DincludeScope=runtime -DoutputDirectory=target/lib --file service/pom.xml
-
-          echo "Whitesource- Running scan"
-          java -jar wss-unified-agent.jar -d  ${{ env.TARGET_DIR }}  -logLevel Info
       - name: Configure AWS credentials
         if: env.DOCKER_PUSH=='true'
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0

--- a/.github/workflows/release-readiness-check.yaml
+++ b/.github/workflows/release-readiness-check.yaml
@@ -36,18 +36,6 @@ jobs:
         with:
           python-version: 3.8
           cache: 'pip'
-      - name: Pre-Release Check - Whitesource vulnurabilities
-        env:
-          WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
-          WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
-        run: |
-          pip install --quiet --upgrade pip
-          export VIRTUAL_ENV=./venv
-          python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
-          cd ./.github/workflows/release_scripts/  && pip install --quiet -r requirements.txt && python3.8 whitesource_vulnurability_checker.py
       - name: Pre-Release Check - SonarQube Hotspots
         if: ${{ always() }}
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,18 +57,6 @@ jobs:
         with:
           python-version: 3.8
           cache: 'pip'
-      - name: Pre-Release Check - Whitesource vulnurabilities
-        env:
-          WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
-          WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
-        run: |
-          pip install --quiet --upgrade pip
-          export VIRTUAL_ENV=./venv
-          python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
-          cd ./.github/workflows/release_scripts/  && pip install --quiet -r requirements.txt && python3.8 whitesource_vulnurability_checker.py
       - name: Pre-Release Check - SonarQube Hotspots
         env:
           SONARQUBE_HOTSPOTS_API_URL: ${{ secrets.SONARQUBE_HOTSPOTS_API_URL }}


### PR DESCRIPTION
## Summary

Removes all deprecated Whitesource/Mend scanning references from the GitHub Actions workflow files.

- **`build.yaml`**: Removed the `WhiteSource Scan` step (which downloaded and ran the `wss-unified-agent.jar`) and the associated `WHITESOURCE_SCAN` environment variable exports and conditionals.
- **`release.yaml`**: Removed the `Pre-Release Check - Whitesource vulnurabilities` step, including the `WS_APIKEY` and `WS_PROJECTTOKEN` secret references.
- **`release-readiness-check.yaml`**: Removed the `Pre-Release Check - Whitesource vulnurabilities` step, including the `WS_APIKEY` and `WS_PROJECTTOKEN` secret references.

## Motivation

Whitesource (now Mend) scanning has been superseded by FOSSA for SCA (Software Composition Analysis). The Whitesource secrets (`WHITESOURCE_API_KEY`, `WHITESOURCE_PROJECT_TOKEN`) are no longer active, and the scan steps were non-functional. Removing them cleans up the CI pipelines and eliminates dead code that references deprecated tooling.

## Test plan

- [ ] Verify `build.yaml` runs successfully on a PR — FOSSA scan and all build/test steps pass without the WhiteSource step
- [ ] Verify `release.yaml` progresses past the pre-release checks without the Whitesource step
- [ ] Verify `release-readiness-check.yaml` runs the remaining SonarQube and Prisma checks without the Whitesource step
- [ ] Confirm no `whitesource`/`WS_APIKEY`/`WS_PROJECTTOKEN` references remain in any workflow YAML files

🤖 Generated with [Claude Code](https://claude.com/claude-code)