### PR TITLE
DATAGO-136804: Fix tomcat and bouncycastle CVEs via version overrides

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -46,10 +46,16 @@
              Spring Boot BOM uses this property to manage all io.netty:* versions.
              Applies to plugin and application modules (inheritors of this parent). -->
         <netty.version>4.1.133.Final</netty.version>
+        <tomcat.version>10.1.55</tomcat.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>1.84</version>
+            </dependency>
             <!-- Fix CVE-2025-48924: commons-lang3 uncontrolled recursion (override Spring Boot BOM 3.17.0) -->
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
### What is the purpose of this change?

- Override tomcat.version to 10.1.55 (fixes CVE-2026-41293, CVE-2026-43512, CVE-2026-43515, CVE-2026-41284, CVE-2026-42498, CVE-2026-43513)
- Override bcprov-jdk18on to 1.84 (fixes CVE-2026-5598, CVE-2026-0636)

DATAGO-136804, DATAGO-133787, DATAGO-132555

### How was this change implemented?

    ...

### How was this change tested?

    ...

### Is there anything the reviewers should focus on/be aware of?

    ...
