### PR TITLE
DATAGO-137993: add SEMP delete support for ACL client connect exception

### DIFF
--- a/service/application/src/main/java/com/solace/maas/ep/common/model/SempAclClientConnectExceptionDeletionRequest.java
+++ b/service/application/src/main/java/com/solace/maas/ep/common/model/SempAclClientConnectExceptionDeletionRequest.java
@@ -1,0 +1,16 @@
+package com.solace.maas.ep.common.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class SempAclClientConnectExceptionDeletionRequest {
+
+    private String msgVpn;
+    private String aclProfileName;
+    /**
+     * The IP address/netmask of the client connect exception in canonical CIDR form.
+     */
+    private String clientConnectExceptionAddress;
+}

--- a/service/application/src/main/java/com/solace/maas/ep/common/model/SempEntityType.java
+++ b/service/application/src/main/java/com/solace/maas/ep/common/model/SempEntityType.java
@@ -11,6 +11,7 @@ public enum SempEntityType {
     solaceRdpOauthJwtClaim("solaceRdpOauthJwtClaim"),
     solaceAclSubscribeTopicException("solaceAclSubscribeTopicException"),
     solaceAclPublishTopicException("solaceAclPublishTopicException"),
+    solaceAclClientConnectException("solaceAclClientConnectException"),
     solaceClientUsername("solaceClientUsername"),
     solaceClientCertificateUsername("solaceClientCertificateUsername"),
     solaceClientProfileName("solaceClientProfileName"),

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/AbstractSempCommandManager.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/AbstractSempCommandManager.java
@@ -17,6 +17,7 @@ import static com.solace.maas.ep.event.management.agent.plugin.terraform.manager
 @Slf4j
 public abstract class AbstractSempCommandManager {
     public static final String MSG_VPN_EMPTY_ERROR_MSG = "Msg VPN must not be empty";
+    public static final String ACL_PROFILE_NAME_EMPTY_ERROR_MSG = "ACL profile name must not be empty";
 
     public abstract String supportedSempCommand();
 

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/SempDeleteCommandManager.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/SempDeleteCommandManager.java
@@ -112,7 +112,7 @@ public class SempDeleteCommandManager extends AbstractSempCommandManager {
                 objectMapper.writeValueAsString(command.getParameters().get(SempCommandConstants.SEMP_COMMAND_DATA)),
                 SempAclProfileDeletionRequest.class);
         Validate.notEmpty(request.getMsgVpn(), MSG_VPN_EMPTY_ERROR_MSG);
-        Validate.notEmpty(request.getAclProfileName(), "ACL profile name must not be empty");
+        Validate.notEmpty(request.getAclProfileName(), ACL_PROFILE_NAME_EMPTY_ERROR_MSG);
 
         log.info("SEMP delete: Deleting ACL profile");
         try {
@@ -129,7 +129,7 @@ public class SempDeleteCommandManager extends AbstractSempCommandManager {
                 SempAclPublishTopicExceptionDeletionRequest.class);
 
         Validate.notEmpty(request.getMsgVpn(), MSG_VPN_EMPTY_ERROR_MSG);
-        Validate.notEmpty(request.getAclProfileName(), "ACL profile name must not be empty");
+        Validate.notEmpty(request.getAclProfileName(), ACL_PROFILE_NAME_EMPTY_ERROR_MSG);
         Validate.notEmpty(request.getPublishTopic(), "Publish topic must not be empty");
         log.info("SEMP delete: Deleting ACL publish topic exception");
         try {
@@ -146,7 +146,7 @@ public class SempDeleteCommandManager extends AbstractSempCommandManager {
                 SempAclSubscribeTopicExceptionDeletionRequest.class);
 
         Validate.notEmpty(request.getMsgVpn(), MSG_VPN_EMPTY_ERROR_MSG);
-        Validate.notEmpty(request.getAclProfileName(), "ACL profile name must not be empty");
+        Validate.notEmpty(request.getAclProfileName(), ACL_PROFILE_NAME_EMPTY_ERROR_MSG);
         Validate.notEmpty(request.getSubscribeTopic(), "Subscribe topic must not be empty");
 
         log.info("SEMP delete: Deleting ACL subscribe topic exception");
@@ -164,7 +164,7 @@ public class SempDeleteCommandManager extends AbstractSempCommandManager {
                 SempAclClientConnectExceptionDeletionRequest.class);
 
         Validate.notEmpty(request.getMsgVpn(), MSG_VPN_EMPTY_ERROR_MSG);
-        Validate.notEmpty(request.getAclProfileName(), "ACL profile name must not be empty");
+        Validate.notEmpty(request.getAclProfileName(), ACL_PROFILE_NAME_EMPTY_ERROR_MSG);
         Validate.notEmpty(request.getClientConnectExceptionAddress(), "Client connect exception address must not be empty");
 
         log.info("SEMP delete: Deleting ACL client connect exception");

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/SempDeleteCommandManager.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/SempDeleteCommandManager.java
@@ -8,6 +8,7 @@ import com.solace.client.sempv2.api.AuthorizationGroupApi;
 import com.solace.client.sempv2.api.ClientUsernameApi;
 import com.solace.client.sempv2.api.QueueApi;
 import com.solace.client.sempv2.api.RestDeliveryPointApi;
+import com.solace.maas.ep.common.model.SempAclClientConnectExceptionDeletionRequest;
 import com.solace.maas.ep.common.model.SempAclProfileDeletionRequest;
 import com.solace.maas.ep.common.model.SempAclPublishTopicExceptionDeletionRequest;
 import com.solace.maas.ep.common.model.SempAclSubscribeTopicExceptionDeletionRequest;
@@ -93,6 +94,9 @@ public class SempDeleteCommandManager extends AbstractSempCommandManager {
             case solaceAclPublishTopicException:
                 executeDeleteAclPublishTopicException(command, sempApiProvider);
                 break;
+            case solaceAclClientConnectException:
+                executeDeleteAclClientConnectException(command, sempApiProvider);
+                break;
             case solaceRdpOauthJwtClaim:
                 executeDeleteRdpOauthJwtClaims(command, sempApiProvider);
                 break;
@@ -150,6 +154,25 @@ public class SempDeleteCommandManager extends AbstractSempCommandManager {
             aclProfileApi.deleteMsgVpnAclProfileSubscribeTopicException(request.getMsgVpn(), request.getAclProfileName(), "smf", request.getSubscribeTopic());
         } catch (ApiException e) {
             handleSempOperationException(e, "ACL subscribe topic exception", supportedSempCommand());
+        }
+    }
+
+    private void executeDeleteAclClientConnectException(Command command, SempApiProvider sempApiProvider) throws ApiException, JsonProcessingException {
+        AclProfileApi aclProfileApi = sempApiProvider.getAclProfileApi();
+        SempAclClientConnectExceptionDeletionRequest request = objectMapper.readValue(
+                objectMapper.writeValueAsString(command.getParameters().get(SempCommandConstants.SEMP_COMMAND_DATA)),
+                SempAclClientConnectExceptionDeletionRequest.class);
+
+        Validate.notEmpty(request.getMsgVpn(), MSG_VPN_EMPTY_ERROR_MSG);
+        Validate.notEmpty(request.getAclProfileName(), "ACL profile name must not be empty");
+        Validate.notEmpty(request.getClientConnectExceptionAddress(), "Client connect exception address must not be empty");
+
+        log.info("SEMP delete: Deleting ACL client connect exception");
+        try {
+            aclProfileApi.deleteMsgVpnAclProfileClientConnectException(
+                    request.getMsgVpn(), request.getAclProfileName(), request.getClientConnectExceptionAddress());
+        } catch (ApiException e) {
+            handleSempOperationException(e, "ACL client connect exception", supportedSempCommand());
         }
     }
 

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/commandManager/SempDeleteCommandManagerTest.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/commandManager/SempDeleteCommandManagerTest.java
@@ -29,6 +29,7 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.solace.maas.ep.common.model.SempEntityType.solaceAclClientConnectException;
 import static com.solace.maas.ep.common.model.SempEntityType.solaceAclProfile;
 import static com.solace.maas.ep.common.model.SempEntityType.solaceAclPublishTopicException;
 import static com.solace.maas.ep.common.model.SempEntityType.solaceAclSubscribeTopicException;
@@ -263,6 +264,72 @@ public class SempDeleteCommandManagerTest {
                     .build();
             sempDeleteCommandManager.execute(cmd, sempApiProvider);
             verify(aclProfileApi).deleteMsgVpnAclProfileSubscribeTopicException("default", "aclProfileName", "smf", "a/b/c");
+            assertThat(cmd.getResult().getStatus()).isEqualTo(JobStatus.error);
+        }
+
+    }
+
+    @Nested
+    class ClientConnectException {
+        @Test
+        void happyPath() throws ApiException {
+            AclProfileApi aclProfileApi = Mockito.mock(AclProfileApi.class);
+            when(sempApiProvider.getAclProfileApi()).thenReturn(aclProfileApi);
+            when((aclProfileApi).deleteMsgVpnAclProfileClientConnectException(any(), any(), any())).thenReturn(new SempMetaOnlyResponse());
+            Command cmd = Command.builder()
+                    .commandType(CommandType.semp)
+                    .command(SEMP_DELETE_OPERATION)
+                    .parameters(createDeleteAclClientConnectExceptionParameters(true))
+                    .build();
+            sempDeleteCommandManager.execute(cmd, sempApiProvider);
+            verify(aclProfileApi).deleteMsgVpnAclProfileClientConnectException("default", "aclProfileName", "1.2.3.4/32");
+            assertThat(cmd.getResult().getStatus()).isEqualTo(JobStatus.success);
+        }
+
+        @Test
+        void withValidationException() throws ApiException {
+            AclProfileApi aclProfileApi = Mockito.mock(AclProfileApi.class);
+            when(sempApiProvider.getAclProfileApi()).thenReturn(aclProfileApi);
+            when((aclProfileApi).deleteMsgVpnAclProfileClientConnectException(any(), any(), any())).thenReturn(new SempMetaOnlyResponse());
+            Command cmd = Command.builder()
+                    .commandType(CommandType.semp)
+                    .command(SEMP_DELETE_OPERATION)
+                    .parameters(createDeleteAclClientConnectExceptionParameters(false))
+                    .build();
+            sempDeleteCommandManager.execute(cmd, sempApiProvider);
+            verifyNoInteractions(aclProfileApi);
+            assertThat(cmd.getResult().getStatus()).isEqualTo(JobStatus.error);
+        }
+
+        @Test
+        void withNotFoundException() throws ApiException {
+            AclProfileApi aclProfileApi = Mockito.mock(AclProfileApi.class);
+            when(sempApiProvider.getAclProfileApi()).thenReturn(aclProfileApi);
+            when((aclProfileApi).deleteMsgVpnAclProfileClientConnectException(any(), any(), any()))
+                    .thenThrow(createaNotFoundApiException(SEMP_RESPONSE_MISSING_RESOURCE));
+            Command cmd = Command.builder()
+                    .commandType(CommandType.semp)
+                    .command(SEMP_DELETE_OPERATION)
+                    .parameters(createDeleteAclClientConnectExceptionParameters(true))
+                    .build();
+            sempDeleteCommandManager.execute(cmd, sempApiProvider);
+            verify(aclProfileApi).deleteMsgVpnAclProfileClientConnectException("default", "aclProfileName", "1.2.3.4/32");
+            assertThat(cmd.getResult().getStatus()).isEqualTo(JobStatus.success);
+        }
+
+        @Test
+        void withException() throws ApiException {
+            AclProfileApi aclProfileApi = Mockito.mock(AclProfileApi.class);
+            when(sempApiProvider.getAclProfileApi()).thenReturn(aclProfileApi);
+            when((aclProfileApi).deleteMsgVpnAclProfileClientConnectException("default", "aclProfileName", "1.2.3.4/32"))
+                    .thenThrow(createaServerErrorApiException());
+            Command cmd = Command.builder()
+                    .commandType(CommandType.semp)
+                    .command(SEMP_DELETE_OPERATION)
+                    .parameters(createDeleteAclClientConnectExceptionParameters(true))
+                    .build();
+            sempDeleteCommandManager.execute(cmd, sempApiProvider);
+            verify(aclProfileApi).deleteMsgVpnAclProfileClientConnectException("default", "aclProfileName", "1.2.3.4/32");
             assertThat(cmd.getResult().getStatus()).isEqualTo(JobStatus.error);
         }
 
@@ -1132,6 +1199,20 @@ public class SempDeleteCommandManagerTest {
             data.put("aclProfileName", "aclProfileName");
         }
         data.put("publishTopic", "a/b/c");
+        parameters.put(SEMP_COMMAND_DATA, data);
+        return parameters;
+    }
+
+    private Map<String, Object> createDeleteAclClientConnectExceptionParameters(boolean valid) {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(SEMP_COMMAND_ENTITY_TYPE, solaceAclClientConnectException.name());
+
+        Map<String, String> data = new HashMap<>();
+        data.put("msgVpn", "default");
+        if (valid) {
+            data.put("aclProfileName", "aclProfileName");
+        }
+        data.put("clientConnectExceptionAddress", "1.2.3.4/32");
         parameters.put(SEMP_COMMAND_DATA, data);
         return parameters;
     }


### PR DESCRIPTION
### What is the purpose of this change?

Adds EMA-side support for the SEMP DELETE of an ACL client connect exception (IP whitelist entry). This is the EMA half of a two-repo coordinated change; the matching ep-core change is tracked under DATAGO-134695 (https://sol-jira.atlassian.net/browse/DATAGO-134695).

### How was this change implemented?

Mirror the existing publish/subscribe topic exception delete pattern exactly. Four touches:

  - add solaceAclClientConnectException enum value.
  - SempAclClientConnectExceptionDeletionRequest.java (new) — POJO with msgVpn, aclProfileName, clientConnectExceptionAddress. 
    - No topicSyntax field — unlike topic exceptions, the SEMP API for client connect exception takes 3 path params, not 4.
  - SempDeleteCommandManager.java — new switch case + executeDeleteAclClientConnectException(...) handler. Same shape as executeDeleteAclPublishTopicException

### How was this change tested?
  - ITs
  - End-to-end on ep-perf will be exercised once the matching ep-core PR lands behind its feature flag: push [1.2.3.4/32, 5.6.7.8/32] → push [5.6.7.8/32] → SEMP GET confirms only 5.6.7.8/32 remains.

### Is there anything the reviewers should focus on/be aware of?

- EMA changes must be in prod before ep-core starts emitting solaceAclClientConnectException commands. 
- An older EMA receiving this command type will throw IllegalArgumentException: Unsupported SEMP delete entity
  type and fail the entire config push.
