### PR TITLE
DATAGO-141720: Automate S-EMA publish to DockerHub

### DIFF
--- a/.github/workflows/publish-to-dockerhub.yaml
+++ b/.github/workflows/publish-to-dockerhub.yaml
@@ -1,0 +1,162 @@
+name: Publish EMA to DockerHub
+on:
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        description: "Released version to publish (must already exist as ECR :<version>)."
+        required: true
+        default: "A.B.C"
+      pushLatest:
+        description: "Also overwrite the :latest tag. Only enable for stable releases."
+        type: boolean
+        default: false
+
+# Prevent two operators (or one double-click) from racing to publish the same
+# version. cancel-in-progress: false is deliberate — cancelling a docker push
+# mid-flight can leave a corrupt layer upload on DockerHub. The second run
+# queues, waits for the first to finish, then fails when the tag already
+# exists.
+concurrency:
+  group: publish-dockerhub-${{ inputs.releaseVersion }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: prod          # manual approval gate, identical to deploy-managed-ema-image.yaml
+
+    steps:
+      # Two-step version validation. Step A always runs and catches typos
+      # early (before any AWS or DockerHub calls). Step B enforces the
+      # "stable release = no suffix" invariant when pushLatest is set.
+      - name: Validate releaseVersion shape
+        run: |
+          VERSION="${{ inputs.releaseVersion }}"
+          # Step A: strict semver. Allow A.B.C or A.B.C-<alphanumeric suffix>.
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9]+)?$ ]]; then
+            echo "::error::releaseVersion '$VERSION' is not a valid semver (expected A.B.C or A.B.C-<suffix>)."
+            exit 1
+          fi
+          # Step B: any suffix disqualifies the version from updating :latest.
+          # This is intentionally stricter than an allowlist of suffixes — it
+          # avoids the maintenance burden of keeping the list current as new
+          # release flavours (e.g. -hotfix, -cr, -customer1) are introduced.
+          if [[ "${{ inputs.pushLatest }}" == "true" ]] && [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+- ]]; then
+            echo "::error::Refusing to push :latest for pre-release version '$VERSION'. Stable releases have no suffix."
+            exit 1
+          fi
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355  # v2.2.0
+        with:
+          aws-access-key-id: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@2f9f10ea3fa2eed41ac443fee8bfbd059af2d0a4  # v1.6.0
+
+      # Pre-flight: surface "ECR tag missing" as a human-readable error
+      # before we attempt the docker pull (whose 'manifest unknown' failure
+      # is opaque). The most likely cause of a missing tag is that the
+      # Release workflow's publish job hasn't run yet for this version.
+      - name: Verify ECR tag exists
+        env:
+          REGION: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
+          REPO: ${{ github.event.repository.name }}
+          VERSION: ${{ inputs.releaseVersion }}
+        run: |
+          if ! aws ecr describe-images \
+               --repository-name "$REPO" \
+               --image-ids imageTag="$VERSION" \
+               --region "$REGION" \
+               > /dev/null 2>&1; then
+            echo "::error::ECR tag '$REPO:$VERSION' not found in region $REGION."
+            echo "::error::The Release workflow's publish job must run successfully first to create this tag."
+            echo "::error::See: code_bases/ema/deployment/concepts/image-flow.md"
+            exit 1
+          fi
+          echo "::notice::Confirmed ECR tag '$REPO:$VERSION' exists."
+
+      - name: Pull image from ECR
+        run: |
+          ECR_IMAGE="${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:${{ inputs.releaseVersion }}"
+          docker pull "$ECR_IMAGE"
+          echo "ECR_IMAGE=$ECR_IMAGE" >> $GITHUB_ENV
+
+      - name: Login to DockerHub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Idempotency observability: warn (don't block) if the :version tag
+      # already exists on DockerHub. Re-push is safe because ECR is the source
+      # of truth and release tags are immutable there. We log the overwrite
+      # so the audit summary makes the situation legible to operators.
+      #
+      # NOTE on coupling: every "DEST=" line below assumes the DockerHub image
+      # name equals the GitHub repo name (`event-management-agent`). If this
+      # repo is ever renamed, these pushes will silently retarget. If renaming,
+      # update this workflow and verify the destination still resolves to
+      # `solace/event-management-agent`.
+      - name: Check if :version already published on DockerHub
+        id: check-version-exists
+        continue-on-error: true
+        run: |
+          DEST="solace/${{ github.event.repository.name }}:${{ inputs.releaseVersion }}"
+          if docker manifest inspect "$DEST" > /dev/null 2>&1; then
+            echo "::warning::Tag '$DEST' already exists on DockerHub — this push will overwrite the existing manifest. Bits are expected to be identical (same ECR source); re-push is idempotent. Proceeding."
+            echo "already_existed=true"  >> $GITHUB_OUTPUT
+          else
+            echo "already_existed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Tag and push versioned tag
+        id: push-version
+        run: |
+          DEST="solace/${{ github.event.repository.name }}:${{ inputs.releaseVersion }}"
+          docker tag  "$ECR_IMAGE" "$DEST"
+          docker push "$DEST"
+
+      - name: Tag and push :latest
+        id: push-latest
+        if: ${{ inputs.pushLatest }}
+        run: |
+          DEST="solace/${{ github.event.repository.name }}:latest"
+          docker tag  "$ECR_IMAGE" "$DEST"
+          docker push "$DEST"
+
+      # `if: always()` ensures the audit summary is written even when earlier
+      # steps failed (e.g. ECR pull, validation guard). Step outcomes ("success"
+      # / "failure" / "skipped") report what actually happened rather than what
+      # we intended to do — important to avoid the trap of conflating "we
+      # intended to push :latest" with "we successfully pushed :latest".
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## DockerHub publish summary"
+            echo ""
+            echo "- Requested version: \`${{ inputs.releaseVersion }}\`"
+            if [[ -n "$ECR_IMAGE" ]]; then
+              echo "- ECR source: \`$ECR_IMAGE\`"
+            else
+              echo "- ECR source: (ECR pull did not complete — see step logs)"
+            fi
+            echo "- Versioned tag push: \`${{ steps.push-version.outcome || 'not-reached' }}\`"
+            if [[ "${{ steps.check-version-exists.outputs.already_existed }}" == "true" ]]; then
+              echo "  - **NOTE:** This was an overwrite — \`:${{ inputs.releaseVersion }}\` already existed on DockerHub."
+            fi
+            if [[ "${{ inputs.pushLatest }}" == "true" ]]; then
+              echo "- :latest tag push: \`${{ steps.push-latest.outcome || 'not-reached' }}\`"
+            else
+              echo "- :latest tag: skipped (pushLatest=false)"
+            fi
+            echo ""
+            echo "Verify: https://hub.docker.com/r/solace/${{ github.event.repository.name }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-to-dockerhub.yaml
+++ b/.github/workflows/publish-to-dockerhub.yaml
@@ -11,40 +11,37 @@ on:
         type: boolean
         default: false
 
-# Prevent two operators (or one double-click) from racing to publish the same
-# version. cancel-in-progress: false is deliberate — cancelling a docker push
-# mid-flight can leave a corrupt layer upload on DockerHub. The second run
-# queues, waits for the first to finish, then fails when the tag already
-# exists.
+# Only one publish of a given version runs at a time. We never cancel one that's
+# already running — killing a docker push midway can corrupt the upload.
 concurrency:
   group: publish-dockerhub-${{ inputs.releaseVersion }}
   cancel-in-progress: false
 
 permissions:
   contents: read
+  id-token: write            # GitHub OIDC token for Vault JWT auth (DockerHub creds)
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     environment: prod          # manual approval gate, identical to deploy-managed-ema-image.yaml
+    env:
+      VAULT_ADDR: https://vault.maas-vault-prod.solace.cloud:8200
 
     steps:
-      # Two-step version validation. Step A always runs and catches typos
-      # early (before any AWS or DockerHub calls). Step B enforces the
-      # "stable release = no suffix" invariant when pushLatest is set.
+      # Check the version string before making any AWS or DockerHub calls.
       - name: Validate releaseVersion shape
+        env:
+          VERSION: ${{ inputs.releaseVersion }}
+          PUSH_LATEST: ${{ inputs.pushLatest }}
         run: |
-          VERSION="${{ inputs.releaseVersion }}"
-          # Step A: strict semver. Allow A.B.C or A.B.C-<alphanumeric suffix>.
+          # Must look like A.B.C or A.B.C-<suffix>.
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9]+)?$ ]]; then
             echo "::error::releaseVersion '$VERSION' is not a valid semver (expected A.B.C or A.B.C-<suffix>)."
             exit 1
           fi
