### PR TITLE
DATAGO-140514: pin jackson-bom in rabbitmq-plugin

### DIFF
--- a/service/rabbitmq-plugin/pom.xml
+++ b/service/rabbitmq-plugin/pom.xml
@@ -15,6 +15,17 @@
     </properties>
     <dependencyManagement>
         <dependencies>
+            <!-- rabbitmq-plugin has no Spring Boot parent and no spring-boot-dependencies BOM import.
+                 com.rabbitmq:http-client:4.2.0 bundles jackson-databind 2.14.0, which leaks through
+                 without this pin. Fix CVE-2025-52999 (HIGH 8.7, jackson-core stack overflow on deeply
+                 nested JSON). 2.16.1 matches the jackson version every other EMA module uses. -->
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>2.16.1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- rabbitmq-plugin has no Spring Boot parent; Netty arrives transitively via plugin → reactor-netty.
                  This BOM pin fixes CVE-2026-42579/42583/42584/42585/42580/42581/41417/42587 (Netty 4.1.132 batch). -->
             <dependency>


### PR DESCRIPTION
### What is the purpose of this change?

Fixes CVE-2025-52999 (HIGH 8.7): jackson-core < 2.15.0 StackOverflowError on deeply nested JSON input.

Background: com.rabbitmq:http-client:4.2.0 (used by rabbitmq-plugin to parse RabbitMQ Management API responses) bundles jackson-databind:2.14.0. rabbitmq-plugin is the only EMA plugin pom that did not import jackson-bom in its <dependencyManagement>, so Maven's nearest-wins resolution let the 2.14.0 leak through despite the rest of EMA pinning jackson 2.16.1.

jira link: https://sol-jira.atlassian.net/browse/DATAGO-138705

### How was this change implemented?

Adds a jackson-bom:2.16.1 import in rabbitmq-plugin's <dependencyManagement> (mirroring the existing netty-bom pin pattern). Pins jackson-databind/core/ annotations to 2.16.1 - the same jackson version every other EMA module uses.

### How was this change tested?

Verified:
  $ mvn -B -pl rabbitmq-plugin dependency:tree -Dincludes='com.fasterxml.jackson*:*'
  jackson-{databind,core,annotations}:2.16.1 (was 2.14.0)
  $ mvn -B clean compile -DskipTests
  BUILD SUCCESS (9/9 modules).

### Is there anything the reviewers should focus on/be aware of?

Note: the second jackson CVE listed on DATAGO-138705 (GHSA-72hv-8253-57qq against jackson 2.16.1) is out of scope for this commit and will be addressed separately.
