### PR TITLE
DATAGO-140514: bump kafka-clients

### DIFF
--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -17,7 +17,9 @@
         <snakeyaml.version>2.0</snakeyaml.version>
         <spring-security-rsa.version>1.1.3</spring-security-rsa.version>
         <spring-kafka.version>3.3.6</spring-kafka.version>
-        <kafka-clients.version>3.9.1</kafka-clients.version>
+        <!-- Fix CVE-2026-35554 (HIGH 8.7, producer race) + CVE-2026-33558 (MEDIUM 5.3, debug log info leak):
+             Kafka 3.9.1 → 3.9.2. Patch release on the 3.9.x LTS line; no API changes. -->
+        <kafka-clients.version>3.9.2</kafka-clients.version>
         <jackson.version>2.16.1</jackson.version>
         <awaitility.version>4.2.0</awaitility.version>
         <dockerfile-maven.version>1.4.13</dockerfile-maven.version>

--- a/service/kafka-plugin/pom.xml
+++ b/service/kafka-plugin/pom.xml
@@ -11,7 +11,9 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <spring-kafka.version>3.3.6</spring-kafka.version>
-        <kafka-clients.version>3.9.1</kafka-clients.version>
+        <!-- Fix CVE-2026-35554 (HIGH 8.7, producer race) + CVE-2026-33558 (MEDIUM 5.3, debug log info leak):
+             Kafka 3.9.1 → 3.9.2. Patch release on the 3.9.x LTS line; no API changes. -->
+        <kafka-clients.version>3.9.2</kafka-clients.version>
         <spring-boot.version>3.5.14</spring-boot.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <jupiter.version>5.10.2</jupiter.version>


### PR DESCRIPTION
### What is the purpose of this change?

Fixes two Apache Kafka client CVEs:
- CVE-2026-35554 (HIGH 8.7): producer buffer-pool race under delivery.timeout.ms expiry can deliver messages to incorrect topics.
- CVE-2026-33558 (MEDIUM 5.3): NetworkClient logs sensitive admin/cred request/response bodies at DEBUG level.

Jira link: https://sol-jira.atlassian.net/browse/DATAGO-138704

Both fixed in kafka-clients 3.9.2 (patch release on the 3.9.x LTS line; no API changes).

Neither CVE is exploitable in EMA today (kafka-plugin uses only org.apache.kafka.clients.admin.AdminClient - no KafkaProducer.send(); INFO log level by default; EMA does not issue any of the sensitive admin or credential-management request types listed in CVE-2026-33558). Patch is taken for defense in depth and scanner SLA compliance.

### How was this change implemented?

bump kafka-clients 3.9.1 -> 3.9.2

Updates the <kafka-clients.version> property in both pom files that declare it:
  - service/application/pom.xml
  - service/kafka-plugin/pom.xml

### How was this change tested?

Verified:
  $ mvn -B dependency:tree -Dincludes='org.apache.kafka:kafka-clients'
  application and kafka-plugin both resolve kafka-clients:3.9.2.
  $ mvn -B clean compile -DskipTests
  BUILD SUCCESS (9/9 modules).

### Is there anything the reviewers should focus on/be aware of?

No
