### PR TITLE
DATAGO-137105: fix opentofu vulnerabilities

### DIFF
--- a/service/application/docker/Dockerfile
+++ b/service/application/docker/Dockerfile
@@ -20,8 +20,8 @@ WORKDIR /opt/ema
 
 ARG PLATFORM=linux_amd64
 
-COPY tofu_1.10.9_amd64.apk /opt/ema/terraform
-RUN apk --update add --allow-untrusted /opt/ema/terraform/tofu_1.10.9_amd64.apk
+COPY tofu_1.12.0_amd64.apk /opt/ema/terraform
+RUN apk --update add --allow-untrusted /opt/ema/terraform/tofu_1.12.0_amd64.apk
 
 COPY .terraformrc $HOME/.terraformrc
 RUN printf '#!/bin/ash\ntofu $*' > /opt/ema/terraform/terraform

--- a/service/application/docker/tofu_1.10.9_amd64.apk
+++ b/service/application/docker/tofu_1.10.9_amd64.apk
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:00594a7452dca2f61cafef3546c1d2f9dfb46d51a12dd26354a6c46be1238699
-size 28015879

--- a/service/application/docker/tofu_1.12.0_amd64.apk
+++ b/service/application/docker/tofu_1.12.0_amd64.apk
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e5b1873e5c5fbb26a0b287386684cdaf6e8b8173526d663b9151ca267495b2a
+size 36202716


### PR DESCRIPTION
### What is the purpose of this change?

fix opentofu vulnerabilities by bumping OpenTofu binary 1.10.9 -> 1.12.0 (built with Go 1.26.3, grpc v1.79.3).

Covers 4 Prisma findings on the /usr/bin/tofu binary: CVE-2026-32283 (crypto/tls TLS 1.3 deadlock DoS, fix: Go 1.26.2+) CVE-2026-32280 (crypto/x509 DoS, fix: Go 1.26.2+), CVE-2026-32281 (crypto/x509 DoS, fix: Go 1.26.2+), CVE-2026-33186 (grpc authz bypass, fix: grpc v1.79.3)

### How was this change implemented?

replace the current opentofu binary with the new binary

### How was this change tested?

- SHA256 of tofu_1.12.0_amd64.apk verified against official opentofu/opentofu v1.12.0 SHA256SUMS:
  `6e5b1873e5c5fbb26a0b287386684cdaf6e8b8173526d663b9151ca267495b2a`
- IT & manual (tested the image (`1.9.8-bo5`) in ep-perf: lifecycle: deploy, undeploy, update to latest, rollback; config push; discovery scan)

### Is there anything the reviewers should focus on/be aware of?

No