-          # Step B: any suffix disqualifies the version from updating :latest.
-          # This is intentionally stricter than an allowlist of suffixes — it
-          # avoids the maintenance burden of keeping the list current as new
-          # release flavours (e.g. -hotfix, -cr, -customer1) are introduced.
-          if [[ "${{ inputs.pushLatest }}" == "true" ]] && [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+- ]]; then
+          # A suffix (e.g. 1.2.3-rc1) marks a pre-release, so it may not become :latest.
+          if [[ "$PUSH_LATEST" == "true" ]] && [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+- ]]; then
             echo "::error::Refusing to push :latest for pre-release version '$VERSION'. Stable releases have no suffix."
             exit 1
           fi
@@ -60,10 +57,9 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@2f9f10ea3fa2eed41ac443fee8bfbd059af2d0a4  # v1.6.0
 
-      # Pre-flight: surface "ECR tag missing" as a human-readable error
-      # before we attempt the docker pull (whose 'manifest unknown' failure
-      # is opaque). The most likely cause of a missing tag is that the
-      # Release workflow's publish job hasn't run yet for this version.
+      # Fail early with a clear message if the version isn't in ECR yet — usually
+      # means the Release workflow hasn't published it (a raw docker pull failure
+      # here would be cryptic).
       - name: Verify ECR tag exists
         env:
           REGION: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
