### PR TITLE
DATAGO-140514: pin tomcat-embed in poms

### DIFF
--- a/service/confluent-schema-registry-plugin/pom.xml
+++ b/service/confluent-schema-registry-plugin/pom.xml
@@ -21,6 +21,27 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- confluent-schema-registry-plugin has no Spring Boot parent and no spring-boot-dependencies
+                 BOM import. spring-boot-starter-web (pulled via the plugin module) brings tomcat-embed-*
+                 transitively, and the <tomcat.version>10.1.55</tomcat.version> override in service/pom.xml
+                 does NOT reach this pom. Each artifact must be pinned explicitly.
+                 Fix CVE-2026-43515/43512/41293 (Critical) + CVE-2026-41284/43513/42498 (High):
+                 tomcat 10.1.54 → 10.1.55. -->
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>10.1.55</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-el</artifactId>
+                <version>10.1.55</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>10.1.55</version>
+            </dependency>
             <!-- confluent-schema-registry-plugin has no Spring Boot parent; Netty arrives transitively via plugin → reactor-netty.
                  This BOM pin fixes CVE-2026-42579/42583/42584/42585/42580/42581/41417/42587 (Netty 4.1.132 batch). -->
             <dependency>

--- a/service/kafka-plugin/pom.xml
+++ b/service/kafka-plugin/pom.xml
@@ -33,6 +33,27 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- kafka-plugin has no Spring Boot parent and no spring-boot-dependencies BOM import.
+                 spring-boot-starter-web (pulled via the plugin module) brings tomcat-embed-* transitively,
+                 and the <tomcat.version>10.1.55</tomcat.version> override in service/pom.xml does NOT
+                 reach this pom. Each artifact must be pinned explicitly.
+                 Fix CVE-2026-43515/43512/41293 (Critical) + CVE-2026-41284/43513/42498 (High):
+                 tomcat 10.1.54 → 10.1.55. -->
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>10.1.55</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-el</artifactId>
+                <version>10.1.55</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>10.1.55</version>
+            </dependency>
             <!-- kafka-plugin has no Spring Boot parent, so Spring Boot does not manage Netty here.
                  software.amazon.awssdk:netty-nio-client bundles its own Netty version (4.1.118.Final
                  as of awssdk 2.30.17), which would be used without this pin.

--- a/service/local-storage-plugin/pom.xml
+++ b/service/local-storage-plugin/pom.xml
@@ -31,6 +31,27 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- local-storage-plugin has no Spring Boot parent and no spring-boot-dependencies BOM import.
+                 spring-boot-starter-web brings tomcat-embed-* transitively, and the
+                 <tomcat.version>10.1.55</tomcat.version> override in service/pom.xml does NOT reach
+                 this pom. Each artifact must be pinned explicitly.
+                 Fix CVE-2026-43515/43512/41293 (Critical) + CVE-2026-41284/43513/42498 (High):
+                 tomcat 10.1.54 → 10.1.55. -->
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>10.1.55</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-el</artifactId>
+                <version>10.1.55</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>10.1.55</version>
+            </dependency>
             <!-- local-storage-plugin has no Spring Boot parent; Netty arrives transitively via plugin → reactor-netty.
                  This BOM pin fixes CVE-2026-42579/42583/42584/42585/42580/42581/41417/42587 (Netty 4.1.132 batch). -->
             <dependency>

--- a/service/rabbitmq-plugin/pom.xml
+++ b/service/rabbitmq-plugin/pom.xml
@@ -15,6 +15,27 @@
     </properties>
     <dependencyManagement>
         <dependencies>
+            <!-- rabbitmq-plugin has no Spring Boot parent and no spring-boot-dependencies BOM import.
+                 spring-boot-starter-web (pulled via the plugin module) brings tomcat-embed-* transitively,
+                 and the <tomcat.version>10.1.55</tomcat.version> override in service/pom.xml does NOT
+                 reach this pom. Each artifact must be pinned explicitly.
+                 Fix CVE-2026-43515/43512/41293 (Critical) + CVE-2026-41284/43513/42498 (High):
+                 tomcat 10.1.54 → 10.1.55. -->
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>10.1.55</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-el</artifactId>
+                <version>10.1.55</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>10.1.55</version>
+            </dependency>
             <!-- rabbitmq-plugin has no Spring Boot parent; Netty arrives transitively via plugin → reactor-netty.
                  This BOM pin fixes CVE-2026-42579/42583/42584/42585/42580/42581/41417/42587 (Netty 4.1.132 batch). -->
             <dependency>

