### PR TITLE
DATAGO-138201: suppress broker INVALID_PARAMETER on RDP queue-binding request-header DELETE

### DIFF
--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/SempDeleteCommandManager.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/SempDeleteCommandManager.java
@@ -325,45 +325,23 @@ public class SempDeleteCommandManager extends AbstractSempCommandManager {
         Validate.notEmpty(request.getRdpName(), "RDP name must not be empty");
         Validate.notEmpty(request.getQueueBindingName(), "Queue binding name must not be empty");
 
-        // Pre-flight GET: skip the DELETE if the header is not on the broker.
-        // The broker can return INVALID_PARAMETER (not NOT_FOUND) when deleting a
-        // header that was recorded but never accepted on an earlier CREATE.
+        String entityType = request.isProtected() ? "Protected Request Header" : "Request Header";
         try {
             if (request.isProtected()) {
-                restDeliveryPointApi.getMsgVpnRestDeliveryPointQueueBindingProtectedRequestHeader(
-                        request.getMsgVpn(), request.getRdpName(),
-                        request.getQueueBindingName(), request.getHeaderName(),
-                        null, null);
-            } else {
-                restDeliveryPointApi.getMsgVpnRestDeliveryPointQueueBindingRequestHeader(
-                        request.getMsgVpn(), request.getRdpName(),
-                        request.getQueueBindingName(), request.getHeaderName(),
-                        null, null);
-            }
-        } catch (ApiException e) {
-            handleSempOperationException(e,
-                    request.isProtected() ? "Protected Request Header" : "Request Header",
-                    supportedSempCommand());
-            return;
-        }
-
-        if (request.isProtected()) {
-            log.info("SEMP delete: Deleting protected request header");
-            try {
+                log.info("SEMP delete: Deleting protected request header");
                 restDeliveryPointApi.deleteMsgVpnRestDeliveryPointQueueBindingProtectedRequestHeader(request.getMsgVpn(), request.getRdpName(),
                         request.getQueueBindingName(), request.getHeaderName());
-            } catch (ApiException e) {
-                handleSempOperationException(e, "Protected Request Header", supportedSempCommand());
-            }
-        } else {
-            log.info("SEMP delete: Deleting request header");
-            try {
+            } else {
+                log.info("SEMP delete: Deleting request header");
                 restDeliveryPointApi.deleteMsgVpnRestDeliveryPointQueueBindingRequestHeader(request.getMsgVpn(), request.getRdpName(),
                         request.getQueueBindingName(), request.getHeaderName());
-            } catch (ApiException e) {
-                handleSempOperationException(e, "Request Header", supportedSempCommand());
             }
+        } catch (ApiException e) {
+            if (e.getCode() == 400 && e.getResponseBody() != null && e.getResponseBody().contains("INVALID_PARAMETER")) {
+                log.info("SEMP {}: broker rejected {} identifier as invalid; treating as not present", supportedSempCommand(), entityType);
+                return;
+            }
+            handleSempOperationException(e, entityType, supportedSempCommand());
         }
-
     }
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/SempDeleteCommandManager.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/command/SempDeleteCommandManager.java
@@ -324,6 +324,29 @@ public class SempDeleteCommandManager extends AbstractSempCommandManager {
         Validate.notEmpty(request.getMsgVpn(), MSG_VPN_EMPTY_ERROR_MSG);
         Validate.notEmpty(request.getRdpName(), "RDP name must not be empty");
         Validate.notEmpty(request.getQueueBindingName(), "Queue binding name must not be empty");
+
+        // Pre-flight GET: skip the DELETE if the header is not on the broker.
+        // The broker can return INVALID_PARAMETER (not NOT_FOUND) when deleting a
+        // header that was recorded but never accepted on an earlier CREATE.
+        try {
+            if (request.isProtected()) {
+                restDeliveryPointApi.getMsgVpnRestDeliveryPointQueueBindingProtectedRequestHeader(
+                        request.getMsgVpn(), request.getRdpName(),
+                        request.getQueueBindingName(), request.getHeaderName(),
+                        null, null);
+            } else {
+                restDeliveryPointApi.getMsgVpnRestDeliveryPointQueueBindingRequestHeader(
+                        request.getMsgVpn(), request.getRdpName(),
+                        request.getQueueBindingName(), request.getHeaderName(),
+                        null, null);
+            }
+        } catch (ApiException e) {
+            handleSempOperationException(e,
+                    request.isProtected() ? "Protected Request Header" : "Request Header",
+                    supportedSempCommand());
+            return;
+        }
+
         if (request.isProtected()) {
             log.info("SEMP delete: Deleting protected request header");
             try {

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/commandManager/SempDeleteCommandManagerTest.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/commandManager/SempDeleteCommandManagerTest.java
@@ -49,6 +49,7 @@ import static com.solace.maas.ep.event.management.agent.plugin.command.model.Sem
 import static com.solace.maas.ep.event.management.agent.plugin.command.model.SempCommandConstants.SEMP_DELETE_OPERATION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -1009,6 +1010,40 @@ public class SempDeleteCommandManagerTest {
             verify(rdpApi).deleteMsgVpnRestDeliveryPointQueueBindingRequestHeader("default", "someRdp", "someQueueBindingName", "someHeaderName");
             assertThat(cmd.getResult().getStatus()).isEqualTo(JobStatus.success);
         }
+
+        @Test
+        void withPreFlightGetNotFound() throws ApiException {
+            RestDeliveryPointApi rdpApi = Mockito.mock(RestDeliveryPointApi.class);
+            when(sempApiProvider.getRestDeliveryPointApi()).thenReturn(rdpApi);
+            when(rdpApi.getMsgVpnRestDeliveryPointQueueBindingRequestHeader(any(), any(), any(), any(), any(), any()))
+                    .thenThrow(createaNotFoundApiException(SEMP_RESPONSE_MISSING_RESOURCE));
+            Command cmd = Command.builder()
+                    .commandType(CommandType.semp)
+                    .command(SEMP_DELETE_OPERATION)
+                    .parameters(createDeleteRdpQueueBindingRequestHeaderParameters(true, false))
+                    .build();
+            sempDeleteCommandManager.execute(cmd, sempApiProvider);
+            verify(rdpApi).getMsgVpnRestDeliveryPointQueueBindingRequestHeader("default", "someRdp", "someQueueBindingName", "someHeaderName", null, null);
+            verify(rdpApi, never()).deleteMsgVpnRestDeliveryPointQueueBindingRequestHeader(any(), any(), any(), any());
+            assertThat(cmd.getResult().getStatus()).isEqualTo(JobStatus.success);
+        }
+
+        @Test
+        void withPreFlightGetServerError() throws ApiException {
+            RestDeliveryPointApi rdpApi = Mockito.mock(RestDeliveryPointApi.class);
+            when(sempApiProvider.getRestDeliveryPointApi()).thenReturn(rdpApi);
+            when(rdpApi.getMsgVpnRestDeliveryPointQueueBindingRequestHeader(any(), any(), any(), any(), any(), any()))
+                    .thenThrow(createaServerErrorApiException());
+            Command cmd = Command.builder()
+                    .commandType(CommandType.semp)
+                    .command(SEMP_DELETE_OPERATION)
+                    .parameters(createDeleteRdpQueueBindingRequestHeaderParameters(true, false))
+                    .build();
+            sempDeleteCommandManager.execute(cmd, sempApiProvider);
+            verify(rdpApi).getMsgVpnRestDeliveryPointQueueBindingRequestHeader("default", "someRdp", "someQueueBindingName", "someHeaderName", null, null);
+            verify(rdpApi, never()).deleteMsgVpnRestDeliveryPointQueueBindingRequestHeader(any(), any(), any(), any());
+            assertThat(cmd.getResult().getStatus()).isEqualTo(JobStatus.error);
+        }
     }
 
     @Nested
@@ -1073,6 +1108,42 @@ public class SempDeleteCommandManagerTest {
             sempDeleteCommandManager.execute(cmd, sempApiProvider);
             verify(rdpApi).deleteMsgVpnRestDeliveryPointQueueBindingProtectedRequestHeader("default", "someRdp", "someQueueBindingName", "someHeaderName");
             assertThat(cmd.getResult().getStatus()).isEqualTo(JobStatus.success);
+        }
+
+        @Test
+        void withPreFlightGetNotFound() throws ApiException {
+            RestDeliveryPointApi rdpApi = Mockito.mock(RestDeliveryPointApi.class);
+            when(sempApiProvider.getRestDeliveryPointApi()).thenReturn(rdpApi);
+            when(rdpApi.getMsgVpnRestDeliveryPointQueueBindingProtectedRequestHeader(any(), any(), any(), any(), any(), any()))
+                    .thenThrow(createaNotFoundApiException(SEMP_RESPONSE_MISSING_RESOURCE));
+            Command cmd = Command.builder()
+                    .commandType(CommandType.semp)
+                    .command(SEMP_DELETE_OPERATION)
+                    .parameters(createDeleteRdpQueueBindingRequestHeaderParameters(true, true))
+                    .build();
+            sempDeleteCommandManager.execute(cmd, sempApiProvider);
+            verify(rdpApi).getMsgVpnRestDeliveryPointQueueBindingProtectedRequestHeader(
+                    "default", "someRdp", "someQueueBindingName", "someHeaderName", null, null);
+            verify(rdpApi, never()).deleteMsgVpnRestDeliveryPointQueueBindingProtectedRequestHeader(any(), any(), any(), any());
+            assertThat(cmd.getResult().getStatus()).isEqualTo(JobStatus.success);
+        }
+
+        @Test
+        void withPreFlightGetServerError() throws ApiException {
+            RestDeliveryPointApi rdpApi = Mockito.mock(RestDeliveryPointApi.class);
+            when(sempApiProvider.getRestDeliveryPointApi()).thenReturn(rdpApi);
+            when(rdpApi.getMsgVpnRestDeliveryPointQueueBindingProtectedRequestHeader(any(), any(), any(), any(), any(), any()))
+                    .thenThrow(createaServerErrorApiException());
+            Command cmd = Command.builder()
+                    .commandType(CommandType.semp)
+                    .command(SEMP_DELETE_OPERATION)
+                    .parameters(createDeleteRdpQueueBindingRequestHeaderParameters(true, true))
+                    .build();
+            sempDeleteCommandManager.execute(cmd, sempApiProvider);
+            verify(rdpApi).getMsgVpnRestDeliveryPointQueueBindingProtectedRequestHeader(
+                    "default", "someRdp", "someQueueBindingName", "someHeaderName", null, null);
+            verify(rdpApi, never()).deleteMsgVpnRestDeliveryPointQueueBindingProtectedRequestHeader(any(), any(), any(), any());
+            assertThat(cmd.getResult().getStatus()).isEqualTo(JobStatus.error);
         }
     }
 

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/commandManager/SempDeleteCommandManagerTest.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/commandManager/SempDeleteCommandManagerTest.java
@@ -49,7 +49,6 @@ import static com.solace.maas.ep.event.management.agent.plugin.command.model.Sem
 import static com.solace.maas.ep.event.management.agent.plugin.command.model.SempCommandConstants.SEMP_DELETE_OPERATION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -61,6 +60,7 @@ public class SempDeleteCommandManagerTest {
 
     private final static String DIR_SEMP_RESOURCES = "src/test/resources/sempResponses/";
     private final static String SEMP_RESPONSE_MISSING_RESOURCE = "sempResponseMissingResource.json";
+    private final static String SEMP_RESPONSE_INVALID_PARAMETER = "sempResponseInvalidParameter.json";
 
     @MockitoSpyBean
     private SempDeleteCommandManager sempDeleteCommandManager;
@@ -1012,37 +1012,19 @@ public class SempDeleteCommandManagerTest {
         }
 
         @Test
-        void withPreFlightGetNotFound() throws ApiException {
+        void withInvalidParameterException() throws ApiException {
             RestDeliveryPointApi rdpApi = Mockito.mock(RestDeliveryPointApi.class);
             when(sempApiProvider.getRestDeliveryPointApi()).thenReturn(rdpApi);
-            when(rdpApi.getMsgVpnRestDeliveryPointQueueBindingRequestHeader(any(), any(), any(), any(), any(), any()))
-                    .thenThrow(createaNotFoundApiException(SEMP_RESPONSE_MISSING_RESOURCE));
+            when((rdpApi).deleteMsgVpnRestDeliveryPointQueueBindingRequestHeader(any(), any(), any(), any()))
+                    .thenThrow(createInvalidParameterApiException(SEMP_RESPONSE_INVALID_PARAMETER));
             Command cmd = Command.builder()
                     .commandType(CommandType.semp)
                     .command(SEMP_DELETE_OPERATION)
                     .parameters(createDeleteRdpQueueBindingRequestHeaderParameters(true, false))
                     .build();
             sempDeleteCommandManager.execute(cmd, sempApiProvider);
-            verify(rdpApi).getMsgVpnRestDeliveryPointQueueBindingRequestHeader("default", "someRdp", "someQueueBindingName", "someHeaderName", null, null);
-            verify(rdpApi, never()).deleteMsgVpnRestDeliveryPointQueueBindingRequestHeader(any(), any(), any(), any());
+            verify(rdpApi).deleteMsgVpnRestDeliveryPointQueueBindingRequestHeader("default", "someRdp", "someQueueBindingName", "someHeaderName");
             assertThat(cmd.getResult().getStatus()).isEqualTo(JobStatus.success);
-        }
-
-        @Test
-        void withPreFlightGetServerError() throws ApiException {
-            RestDeliveryPointApi rdpApi = Mockito.mock(RestDeliveryPointApi.class);
-            when(sempApiProvider.getRestDeliveryPointApi()).thenReturn(rdpApi);
-            when(rdpApi.getMsgVpnRestDeliveryPointQueueBindingRequestHeader(any(), any(), any(), any(), any(), any()))
-                    .thenThrow(createaServerErrorApiException());
-            Command cmd = Command.builder()
-                    .commandType(CommandType.semp)
-                    .command(SEMP_DELETE_OPERATION)
-                    .parameters(createDeleteRdpQueueBindingRequestHeaderParameters(true, false))
-                    .build();
-            sempDeleteCommandManager.execute(cmd, sempApiProvider);
-            verify(rdpApi).getMsgVpnRestDeliveryPointQueueBindingRequestHeader("default", "someRdp", "someQueueBindingName", "someHeaderName", null, null);
-            verify(rdpApi, never()).deleteMsgVpnRestDeliveryPointQueueBindingRequestHeader(any(), any(), any(), any());
-            assertThat(cmd.getResult().getStatus()).isEqualTo(JobStatus.error);
         }
     }
 
@@ -1111,39 +1093,19 @@ public class SempDeleteCommandManagerTest {
         }
 
         @Test
-        void withPreFlightGetNotFound() throws ApiException {
+        void withInvalidParameterException() throws ApiException {
             RestDeliveryPointApi rdpApi = Mockito.mock(RestDeliveryPointApi.class);
             when(sempApiProvider.getRestDeliveryPointApi()).thenReturn(rdpApi);
-            when(rdpApi.getMsgVpnRestDeliveryPointQueueBindingProtectedRequestHeader(any(), any(), any(), any(), any(), any()))
-                    .thenThrow(createaNotFoundApiException(SEMP_RESPONSE_MISSING_RESOURCE));
+            when((rdpApi).deleteMsgVpnRestDeliveryPointQueueBindingProtectedRequestHeader(any(), any(), any(), any()))
+                    .thenThrow(createInvalidParameterApiException(SEMP_RESPONSE_INVALID_PARAMETER));
             Command cmd = Command.builder()
                     .commandType(CommandType.semp)
                     .command(SEMP_DELETE_OPERATION)
                     .parameters(createDeleteRdpQueueBindingRequestHeaderParameters(true, true))
                     .build();
             sempDeleteCommandManager.execute(cmd, sempApiProvider);
-            verify(rdpApi).getMsgVpnRestDeliveryPointQueueBindingProtectedRequestHeader(
-                    "default", "someRdp", "someQueueBindingName", "someHeaderName", null, null);
-            verify(rdpApi, never()).deleteMsgVpnRestDeliveryPointQueueBindingProtectedRequestHeader(any(), any(), any(), any());
+            verify(rdpApi).deleteMsgVpnRestDeliveryPointQueueBindingProtectedRequestHeader("default", "someRdp", "someQueueBindingName", "someHeaderName");
             assertThat(cmd.getResult().getStatus()).isEqualTo(JobStatus.success);
-        }
-
-        @Test
-        void withPreFlightGetServerError() throws ApiException {
-            RestDeliveryPointApi rdpApi = Mockito.mock(RestDeliveryPointApi.class);
-            when(sempApiProvider.getRestDeliveryPointApi()).thenReturn(rdpApi);
-            when(rdpApi.getMsgVpnRestDeliveryPointQueueBindingProtectedRequestHeader(any(), any(), any(), any(), any(), any()))
-                    .thenThrow(createaServerErrorApiException());
-            Command cmd = Command.builder()
-                    .commandType(CommandType.semp)
-                    .command(SEMP_DELETE_OPERATION)
-                    .parameters(createDeleteRdpQueueBindingRequestHeaderParameters(true, true))
-                    .build();
-            sempDeleteCommandManager.execute(cmd, sempApiProvider);
-            verify(rdpApi).getMsgVpnRestDeliveryPointQueueBindingProtectedRequestHeader(
-                    "default", "someRdp", "someQueueBindingName", "someHeaderName", null, null);
-            verify(rdpApi, never()).deleteMsgVpnRestDeliveryPointQueueBindingProtectedRequestHeader(any(), any(), any(), any());
-            assertThat(cmd.getResult().getStatus()).isEqualTo(JobStatus.error);
         }
     }
 
@@ -1345,6 +1307,10 @@ public class SempDeleteCommandManagerTest {
     }
 
     private ApiException createaNotFoundApiException(String resourceName) {
+        return new ApiException(400, "", new HashMap<>(), readSempResponseResource(resourceName));
+    }
+
+    private ApiException createInvalidParameterApiException(String resourceName) {
         return new ApiException(400, "", new HashMap<>(), readSempResponseResource(resourceName));
     }
 

--- a/service/application/src/test/resources/sempResponses/sempResponseInvalidParameter.json
+++ b/service/application/src/test/resources/sempResponses/sempResponseInvalidParameter.json
@@ -1,0 +1,14 @@
+{
+  "meta": {
+    "error": {
+      "code": 11,
+      "description": "'headerName' validation failed: Please use the HTTP header authentication scheme for the Authorization header, where the header value will be better protected.",
+      "status": "INVALID_PARAMETER"
+    },
+    "request": {
+      "method": "DELETE",
+      "uri": "https://some.url.pointing.to.solace.broker"
+    },
+    "responseCode": 400
+  }
+}


### PR DESCRIPTION
### What is the purpose of this change?

EMA's config push deletes RDP queue-binding request headers via SEMP.  When a user configures a header name the broker doesn't accept (e.g. `Authorization`, which is reserved), the first push fails on the CREATE. That part is expected.
The problem is the recovery push (this is the reported bug). When the user removes the bad header and pushes again, ep-core asks EMA to delete the stale header from the broker. The broker rejects this DELETE with `400 + status: "INVALID_PARAMETER"`.  EMA only knows how to swallow `400 + NOT_FOUND`, so it rethrows and the push fails.

Note: based on manual testing, a third push then succeeds on its own, but the customer still has to live through one failed recovery push. This fix removes that.

Bug link: https://sol-jira.atlassian.net/browse/DATAGO-138201

### How was this change implemented?

Changed `SempDeleteCommandManager.executeRdpQueueBindingRequestHeader` (regular + protected variants). After the DELETE call, two broker responses are now suppressed instead of one:

  - `400 + NOT_FOUND` — already handled by the shared `handleSempOperationException`. Unchanged.
  - `400 + INVALID_PARAMETER` — new. Logged at INFO with entity type only. Returns success.

Anything else still rethrows.

### How was this change tested?

Manual test on ep-perf: push 1 with bad header fails as expected. Push 2 with the header removed used to fail on the SEMP DELETE — now it succeeds.

### Is there anything the reviewers should focus on/be aware of?

**Other DELETE surfaces** in `SempDeleteCommandManager` (ACL profile, etc.) may have the same class of bug (flagged by Claude, but I didn't test yet), will investigate separately