@@ -83,32 +79,49 @@ jobs:
           echo "::notice::Confirmed ECR tag '$REPO:$VERSION' exists."
 
       - name: Pull image from ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPO: ${{ github.event.repository.name }}
+          VERSION: ${{ inputs.releaseVersion }}
         run: |
-          ECR_IMAGE="${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:${{ inputs.releaseVersion }}"
+          ECR_IMAGE="$ECR_REGISTRY/$REPO:$VERSION"
           docker pull "$ECR_IMAGE"
-          echo "ECR_IMAGE=$ECR_IMAGE" >> $GITHUB_ENV
+          echo "ECR_IMAGE=$ECR_IMAGE" >> "$GITHUB_ENV"
+
+      # DockerHub credentials are fetched from Vault at run time instead of being
+      # stored as a GitHub secret (this needs the id-token permission set above).
+      - name: Retrieve DockerHub credentials from Vault
+        id: secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b  # v3.4.0
+        with:
+          url: "${{ env.VAULT_ADDR }}"
+          role: "cicd-workflows-secret-read-role"
+          method: jwt
+          path: jwt-github
+          jwtGithubAudience: https://github.com/${{ github.repository_owner }}
+          exportToken: true
+          secrets: |
+            secret/data/tools/githubactions DOCKERHUB_USER | DOCKERHUB_USER ;
+            secret/data/tools/githubactions DOCKERHUB_PASS | DOCKERHUB_PASS ;
 
       - name: Login to DockerHub
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ steps.secrets.outputs.DOCKERHUB_USER }}
+          password: ${{ steps.secrets.outputs.DOCKERHUB_PASS }}
 
-      # Idempotency observability: warn (don't block) if the :version tag
-      # already exists on DockerHub. Re-push is safe because ECR is the source
-      # of truth and release tags are immutable there. We log the overwrite
-      # so the audit summary makes the situation legible to operators.
-      #
-      # NOTE on coupling: every "DEST=" line below assumes the DockerHub image
-      # name equals the GitHub repo name (`event-management-agent`). If this
-      # repo is ever renamed, these pushes will silently retarget. If renaming,
-      # update this workflow and verify the destination still resolves to
-      # `solace/event-management-agent`.
+      # Warn (don't fail) if this version tag already exists on DockerHub —
+      # re-pushing the same image from ECR is harmless. Note: the "DEST" names
+      # below assume the DockerHub repo matches the GitHub repo name; revisit if
+      # this repo is ever renamed.
       - name: Check if :version already published on DockerHub
         id: check-version-exists
         continue-on-error: true
