### PR TITLE
DATAGO-140514: bump netty-bom 4.1.133.Final -> 4.1.135.Final

### DIFF
--- a/service/confluent-schema-registry-plugin/pom.xml
+++ b/service/confluent-schema-registry-plugin/pom.xml
@@ -43,11 +43,12 @@
                 <version>10.1.55</version>
             </dependency>
             <!-- confluent-schema-registry-plugin has no Spring Boot parent; Netty arrives transitively via plugin → reactor-netty.
-                 This BOM pin fixes CVE-2026-42579/42583/42584/42585/42580/42581/41417/42587 (Netty 4.1.132 batch). -->
+                 Current bump 4.1.133 → 4.1.135 fixes CVE-2026-44249/45416 (netty-handler) +
+                 CVE-2026-45674/47691/45673 (netty-resolver-dns). -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.133.Final</version>
+                <version>4.1.135.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/service/kafka-plugin/pom.xml
+++ b/service/kafka-plugin/pom.xml
@@ -62,11 +62,12 @@
                  This BOM pin forces Netty to match the version Spring Boot 3.5.14 manages in all
                  other EMA modules (via reactor-netty).
                  Review when upgrading awssdk:netty-nio-client or when kafka-plugin gains a Spring Boot parent.
-                 Fix CVE-2026-42579/42583/42584/42585/42580/42581/41417/42587: upgraded 4.1.132 → 4.1.133. -->
+                 Current bump 4.1.133 → 4.1.135 fixes CVE-2026-44249/45416 (netty-handler) +
+                 CVE-2026-45674/47691/45673 (netty-resolver-dns). -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.133.Final</version>
+                <version>4.1.135.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/service/local-storage-plugin/pom.xml
+++ b/service/local-storage-plugin/pom.xml
@@ -53,11 +53,12 @@
                 <version>10.1.55</version>
             </dependency>
             <!-- local-storage-plugin has no Spring Boot parent; Netty arrives transitively via plugin → reactor-netty.
-                 This BOM pin fixes CVE-2026-42579/42583/42584/42585/42580/42581/41417/42587 (Netty 4.1.132 batch). -->
+                 Current bump 4.1.133 → 4.1.135 fixes CVE-2026-44249/45416 (netty-handler) +
+                 CVE-2026-45674/47691/45673 (netty-resolver-dns). -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.133.Final</version>
+                <version>4.1.135.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -42,10 +42,12 @@
         <jacoco.line.percentage>0.8</jacoco.line.percentage>
         <camel.version>4.8.7</camel.version>
         <mockito-inline.version>5.2.0</mockito-inline.version>
-        <!-- Fix CVE-2026-42579 (CVSS 8.7), CVE-2026-42583/42584/42585/42580/42581/41417/42587: Netty 4.1.132 batch vulnerabilities.
-             Spring Boot BOM uses this property to manage all io.netty:* versions.
-             Applies to plugin and application modules (inheritors of this parent). -->
-        <netty.version>4.1.133.Final</netty.version>
+        <!-- Spring Boot BOM uses this property to manage all io.netty:* versions.
+             Applies to plugin and application modules (inheritors of this parent).
+             Prior bumps: 4.1.131 → 4.1.132 → 4.1.133 (CVE-2026-42579 + 4.1.132 batch).
+             Current: 4.1.133 → 4.1.135 fixes CVE-2026-44249/45416 (netty-handler) +
+             CVE-2026-45674/47691/45673 (netty-resolver-dns) + bonus CVE-2026-50010. -->
+        <netty.version>4.1.135.Final</netty.version>
         <tomcat.version>10.1.55</tomcat.version>
     </properties>
 

--- a/service/rabbitmq-plugin/pom.xml
+++ b/service/rabbitmq-plugin/pom.xml
@@ -47,11 +47,12 @@
                 <version>10.1.55</version>
             </dependency>
             <!-- rabbitmq-plugin has no Spring Boot parent; Netty arrives transitively via plugin → reactor-netty.
-                 This BOM pin fixes CVE-2026-42579/42583/42584/42585/42580/42581/41417/42587 (Netty 4.1.132 batch). -->
+                 Current bump 4.1.133 → 4.1.135 fixes CVE-2026-44249/45416 (netty-handler) +
+                 CVE-2026-45674/47691/45673 (netty-resolver-dns). -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.133.Final</version>
+                <version>4.1.135.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/service/solace-plugin/pom.xml
+++ b/service/solace-plugin/pom.xml
@@ -53,11 +53,12 @@
                 <version>10.1.55</version>
             </dependency>
             <!-- solace-plugin has no Spring Boot parent; Netty arrives transitively via plugin → reactor-netty.
