### PR TITLE
DATAGO-139678: download release JAR in publish job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -120,15 +120,24 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ needs.maven_release.outputs.tag }}
+      - name: Download release JAR from GitHub Packages
+        # publish runs on a separate runner from maven_release, so target/ is empty.
+        # mvn release:perform already deployed the JAR to GitHub Packages — fetch it
+        # so Create GitHub Release has an artifact to attach.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.maven_release.outputs.version }}
+        run: |
+          mkdir -p service/application/target
+          curl -sSfL -u "${{ github.actor }}:$GH_TOKEN" \
+            "https://maven.pkg.github.com/SolaceProducts/event-management-agent/com/solace/maas/event-management-agent/$VERSION/event-management-agent-$VERSION.jar" \
+            -o "service/application/target/event-management-agent-$VERSION.jar"
+          ls -la "service/application/target/event-management-agent-$VERSION.jar"
       - name: Changelog
         uses: Bullrich/generate-release-changelog@master
         id: Changelog
         env:
           REPO: ${{ github.repository }}
-      - name: Debug - List JAR files
-        run: |
-          echo "Listing all JAR files in target directories:"
-          find . -name "*.jar" | grep "target"
       - name: Create GitHub Release
         uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b # v1.20.0
         with:


### PR DESCRIPTION
### What is the purpose of this change?

The `Publish Release` job of the EMA release workflow has been broken since the DATAGO-138311 refactor. It just hit us during the in-flight **v1.9.9** prod release — workflow run [27224528682](https://github.com/SolaceProducts/event-management-agent/actions/runs/27224528682) — leaving the release half-done (git tag pushed, Maven artifacts deployed, **but** no GitHub Release, no ECR re-tag, no Manifest DB write).

Before DATAGO-138311 (#304), everything ran in **one big job** on **one runner**:

  ```
  release  ──►  readiness checks  →  mvn release  →  Create GH Release  →  ECR retag  →  Manifest DB
                                     (JAR built into target/)   (target/ still there)
  ```
  
  DATAGO-138311 split it into **three jobs** for the new Guardian gate:
  
  ```
  release_readiness  ──►  maven_release  ──►  publish
                          (JAR built          (fresh runner —
                           into target/)       NO target/, NO JAR)
  ```

The `publish` job is a **brand new runner**. It runs `actions/checkout` on the just-pushed `v1.9.9` tag, but it never runs `mvn`. So there is no `target/` directory and no JAR file anywhere on this runner.

The job has this step:
  
  ```yaml
  - name: Debug - List JAR files
    run: |
      echo "Listing all JAR files in target directories:"
      find . -name "*.jar" | grep "target"
  ```

When `find` outputs nothing, `grep "target"` exits with code 1 (no match). The step runs under `bash -e`, so exit-1 fails the step. Because the step fails, every step after it in the same job is **skipped** — including the three steps that actually matter:

  1. `Create GitHub Release` (would have created the `v1.9.9` release with the JAR attached)
  2. `ECR Docker Image Release` (would have re-tagged ECR `main` → `1.9.9`)
  3. `Update Release Manifest DB` (would have recorded `1.9.9` as the current prod version)

### How was this change implemented?

`mvn release:perform` in the previous (`maven_release`) job already deployed the JAR to **GitHub Packages**:

  ```
  https://maven.pkg.github.com/SolaceProducts/event-management-agent/
    com/solace/maas/event-management-agent/<VERSION>/event-management-agent-<VERSION>.jar
  ```

This PR adds **one new step** to the `publish` job that downloads that JAR into `service/application/target/` before `Create GitHub Release` runs. The existing artifact glob in `Create GitHub Release` (`**/application/target/event-management-agent-<VERSION>.jar`) then matches it normally, just like it did in the v1.9.8 single-job design.
  
The broken `Debug - List JAR files` step is removed — the new download step already does its own `ls -la` for visibility.

### How was this change tested?

Ran the exact `curl` command locally with my PAT:

  ```bash
  curl -sSfL -u "bol444:$(gh auth token)" \
    "https://maven.pkg.github.com/SolaceProducts/event-management-agent/com/solace/maas/event-management-agent/1.9.9/event-management-agent-1.9.9.
  jar" \
    -o /tmp/test.jar
  ```

Result: `HTTP 200`, **426.9 MB**, `Java archive data (JAR)`, ~30 sec. URL + Basic-auth shape work.

In the workflow, auth is `${{ github.actor }}` + `${{ secrets.GITHUB_TOKEN }}`. That has at least the same read access — `packages: write` on the workflow implies read, and it's the same `GITHUB_TOKEN` that originally deployed the package.

### Is there anything the reviewers should focus on/be aware of?

- The in-flight v1.9.9 release ([run 27224528682](https://github.com/SolaceProducts/event-management-agent/actions/runs/27224528682)) needs **"Re-run failed jobs"** clicked. Only the `publish` job re-runs (`release_readiness` and `maven_release` are both already success). It picks up the fixed workflow file from `main` and completes the three missing steps.
- **CI-only.** No application code is touched. The fix only modifies the publish job in `.github/workflows/release.yaml`.
- The new download step is the only new logic. Every other step in the publish job (`Changelog`, `Create GitHub Release`, AWS config, ECR retag,
   Manifest DB write) is **unchanged** from what was running in v1.9.8 (where it worked) and v1.9.9 attempt 1.
