### PR TITLE
DATAGO-131629: vulnerability fix

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -42,6 +42,8 @@
         <jacoco.line.percentage>0.8</jacoco.line.percentage>
         <camel.version>4.8.7</camel.version>
         <mockito-inline.version>5.2.0</mockito-inline.version>
+        <!-- CVE-2026-22732: spring-security-web 6.5.8 (HTTP headers not written); Spring Boot 3.5.11 BOM manages 6.5.8, override to 6.5.9 -->
+        <spring-security.version>6.5.9</spring-security.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
### What is the purpose of this change?

#### Root cause

Spring Boot 3.5.11 manages spring-security.version=6.5.8 in its BOM. No override exists in the codebase.

#### Scope (all 9 pom files checked)

Only service/application/pom.xml is affected — it inherits spring-boot-starter-security which transitively brings in spring-security-web. All 7 standalone plugin poms (kafka,rabbitmq, solace, local-storage, terraform, confluent-schema-registry) have no spring-boot-starter-security dependency and are not affected. The plugin module inherits from the parent but also has no security dependency.

#### Exploitability

HIGH — EMA is a Spring Boot servlet application using Spring Security with default lazy header-writing. The vulnerability directly suppresses HTTP security headers (X-Frame-Options,X-Content-Type-Options, HSTS) on live endpoints.

Jira link: https://sol-jira.atlassian.net/browse/DATAGO-129407

### How was this change implemented?

pom update

### How was this change tested?

    ...

### Is there anything the reviewers should focus on/be aware of?

    ...
