### PR TITLE
DATAGO-139741: auto-derive developmentVersion in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,13 +3,9 @@ on:
   workflow_dispatch:
     inputs:
       releaseVersion:
-        description: "Default version to use when preparing a release."
+        description: "Version to release, in X.Y.Z form (no -SNAPSHOT, no placeholder). The next development version on main is auto-derived as X.Y.(Z+1)-SNAPSHOT by maven-release-plugin."
         required: true
         default: "A.B.C"
-      developmentVersion:
-        description: "Default version to use for new local working copy (the next version after version A.B.C)."
-        required: true
-        default: "X.Y.Z-SNAPSHOT"
       dry_run:
         description: "Dry run: run the readiness check end-to-end, skip the actual mvn release commit/push and the entire publish job (no GitHub Release, no ECR retag, no manifest DB write). Use for validating the workflow without altering the repo or registries."
         type: boolean
@@ -56,6 +52,21 @@ jobs:
           java-version: 17
           distribution: 'temurin'
           cache: 'maven'
+      - name: Validate release version
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
+        run: |
+          if [[ ! "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::releaseVersion='$RELEASE_VERSION' is not a clean X.Y.Z semver. Reject reasons include: the 'A.B.C' placeholder default was not changed, a '-SNAPSHOT' suffix was included, or a pre-release suffix (e.g. '-rc1') was used."
+            exit 1
+          fi
+          major=$(echo "$RELEASE_VERSION" | cut -d. -f1)
+          minor=$(echo "$RELEASE_VERSION" | cut -d. -f2)
+          patch=$(echo "$RELEASE_VERSION" | cut -d. -f3)
+          derived_dev="$major.$minor.$((patch + 1))-SNAPSHOT"
+          echo "releaseVersion=$RELEASE_VERSION"
+          echo "derived developmentVersion=$derived_dev (auto-computed by maven-release-plugin; not an input)"
+          echo "DERIVED_DEVELOPMENT_VERSION=$derived_dev" >> "$GITHUB_ENV"
       - name: Pre-Release Check - Version
         env:
            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -84,17 +95,16 @@ jobs:
         run: mvn clean --file service/pom.xml
       - name: Maven Release
         if: ${{ !fromJSON(inputs.dry_run) }}
-        run: mvn release:prepare release:perform -B --file service/pom.xml -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ github.event.inputs.developmentVersion }}
+        run: mvn release:prepare release:perform -B --file service/pom.xml -DreleaseVersion=${{ github.event.inputs.releaseVersion }}
       - name: Maven Release (DRY RUN — skipped)
         if: ${{ fromJSON(inputs.dry_run) }}
         run: |
           echo "::warning::DRY RUN — Maven release skipped. Would have executed:"
           echo "  mvn release:prepare release:perform -B --file service/pom.xml \\"
-          echo "    -DreleaseVersion=${{ github.event.inputs.releaseVersion }} \\"
-          echo "    -DdevelopmentVersion=${{ github.event.inputs.developmentVersion }}"
+          echo "    -DreleaseVersion=${{ github.event.inputs.releaseVersion }}"
           echo ""
           echo "Side effects that would have occurred:"
-          echo "  - Commit pom.xml version bumps to ${{ github.event.inputs.releaseVersion }} (release) and ${{ github.event.inputs.developmentVersion }} (next snapshot)"
+          echo "  - Commit pom.xml version bumps to ${{ github.event.inputs.releaseVersion }} (release) and $DERIVED_DEVELOPMENT_VERSION (next snapshot, auto-derived)"
           echo "  - Create + push tag v${{ github.event.inputs.releaseVersion }} to origin"
           echo "  - Deploy artifacts via mvn deploy"
 
@@ -199,11 +209,17 @@ jobs:
           GUARDIAN_STATUS: ${{ needs.release_readiness.outputs.guardian_status }}
           MAVEN_RELEASE_RESULT: ${{ needs.maven_release.result }}
         run: |