+        env:
+          REPO: ${{ github.event.repository.name }}
+          VERSION: ${{ inputs.releaseVersion }}
         run: |
-          DEST="solace/${{ github.event.repository.name }}:${{ inputs.releaseVersion }}"
+          DEST="solace/$REPO:$VERSION"
           if docker manifest inspect "$DEST" > /dev/null 2>&1; then
             echo "::warning::Tag '$DEST' already exists on DockerHub — this push will overwrite the existing manifest. Bits are expected to be identical (same ECR source); re-push is idempotent. Proceeding."
             echo "already_existed=true"  >> $GITHUB_OUTPUT
@@ -118,45 +131,53 @@ jobs:
 
       - name: Tag and push versioned tag
         id: push-version
+        env:
+          REPO: ${{ github.event.repository.name }}
+          VERSION: ${{ inputs.releaseVersion }}
         run: |
-          DEST="solace/${{ github.event.repository.name }}:${{ inputs.releaseVersion }}"
+          DEST="solace/$REPO:$VERSION"
           docker tag  "$ECR_IMAGE" "$DEST"
           docker push "$DEST"
 
       - name: Tag and push :latest
         id: push-latest
         if: ${{ inputs.pushLatest }}
+        env:
+          REPO: ${{ github.event.repository.name }}
         run: |
-          DEST="solace/${{ github.event.repository.name }}:latest"
+          DEST="solace/$REPO:latest"
           docker tag  "$ECR_IMAGE" "$DEST"
           docker push "$DEST"
 
-      # `if: always()` ensures the audit summary is written even when earlier
-      # steps failed (e.g. ECR pull, validation guard). Step outcomes ("success"
-      # / "failure" / "skipped") report what actually happened rather than what
-      # we intended to do — important to avoid the trap of conflating "we
-      # intended to push :latest" with "we successfully pushed :latest".
+      # Always write a summary of what actually happened, even if a step failed.
       - name: Summary
         if: always()
