### PR TITLE
DATAGO-137105: fix openssl vulnerabilities

### DIFF
--- a/service/application/docker/buildEventManagementAgentDocker.sh
+++ b/service/application/docker/buildEventManagementAgentDocker.sh
@@ -80,7 +80,7 @@ setup_colors
 
 msg "${GREEN}Building image:${YELLOW} event-management-agent:${IMAGE_TAG}\n${NOFORMAT}"
 
-export BASE_IMAGE=eclipse-temurin:17.0.16_8-jre-alpine
+export BASE_IMAGE=eclipse-temurin:17.0.19_10-jre-alpine
 export GITHASH=$(git rev-parse HEAD)
 export GITBRANCH=$(git branch --show-current)
 export BUILD_TIMESTAMP=$(date -u)


### PR DESCRIPTION
### What is the purpose of this change?

fix openssl vulnerabilities by bumping base image eclipse-temurin:17.0.16_8-jre-alpine -> 17.0.19_10-jre-alpine to pick up Alpine 3.23.4 with openssl-3.5.6-r0 (libssl3/libcrypto3 also 3.5.6-r0).

Covers all 19 OpenSSL CVEs flagged by Prisma Cloud on openssl-3.5.4-r0: CVE-2026-31789 (Critical), CVE-2025-15467, CVE-2025-69418/19/20/21, CVE-2026-28387/88/89/90, CVE-2026-31790, CVE-2026-2673, CVE-2025-11187, CVE-2025-15468/69, CVE-2025-66199, CVE-2025-68160, CVE-2026-22795/96.

### How was this change implemented?

`buildEventManagementAgentDocker.sh`

### How was this change tested?

IT & manual (tested the image (`1.9.8-bo4`) in ep-perf: lifecycle: deploy, undeploy, update to latest, rollback; config push; discovery scan)

### Is there anything the reviewers should focus on/be aware of?

No