+          if [[ "$VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            derived_dev="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.$((BASH_REMATCH[3] + 1))-SNAPSHOT"
+          else
+            derived_dev="(N/A — releaseVersion did not pass validation)"
+          fi
           {
             echo "## Dry Run Summary"
             echo ""
             echo "Scanned commit: \`${{ github.sha }}\`"
             echo "Target release version: \`$VERSION\`"
+            echo "Auto-derived next development version: \`$derived_dev\`"
             echo ""
             echo "### Readiness gates (overall: \`$READINESS_RESULT\`)"
             echo ""

--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>com.solace.maas</groupId>
         <artifactId>maas-event-management-agent-parent</artifactId>
-        <version>1.9.9-SNAPSHOT</version>
+        <version>1.9.10-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>event-management-agent</artifactId>
-    <version>1.9.9-SNAPSHOT</version>
+    <version>1.9.10-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Solace Event Management Agent - Application</name>
     <description>Solace Event Management Agent - Application</description>
@@ -242,32 +242,32 @@
         <dependency>
             <groupId>com.solace.maas</groupId>
             <artifactId>plugin</artifactId>
-            <version>1.9.9-SNAPSHOT</version>
+            <version>1.9.10-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.solace.maas.plugin.kafka</groupId>
             <artifactId>kafka-plugin</artifactId>
-            <version>1.9.9-SNAPSHOT</version>
+            <version>1.9.10-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.solace.maas.plugin.solace</groupId>
             <artifactId>solace-plugin</artifactId>
-            <version>1.9.9-SNAPSHOT</version>
+            <version>1.9.10-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.solace.maas.plugin.localstorage</groupId>
             <artifactId>local-storage-plugin</artifactId>
-            <version>1.9.9-SNAPSHOT</version>
+            <version>1.9.10-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.solace.maas.plugin.confluent-schema-registry</groupId>
             <artifactId>confluent-schema-registry-plugin</artifactId>
-            <version>1.9.9-SNAPSHOT</version>
+            <version>1.9.10-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.solace.maas.plugin.terraform</groupId>
             <artifactId>terraform-plugin</artifactId>
-            <version>1.9.9-SNAPSHOT</version>
+            <version>1.9.10-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/service/confluent-schema-registry-plugin/pom.xml
+++ b/service/confluent-schema-registry-plugin/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.solace.maas.plugin.confluent-schema-registry</groupId>
     <artifactId>confluent-schema-registry-plugin</artifactId>
-    <version>1.9.9-SNAPSHOT</version>
+    <version>1.9.10-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Solace Event Management Agent - Confluent Schema Registry Plugin</name>
     <description>Solace Event Management Agent - Confluent Schema Registry Plugin</description>
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>com.solace.maas</groupId>
             <artifactId>plugin</artifactId>
-            <version>1.9.9-SNAPSHOT</version>
+            <version>1.9.10-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/service/kafka-plugin/pom.xml
+++ b/service/kafka-plugin/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.solace.maas.plugin.kafka</groupId>
     <artifactId>kafka-plugin</artifactId>
-    <version>1.9.9-SNAPSHOT</version>
+    <version>1.9.10-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Solace Event Management Agent - Kafka Plugin</name>
     <description>Solace Event Management Agent - Kafka Plugin</description>
@@ -119,7 +119,7 @@
         <dependency>
             <groupId>com.solace.maas</groupId>
             <artifactId>plugin</artifactId>
-            <version>1.9.9-SNAPSHOT</version>
+            <version>1.9.10-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/service/local-storage-plugin/pom.xml
+++ b/service/local-storage-plugin/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.solace.maas.plugin.localstorage</groupId>
     <artifactId>local-storage-plugin</artifactId>
-    <version>1.9.9-SNAPSHOT</version>
+    <version>1.9.10-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Solace Event Management Agent - Local Storage Plugin</name>
     <description>Solace Event Management Agent - Local Storage Plugin</description>
@@ -147,7 +147,7 @@
         <dependency>
             <groupId>com.solace.maas</groupId>
             <artifactId>plugin</artifactId>
-            <version>1.9.9-SNAPSHOT</version>
+            <version>1.9.10-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>

--- a/service/plugin/pom.xml
+++ b/service/plugin/pom.xml
@@ -6,13 +6,13 @@
     <parent>
         <groupId>com.solace.maas</groupId>
         <artifactId>maas-event-management-agent-parent</artifactId>
-        <version>1.9.9-SNAPSHOT</version>
+        <version>1.9.10-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 
     <groupId>com.solace.maas</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.9.9-SNAPSHOT</version>
+    <version>1.9.10-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Solace Event Management Agent - Plugin</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>com.solace.maas</groupId>
     <artifactId>maas-event-management-agent-parent</artifactId>
-    <version>1.9.9-SNAPSHOT</version>
+    <version>1.9.10-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Solace Event Management Agent Maven Parent</name>
     <description>Solace Solace Event Management Agent Maven Parent</description>

--- a/service/rabbitmq-plugin/pom.xml
+++ b/service/rabbitmq-plugin/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.solace.maas.plugin.rabbitmq</groupId>
     <artifactId>rabbitmq-plugin</artifactId>
-    <version>1.9.9-SNAPSHOT</version>
+    <version>1.9.10-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Solace Event Management Agent - RabbitMQ Plugin</name>
     <description>Solace Event Management Agent - RabbitMQ Plugin</description>
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>com.solace.maas</groupId>
             <artifactId>plugin</artifactId>
-            <version>1.9.9-SNAPSHOT</version>
+            <version>1.9.10-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <build>

--- a/service/solace-plugin/pom.xml
+++ b/service/solace-plugin/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.solace.maas.plugin.solace</groupId>
     <artifactId>solace-plugin</artifactId>
-    <version>1.9.9-SNAPSHOT</version>
+    <version>1.9.10-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Solace Event Management Agent - Solace Plugin</name>
     <description>Solace Event Management Agent - Solace Plugin</description>
@@ -130,7 +130,7 @@
         <dependency>
             <groupId>com.solace.maas</groupId>
             <artifactId>plugin</artifactId>
-            <version>1.9.9-SNAPSHOT</version>
+            <version>1.9.10-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>

--- a/service/terraform-plugin/pom.xml
+++ b/service/terraform-plugin/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.solace.maas.plugin.terraform</groupId>
     <artifactId>terraform-plugin</artifactId>
-    <version>1.9.9-SNAPSHOT</version>
+    <version>1.9.10-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Solace Event Management Agent - Terraform Plugin</name>
     <description>Solace Event Management Agent - Terraform Plugin</description>
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>com.solace.maas</groupId>
             <artifactId>plugin</artifactId>
-            <version>1.9.9-SNAPSHOT</version>
+            <version>1.9.10-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>


### PR DESCRIPTION
## What are the changes

- **Workflow fix:** remove the `developmentVersion` `workflow_dispatch` input and let `maven-release-plugin` auto-derive it as `<patch+1 of releaseVersion>-SNAPSHOT`. 
- Add a `Validate release version` step that rejects malformed inputs and surfaces the auto-derived value.
- **Cleanup commit:** bump main's 9 module poms from `1.9.9-SNAPSHOT` to `1.9.10-SNAPSHOT`, completing the version-bump that should have happened automatically during the v1.9.9 release.

Jira link: [DATAGO-139741](https://sol-jira.atlassian.net/browse/DATAGO-139741).

## Why the workflow fix

The v1.9.9 release ended up with `main`'s pom at `1.9.9-SNAPSHOT` instead of `1.9.10-SNAPSHOT` because the operator entered `developmentVersion=1.9.9-SNAPSHOT` (the snapshot form of the just-released version) instead of `1.9.10-SNAPSHOT` (the next-version snapshot). The workflow passed the value verbatim to `mvn`, which dutifully round-tripped the pom version.
The workflow fix removes this manual entering of `developmentVersion` value by the operator and let `maven-release-plugin` auto-derive it as `<patch+1 of releaseVersion>-SNAPSHOT`