### PR TITLE
DATAGO-133286: upgrade to spring boot 3.5.14

### DIFF
--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -13,7 +13,7 @@
     <name>Solace Event Management Agent - Application</name>
     <description>Solace Event Management Agent - Application</description>
     <properties>
-        <spring-boot.version>3.5.11</spring-boot.version>
+        <spring-boot.version>3.5.14</spring-boot.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <spring-security-rsa.version>1.1.3</spring-security-rsa.version>
         <spring-kafka.version>3.3.6</spring-kafka.version>

--- a/service/confluent-schema-registry-plugin/pom.xml
+++ b/service/confluent-schema-registry-plugin/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <spring-boot.version>3.5.11</spring-boot.version>
+        <spring-boot.version>3.5.14</spring-boot.version>
         <httpclient.version>4.5.14</httpclient.version>
         <mockwebserver.version>4.9.0</mockwebserver.version>
         <jupiter.version>5.10.2</jupiter.version>

--- a/service/kafka-plugin/pom.xml
+++ b/service/kafka-plugin/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <spring-kafka.version>3.3.6</spring-kafka.version>
         <kafka-clients.version>3.9.1</kafka-clients.version>
-        <spring-boot.version>3.5.11</spring-boot.version>
+        <spring-boot.version>3.5.14</spring-boot.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <jupiter.version>5.10.2</jupiter.version>
         <camel.version>4.8.7</camel.version>
@@ -36,13 +36,13 @@
             <!-- kafka-plugin has no Spring Boot parent, so Spring Boot does not manage Netty here.
                  software.amazon.awssdk:netty-nio-client bundles its own Netty version (4.1.118.Final
                  as of awssdk 2.30.17), which would be used without this pin.
-                 This BOM pin forces Netty to match the version Spring Boot 3.5.11 manages in all
-                 other EMA modules (via reactor-netty 1.2.15).
+                 This BOM pin forces Netty to match the version Spring Boot 3.5.14 manages in all
+                 other EMA modules (via reactor-netty).
                  Review when upgrading awssdk:netty-nio-client or when kafka-plugin gains a Spring Boot parent. -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.131.Final</version>
+                <version>4.1.132.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/service/local-storage-plugin/pom.xml
+++ b/service/local-storage-plugin/pom.xml
@@ -15,7 +15,7 @@
         <snakeyaml.version>2.0</snakeyaml.version>
         <jacksondatabind.version>2.13.4.2</jacksondatabind.version>
         <junit.version>4.13.2</junit.version>
-        <spring-boot.version>3.5.11</spring-boot.version>
+        <spring-boot.version>3.5.14</spring-boot.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <jupiter.version>5.10.2</jupiter.version>
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>

--- a/service/plugin/pom.xml
+++ b/service/plugin/pom.xml
@@ -23,7 +23,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <snakeyaml.version>2.0</snakeyaml.version>
         <jackson.version>2.16.1</jackson.version>
-        <spring-boot.version>3.5.11</spring-boot.version>
+        <spring-boot.version>3.5.14</spring-boot.version>
     </properties>
 
     <dependencyManagement>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.11</version>
+        <version>3.5.14</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.solace.maas</groupId>
@@ -42,8 +42,6 @@
         <jacoco.line.percentage>0.8</jacoco.line.percentage>
         <camel.version>4.8.7</camel.version>
         <mockito-inline.version>5.2.0</mockito-inline.version>
-        <!-- CVE-2026-22732: spring-security-web 6.5.8 (HTTP headers not written); Spring Boot 3.5.11 BOM manages 6.5.8, override to 6.5.9 -->
-        <spring-security.version>6.5.9</spring-security.version>
     </properties>
 
     <dependencyManagement>

--- a/service/rabbitmq-plugin/pom.xml
+++ b/service/rabbitmq-plugin/pom.xml
@@ -11,7 +11,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
-        <spring-boot.version>3.5.11</spring-boot.version>
+        <spring-boot.version>3.5.14</spring-boot.version>
     </properties>
     <dependencies>
         <dependency>

--- a/service/solace-plugin/pom.xml
+++ b/service/solace-plugin/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <solace-messaging-client.version>1.4.0</solace-messaging-client.version>
         <solclientj.version>10.0.0</solclientj.version>
-        <spring-boot.version>3.5.11</spring-boot.version>
+        <spring-boot.version>3.5.14</spring-boot.version>
         <jupiter.version>5.12.2</jupiter.version>
         <camel.version>4.8.7</camel.version>
         <commons-collections4.version>4.4</commons-collections4.version>

--- a/service/terraform-plugin/pom.xml
+++ b/service/terraform-plugin/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <spring-boot.version>3.5.11</spring-boot.version>
+        <spring-boot.version>3.5.14</spring-boot.version>
         <jupiter.version>5.10.2</jupiter.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <snakeyaml.version>2.0</snakeyaml.version>


### PR DESCRIPTION
### What is the purpose of this change?

Fix vulnerabilities by upgrading spring-boot.version 3.5.11 → 3.5.14

- tomcat-embed-core: 10.1.54
- spring-security-web: 6.5.10
- All io.netty:* (all modules): 4.1.132.Final
- netty-nio-client sub-deps (kafka-plugin): 4.1.132.Final


### How was this change implemented?

pom file

### How was this change tested?

ITs & manul

### Is there anything the reviewers should focus on/be aware of?

No