+        env:
+          VERSION: ${{ inputs.releaseVersion }}
+          PUSH_LATEST: ${{ inputs.pushLatest }}
+          REPO: ${{ github.event.repository.name }}
+          PUSH_VERSION_OUTCOME: ${{ steps.push-version.outcome || 'not-reached' }}
+          PUSH_LATEST_OUTCOME: ${{ steps.push-latest.outcome || 'not-reached' }}
+          ALREADY_EXISTED: ${{ steps.check-version-exists.outputs.already_existed }}
         run: |
           {
             echo "## DockerHub publish summary"
             echo ""
-            echo "- Requested version: \`${{ inputs.releaseVersion }}\`"
+            echo "- Requested version: \`$VERSION\`"
             if [[ -n "$ECR_IMAGE" ]]; then
               echo "- ECR source: \`$ECR_IMAGE\`"
             else
               echo "- ECR source: (ECR pull did not complete — see step logs)"
             fi
-            echo "- Versioned tag push: \`${{ steps.push-version.outcome || 'not-reached' }}\`"
-            if [[ "${{ steps.check-version-exists.outputs.already_existed }}" == "true" ]]; then
-              echo "  - **NOTE:** This was an overwrite — \`:${{ inputs.releaseVersion }}\` already existed on DockerHub."
+            echo "- Versioned tag push: \`$PUSH_VERSION_OUTCOME\`"
+            if [[ "$ALREADY_EXISTED" == "true" ]]; then
+              echo "  - **NOTE:** This was an overwrite — \`:$VERSION\` already existed on DockerHub."
             fi
-            if [[ "${{ inputs.pushLatest }}" == "true" ]]; then
-              echo "- :latest tag push: \`${{ steps.push-latest.outcome || 'not-reached' }}\`"
+            if [[ "$PUSH_LATEST" == "true" ]]; then
+              echo "- :latest tag push: \`$PUSH_LATEST_OUTCOME\`"
             else
               echo "- :latest tag: skipped (pushLatest=false)"
             fi
             echo ""
-            echo "Verify: https://hub.docker.com/r/solace/${{ github.event.repository.name }}"
+            echo "Verify: https://hub.docker.com/r/solace/$REPO"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/publish-to-dockerhub.yaml` to automate **Phase 6** of the EMA prod release — the S-EMA image push to public DockerHub `solace/event-management-agent`. This is currently the only fully-manual hop in the release pipeline (local command line based `docker pull → tag → push`); every other hop is already gated by GitHub Actions + the `prod` environment.

Jira: https://sol-jira.atlassian.net/browse/DATAGO-141720

## Today's manual flow

1. Operator logs into AWS ECR + DockerHub on their laptop.
2. `docker pull` ECR `:<version>` → `docker tag` for `solace/...:<version>` + `:latest` → `docker push` both.
3. Verify in browser.


## What are the changes

Mirrors the existing `deploy-managed-ema-image.yaml` pattern:

- `workflow_dispatch` with two inputs: `releaseVersion` (required) and `pushLatest` (boolean, default false).
- `environment: prod` for both the second-reviewer approval gate and the secret scoping.
- `aws-actions/configure-aws-credentials`, `aws-actions/amazon-ecr-login`, `docker/login-action` — all SHA-pinned to the same versions referenced by `deploy-managed-ema-image.yaml`.
- `permissions: contents: read` (minimum).

Additional guards beyond the existing pattern:

- **Strict semver validation** rejects `v1.9.9`, `1.9.9.0`, `1.9`, etc. before any AWS / DockerHub calls.
- **`:latest` pre-release guard** — any `releaseVersion` carrying a suffix (`A.B.C-...`) is refused when `pushLatest=true`. Stricter than an allowlist of suffixes, deliberately, so the guard doesn't drift as new release flavours appear.
- **ECR-existence pre-flight** — `aws ecr describe-images` before `docker pull` so a missing tag surfaces as a human-readable error rather than the opaque `manifest unknown`.
- **Per-version `concurrency:` block** with `cancel-in-progress: false` — prevents two operators racing a push of the same version. The deliberate \"don't cancel mid-flight\" choice avoids corrupt layer uploads on DockerHub.
- **Idempotency observability** — warns (does not block) when re-pushing a `:<version>` tag that already exists. Re-push is safe (ECR release tags are immutable, same bits get written); the warning makes the situation legible in the audit summary.
- **`if: always()` audit summary** with per-step outcomes (`success` / `failure` / `skipped` / `not-reached`). Reports what actually happened rather than what we intended to do.

### Why a separate workflow, not a third branch of `deploy-managed-ema-image.yaml`

Considered. Rejected because:

- DockerHub pushes two tags (`:version` + `:latest`); GCR pushes one. Conditional logic would muddy the existing file.
- The `:latest` pre-release guard has no analog on the GCR side.
- Audit trail is clearer when a DockerHub publish is its own workflow run, not a sub-branch of a multi-target invocation.

## Secret scoping (suggested by Claude, I think it is well reasoned)

`DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` should be added as **`prod`-environment secrets**, not repo-level secrets.

Rationale: repo-level secrets are readable by **any** workflow in the repo on any branch. That includes workflows whose third-party-action list is not fully SHA-pinned. For example, `release.yaml:137` references `Bullrich/generate-release-changelog@master` — pinned to a moving Git ref. If that action is compromised, the malicious code runs inside `release.yaml`'s `publish` job (which already has `environment: prod`) and can read any repo-level secret. A `prod`-environment secret is only injected into a job that declares `environment: prod`, and only **after** the prod approval gate passes — bounding the blast radius to approved runs.

The new workflow declares `environment: prod`, so it will read the secrets correctly once they're added.

## Open questions

### Service-account DockerHub user — does one exist, and is the pattern endorsed?

The plan calls for the PAT to live on a **dedicated bot account**, not on a personal DockerHub user. Reasons:

- Decouples the credential from any individual person's lifecycle
- Scopes the PAT to **only** what `eventportalrelease` needs (least privilege).

Open sub-questions: Does Solace already have a DockerHub bot user we should reuse, or do we create a new one?

The eventual onboarding ask (add bot user to `solace/eventportalrelease` team, generate `Read & Write`-scoped PAT, register secrets in the `prod` environment) is held until the team agrees on the approach.