### PR TITLE
DATAGO-138707: updating tomcat to v 10.1.55

### DIFF
--- a/service/confluent-schema-registry-plugin/pom.xml
+++ b/service/confluent-schema-registry-plugin/pom.xml
@@ -52,6 +52,25 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- Fix CVE-2026-43515/43512/41293/41284/43513/42498 (Tomcat 10.1.54 batch).
+                 This module has no Spring Boot <parent>, so the <tomcat.version> override in the
+                 parent pom does not reach it. Pin tomcat-embed-* to 10.1.55 to match what the
+                 application/plugin modules resolve via Spring Boot 3.5.14 + the parent override. -->
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>10.1.55</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-el</artifactId>
+                <version>10.1.55</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>10.1.55</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/service/kafka-plugin/pom.xml
+++ b/service/kafka-plugin/pom.xml
@@ -71,6 +71,25 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- Fix CVE-2026-43515/43512/41293/41284/43513/42498 (Tomcat 10.1.54 batch).
+                 This module has no Spring Boot <parent>, so the <tomcat.version> override in the
+                 parent pom does not reach it. Pin tomcat-embed-* to 10.1.55 to match what the
+                 application/plugin modules resolve via Spring Boot 3.5.14 + the parent override. -->
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>10.1.55</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-el</artifactId>
+                <version>10.1.55</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>10.1.55</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/service/local-storage-plugin/pom.xml
+++ b/service/local-storage-plugin/pom.xml
@@ -62,6 +62,25 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- Fix CVE-2026-43515/43512/41293/41284/43513/42498 (Tomcat 10.1.54 batch).
+                 This module has no Spring Boot <parent>, so the <tomcat.version> override in the
+                 parent pom does not reach it. Pin tomcat-embed-* to 10.1.55 to match what the
+                 application/plugin modules resolve via Spring Boot 3.5.14 + the parent override. -->
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>10.1.55</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-el</artifactId>
+                <version>10.1.55</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>10.1.55</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>

--- a/service/rabbitmq-plugin/pom.xml
+++ b/service/rabbitmq-plugin/pom.xml
@@ -56,6 +56,25 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- Fix CVE-2026-43515/43512/41293/41284/43513/42498 (Tomcat 10.1.54 batch).
+                 This module has no Spring Boot <parent>, so the <tomcat.version> override in the
+                 parent pom does not reach it. Pin tomcat-embed-* to 10.1.55 to match what the
+                 application/plugin modules resolve via Spring Boot 3.5.14 + the parent override. -->
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>10.1.55</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-el</artifactId>
+                <version>10.1.55</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>10.1.55</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/service/solace-plugin/pom.xml
+++ b/service/solace-plugin/pom.xml
@@ -62,6 +62,25 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- Fix CVE-2026-43515/43512/41293/41284/43513/42498 (Tomcat 10.1.54 batch).
+                 This module has no Spring Boot <parent>, so the <tomcat.version> override in the
+                 parent pom does not reach it. Pin tomcat-embed-* to 10.1.55 to match what the
+                 application/plugin modules resolve via Spring Boot 3.5.14 + the parent override. -->
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>10.1.55</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-el</artifactId>
+                <version>10.1.55</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>10.1.55</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/service/terraform-plugin/pom.xml
+++ b/service/terraform-plugin/pom.xml
@@ -53,6 +53,25 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- Fix CVE-2026-43515/43512/41293/41284/43513/42498 (Tomcat 10.1.54 batch).
+                 This module has no Spring Boot <parent>, so the <tomcat.version> override in the
+                 parent pom does not reach it. Pin tomcat-embed-* to 10.1.55 to match what the
+                 application/plugin modules resolve via Spring Boot 3.5.14 + the parent override. -->
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>10.1.55</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-el</artifactId>
+                <version>10.1.55</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>10.1.55</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
### What is the purpose of this change?


  This change patches a security vulnerability by upgrading the embedded Apache Tomcat runtime from 10.1.54 to 10.1.55 across the plugin modules. The commit comments explicitly call out the batch of CVEs being fixed:

  ▎ CVE-2026-43515 / 43512 / 41293 / 41284 / 43513 / 42498 (the Tomcat 10.1.54
  ▎ batch)

  The goal is to ensure all plugin modules resolve the patched tomcat-embed-* artifacts so they're not shipping the vulnerable 10.1.54 versions.

### How was this change implemented?

The change adds <dependencyManagement> pins for the three embedded Tomcat artifacts — tomcat-embed-core, tomcat-embed-el, and tomcat-embed-websocket — at version 10.1.55 in 6 plugin POMs:

  - confluent-schema-registry-plugin
  - kafka-plugin
  - local-storage-plugin
  - rabbitmq-plugin
  - solace-plugin
  - terraform-plugin

  The key reasoning (captured in the inline comment) is that these modules have no Spring Boot <parent>, so the <tomcat.version> override defined in the parent pom doesn't propagate to them. Without an explicit pin, they'd fall back to the vulnerable transitive version. Pinning here forces them to match what the application/plugin modules already resolve via Spring Boot 3.5.14 + the parent override.

  It's a purely declarative dependency-management change — +114 lines, no code changes, just version coordination.

### How was this change tested?

 1. mvn dependency:tree on each plugin module to confirm tomcat-embed-* now resolves to 10.1.55 (no 10.1.54 remaining).
  2. A clean build (mvn clean install) to confirm nothing breaks with the new version.
  3. A CVE/dependency scan (e.g., the same scanner that flagged the CVEs) to confirm the findings clear.

