### PR TITLE
DATAGO-133286: vulnerability fix

### DIFF
--- a/service/application/docker/Dockerfile
+++ b/service/application/docker/Dockerfile
@@ -20,8 +20,8 @@ WORKDIR /opt/ema
 
 ARG PLATFORM=linux_amd64
 
-COPY tofu_1.10.7_amd64.apk /opt/ema/terraform
-RUN apk --update add --allow-untrusted /opt/ema/terraform/tofu_1.10.7_amd64.apk
+COPY tofu_1.10.9_amd64.apk /opt/ema/terraform
+RUN apk --update add --allow-untrusted /opt/ema/terraform/tofu_1.10.9_amd64.apk
 
 COPY .terraformrc $HOME/.terraformrc
 RUN printf '#!/bin/ash\ntofu $*' > /opt/ema/terraform/terraform

--- a/service/application/docker/tofu_1.10.7_amd64.apk
+++ b/service/application/docker/tofu_1.10.7_amd64.apk
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d8d26633bf6eb41ec676623079caf9ba5ca21fb2607e4f6424d0aa25dcefe57e
-size 27992810

--- a/service/application/docker/tofu_1.10.9_amd64.apk
+++ b/service/application/docker/tofu_1.10.9_amd64.apk
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00594a7452dca2f61cafef3546c1d2f9dfb46d51a12dd26354a6c46be1238699
+size 28015879

--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -38,6 +38,12 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- CVE-2023-3635: okio < 1.17.6 GzipSource DoS; transitive via okhttp 2.7.5 -->
+            <dependency>
+                <groupId>com.squareup.okio</groupId>
+                <artifactId>okio</artifactId>
+                <version>1.17.6</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>


### PR DESCRIPTION
### What is the purpose of this change?

update tofu APK to version 1.10.9 and add okio dependency to address CVE-2023-3635

Jira links:
- https://sol-jira.atlassian.net/browse/DATAGO-129437
- https://sol-jira.atlassian.net/browse/DATAGO-129418

### How was this change implemented?

pom & dockerfile

### How was this change tested?

ITs & manual testing

### Is there anything the reviewers should focus on/be aware of?

No