-                 This BOM pin fixes CVE-2026-42579/42583/42584/42585/42580/42581/41417/42587 (Netty 4.1.132 batch). -->
+                 Current bump 4.1.133 → 4.1.135 fixes CVE-2026-44249/45416 (netty-handler) +
+                 CVE-2026-45674/47691/45673 (netty-resolver-dns). -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.133.Final</version>
+                <version>4.1.135.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/service/terraform-plugin/pom.xml
+++ b/service/terraform-plugin/pom.xml
@@ -44,11 +44,12 @@
                 <version>10.1.55</version>
             </dependency>
             <!-- terraform-plugin has no Spring Boot parent; Netty arrives transitively via plugin → reactor-netty.
-                 This BOM pin fixes CVE-2026-42579/42583/42584/42585/42580/42581/41417/42587 (Netty 4.1.132 batch). -->
+                 Current bump 4.1.133 → 4.1.135 fixes CVE-2026-44249/45416 (netty-handler) +
+                 CVE-2026-45674/47691/45673 (netty-resolver-dns). -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.133.Final</version>
+                <version>4.1.135.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
## Summary

Bump `netty-bom` from **4.1.133.Final → 4.1.135.Final** in all 7 EMA pom files (`service/pom.xml` + 6 standalone plugin poms). Fixes 5 CVEs across two Jira tickets:

- **[DATAGO-139492](https://sol-jira.atlassian.net/browse/DATAGO-139492)** (`netty-handler`)
  - CVE-2026-44249 — HIGH 8.1 — IPv6 subnet filter ACL bypass
  - CVE-2026-45416 — HIGH 7.5 — SniHandler ClientHello DoS
- **[DATAGO-139494](https://sol-jira.atlassian.net/browse/DATAGO-139494)** (`netty-resolver-dns`)
  - CVE-2026-45674 — HIGH 8.7 — DNS cache poisoning
  - CVE-2026-47691 — HIGH 8.7 — DNS cache poisoning (NS bailiwick)
  - CVE-2026-45673 — MEDIUM 6.8 — DNS cache poisoning

Also preempts **CVE-2026-50010** (TLS hostname verification bypass) which 4.1.135 fixes — EMA hasn't been flagged for it yet but the next scan likely would.

## Why PATCH (not exclude)

- `netty-resolver-dns` sits on an **active EMA code path**: reactor-netty's default `DnsAddressResolverGroup` resolves every outbound SEMP WebClient call. The "architecturally unreachable" argument doesn't hold for the 3 DNS poisoning CVEs.
- `netty-handler` CVEs *are* architecturally unreachable (EMA's HTTP server is Tomcat, not Netty), but ride along free with the same pin bump.
- Pin is **already actively maintained** — third bump in 6 months (4.1.131 → 4.1.132 → 4.1.133 → 4.1.135). No new stale-pin debt.
- Direct precedent: maas-ep-core just shipped the same `netty-bom` 4.1.133 → 4.1.135 bump for [DATAGO-139450](https://sol-jira.atlassian.net/browse/DATAGO-139450), covering the identical netty-handler CVE pair.

## Files changed

| File | Change |
|---|---|
| `service/pom.xml` | `<netty.version>` property + comment refresh |
| `service/kafka-plugin/pom.xml` | `netty-bom` pin (parent-less — must be updated independently) |
| `service/confluent-schema-registry-plugin/pom.xml` | `netty-bom` pin |
| `service/local-storage-plugin/pom.xml` | `netty-bom` pin |
| `service/rabbitmq-plugin/pom.xml` | `netty-bom` pin |
| `service/solace-plugin/pom.xml` | `netty-bom` pin |
| `service/terraform-plugin/pom.xml` | `netty-bom` pin |

The `<netty.version>` property in `service/pom.xml` does NOT cascade to the 6 standalone plugin poms (no Spring Boot `<parent>`), so each must be updated explicitly.

## Test plan

- [x] `mvn dependency:tree -Dincludes='io.netty:netty-handler'` — all 9 modules resolve `4.1.135.Final`, including parent-less kafka-plugin
- [x] `mvn dependency:tree -Dincludes='io.netty:netty-resolver-dns'` — all 9 modules resolve `4.1.135.Final`
- [x] `mvn clean compile` — BUILD SUCCESS, 9/9 modules
- [ ] CI test suite green
- [ ] Next Prisma/FOSSA scan clears CVEs from DATAGO-139492 + DATAGO-139494

🤖 Generated with [Claude Code](https://claude.com/claude-code)