--- a/service/solace-plugin/pom.xml
+++ b/service/solace-plugin/pom.xml
@@ -31,6 +31,27 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- solace-plugin has no Spring Boot parent and no spring-boot-dependencies BOM import.
+                 spring-boot-starter-web (pulled via the plugin module) brings tomcat-embed-* transitively,
+                 and the <tomcat.version>10.1.55</tomcat.version> override in service/pom.xml does NOT
+                 reach this pom. Each artifact must be pinned explicitly.
+                 Fix CVE-2026-43515/43512/41293 (Critical) + CVE-2026-41284/43513/42498 (High):
+                 tomcat 10.1.54 → 10.1.55. -->
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>10.1.55</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-el</artifactId>
+                <version>10.1.55</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>10.1.55</version>
+            </dependency>
             <!-- solace-plugin has no Spring Boot parent; Netty arrives transitively via plugin → reactor-netty.
                  This BOM pin fixes CVE-2026-42579/42583/42584/42585/42580/42581/41417/42587 (Netty 4.1.132 batch). -->
             <dependency>

--- a/service/terraform-plugin/pom.xml
+++ b/service/terraform-plugin/pom.xml
@@ -22,6 +22,27 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- terraform-plugin has no Spring Boot parent and no spring-boot-dependencies BOM import.
+                 spring-boot-starter-web brings tomcat-embed-* transitively, and the
+                 <tomcat.version>10.1.55</tomcat.version> override in service/pom.xml does NOT reach
+                 this pom. Each artifact must be pinned explicitly.
+                 Fix CVE-2026-43515/43512/41293 (Critical) + CVE-2026-41284/43513/42498 (High):
+                 tomcat 10.1.54 → 10.1.55. -->
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>10.1.55</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-el</artifactId>
+                <version>10.1.55</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>10.1.55</version>
+            </dependency>
             <!-- terraform-plugin has no Spring Boot parent; Netty arrives transitively via plugin → reactor-netty.
                  This BOM pin fixes CVE-2026-42579/42583/42584/42585/42580/42581/41417/42587 (Netty 4.1.132 batch). -->
             <dependency>


### PR DESCRIPTION
### What is the purpose of this change?

Fixes 6 Tomcat CVEs flagged by fossa against tomcat-embed-core 10.1.54: CVE-2026-43515, CVE-2026-43512, CVE-2026-41293 (Critical) and CVE-2026-41284, CVE-2026-43513, CVE-2026-42498 (High). All fixed in 10.1.55.

Background: service/pom.xml already declares <tomcat.version>10.1.55</tomcat.version>
to override Spring Boot's BOM, but that override only reaches the two modules that inherit maas-event-management-agent-parent (application, plugin). The 6 standalone plugin poms have no <parent> element and no spring-boot-dependencies BOM import, so Spring Boot's <tomcat.version> override does not apply there - they fall through to Spring Boot 3.5.14's bundled tomcat (10.1.54).

jira link: https://sol-jira.atlassian.net/browse/DATAGO-138707

### How was this change implemented?

This change pins tomcat-embed-{core,el,websocket}:10.1.55 in <dependencyManagement> of each of the 6 standalone plugin poms (kafka, solace, rabbitmq, terraform, local-storage, confluent-schema-registry). rabbitmq-plugin is included because it pulls tomcat transitively via its com.solace.maas:plugin dep -> spring-boot-starter-web.

Pattern mirrors the existing netty-bom pins already present in each of these poms (see DATAGO-129869 / netty BOM lifecycle).

### How was this change tested?

Verified:
  $ mvn -B dependency:tree -Dincludes='org.apache.tomcat.embed:*'
  All 9 modules resolve tomcat-embed-{core,el,websocket}:10.1.55.
  $ mvn -B clean compile -DskipTests
  BUILD SUCCESS (9/9 modules).

### Is there anything the reviewers should focus on/be aware of?

No
