### PR TITLE
DATAGO-142260: spring boot 4 migration

### DIFF
--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -32,11 +32,8 @@
     </repositories>
     <dependencyManagement>
         <dependencies>
-            <!-- SB4 manages Jackson via its bundled jackson-2-bom (com.fasterxml, 2.21.x) + jackson-3
-                 bom (tools.jackson, 3.1.x). The former EMA jackson-bom 2.16.1 import pinned
-                 jackson-annotations to 2.16.1, which lacks JsonSerializeAs and broke Jackson 3's
-                 JsonMapper init at boot (DATAGO-142260). Let the SB4 BOM govern Jackson so the
-                 annotations are shared between J2 and J3. -->
+            <!-- Let the SB4 BOM govern Jackson: a prior explicit jackson-bom pinned jackson-annotations
+                 to a version missing JsonSerializeAs, which broke Jackson 3's JsonMapper init at boot. -->
             <!-- CVE-2023-3635: okio < 1.17.6 GzipSource DoS; transitive via okhttp 2.7.5 -->
             <dependency>
                 <groupId>com.squareup.okio</groupId>
@@ -150,10 +147,6 @@
             <artifactId>camel-jackson</artifactId>
             <version>${camel.version}</version>
         </dependency>
-        <!-- camel-directvm-starter removed: the direct-vm component was dropped in Camel 4.19,
-             and EMA has zero direct-vm: endpoints (99 plain direct: endpoints are camel-core and
-             unaffected). Only one test referenced DirectVmEndpoint; it is repointed to
-             DirectEndpoint. (DATAGO-142260) -->
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-file</artifactId>
@@ -265,12 +258,8 @@
             <version>1.9.10-SNAPSHOT</version>
         </dependency>
 
-        <!-- SB4 moved the Micrometer tracing autoconfig out of actuator into the
-             spring-boot-micrometer-tracing modules. EMA previously relied on the actuator
-             autoconfig + the io.micrometer:micrometer-tracing-bridge-brave lib to get an
-             io.micrometer.tracing.Tracer bean (injected by DataImportControllerImpl). Under SB4
-             that bean is gone; use the SB4 brave tracing starter, which pulls the bridge plus its
-             autoconfiguration so the Tracer bean is created again. (DATAGO-142260) -->
+        <!-- SB4 brave tracing starter: restores the io.micrometer.tracing.Tracer bean (injected by
+             DataImportControllerImpl) that SB4 no longer auto-configures via actuator. -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-micrometer-tracing-brave</artifactId>

--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -20,7 +20,6 @@
         <!-- Fix CVE-2026-35554 (HIGH 8.7, producer race) + CVE-2026-33558 (MEDIUM 5.3, debug log info leak):
              Kafka 3.9.1 → 3.9.2. Patch release on the 3.9.x LTS line; no API changes. -->
         <kafka-clients.version>3.9.2</kafka-clients.version>
-        <jackson.version>2.16.1</jackson.version>
         <awaitility.version>4.2.0</awaitility.version>
         <dockerfile-maven.version>1.4.13</dockerfile-maven.version>
         <swagger-codegen-maven-plugin.version>2.4.43</swagger-codegen-maven-plugin.version>
@@ -33,13 +32,10 @@
     </repositories>
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>com.fasterxml.jackson</groupId>
-                <artifactId>jackson-bom</artifactId>
-                <version>${jackson.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
+            <!-- SB4 manages Jackson via jackson-2-bom (2.21.2) + jackson-bom (3.1.2). The former
+                 EMA jackson-bom 2.16.1 import pinned jackson-annotations to 2.16.1, which lacks
+                 JsonSerializeAs and broke Jackson 3's JsonMapper init at boot (DATAGO-142260).
+                 Let the SB4 BOM govern Jackson so the annotations are shared between J2 and J3. -->
             <!-- CVE-2023-3635: okio < 1.17.6 GzipSource DoS; transitive via okhttp 2.7.5 -->
             <dependency>
                 <groupId>com.squareup.okio</groupId>
@@ -52,7 +48,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -269,10 +264,15 @@
             <version>1.9.9-SNAPSHOT</version>
         </dependency>
 
+        <!-- SB4 moved the Micrometer tracing autoconfig out of actuator into the
+             spring-boot-micrometer-tracing modules. EMA previously relied on the actuator
+             autoconfig + the io.micrometer:micrometer-tracing-bridge-brave lib to get an
+             io.micrometer.tracing.Tracer bean (injected by DataImportControllerImpl). Under SB4
+             that bean is gone; use the SB4 brave tracing starter, which pulls the bridge plus its
+             autoconfiguration so the Tracer bean is created again. (DATAGO-142260) -->
         <dependency>
-            <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-tracing-bridge-brave</artifactId>
-            <!--version>1.1.1</version-->
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-micrometer-tracing-brave</artifactId>
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>

--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -13,7 +13,7 @@
     <name>Solace Event Management Agent - Application</name>
     <description>Solace Event Management Agent - Application</description>
     <properties>
-        <spring-boot.version>4.0.6</spring-boot.version>
+        <spring-boot.version>4.1.0</spring-boot.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <spring-security-rsa.version>1.1.3</spring-security-rsa.version>
         <spring-kafka.version>3.3.16</spring-kafka.version>

--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -296,13 +296,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
-        <!-- TODO(DATAGO-142260): temporary SB4 migration aid — surfaces renamed/removed config
-             properties at startup. REMOVE before merging to main. -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-properties-migrator</artifactId>
-            <scope>runtime</scope>
-        </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>

--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -13,7 +13,7 @@
     <name>Solace Event Management Agent - Application</name>
     <description>Solace Event Management Agent - Application</description>
     <properties>
-        <spring-boot.version>3.5.14</spring-boot.version>
+        <spring-boot.version>4.0.6</spring-boot.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <spring-security-rsa.version>1.1.3</spring-security-rsa.version>
         <spring-kafka.version>3.3.6</spring-kafka.version>
@@ -71,13 +71,13 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
             <version>${spring-boot.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.2.0</version>
+            <version>3.0.3</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -157,7 +157,7 @@
         <dependency>
             <groupId>org.apache.camel.springboot</groupId>
             <artifactId>camel-directvm-starter</artifactId>
-            <version>4.0.0-M2</version>
+            <version>${camel.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
@@ -296,6 +296,13 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <!-- TODO(DATAGO-142260): temporary SB4 migration aid — surfaces renamed/removed config
+             properties at startup. REMOVE before merging to main. -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-properties-migrator</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>

--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -32,10 +32,11 @@
     </repositories>
     <dependencyManagement>
         <dependencies>
-            <!-- SB4 manages Jackson via jackson-2-bom (2.21.2) + jackson-bom (3.1.2). The former
-                 EMA jackson-bom 2.16.1 import pinned jackson-annotations to 2.16.1, which lacks
-                 JsonSerializeAs and broke Jackson 3's JsonMapper init at boot (DATAGO-142260).
-                 Let the SB4 BOM govern Jackson so the annotations are shared between J2 and J3. -->
+            <!-- SB4 manages Jackson via its bundled jackson-2-bom (com.fasterxml, 2.21.x) + jackson-3
+                 bom (tools.jackson, 3.1.x). The former EMA jackson-bom 2.16.1 import pinned
+                 jackson-annotations to 2.16.1, which lacks JsonSerializeAs and broke Jackson 3's
+                 JsonMapper init at boot (DATAGO-142260). Let the SB4 BOM govern Jackson so the
+                 annotations are shared between J2 and J3. -->
             <!-- CVE-2023-3635: okio < 1.17.6 GzipSource DoS; transitive via okhttp 2.7.5 -->
             <dependency>
                 <groupId>com.squareup.okio</groupId>

--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -154,11 +154,10 @@
             <artifactId>camel-jackson</artifactId>
             <version>${camel.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.camel.springboot</groupId>
-            <artifactId>camel-directvm-starter</artifactId>
-            <version>${camel.version}</version>
-        </dependency>
+        <!-- camel-directvm-starter removed: the direct-vm component was dropped in Camel 4.19,
+             and EMA has zero direct-vm: endpoints (99 plain direct: endpoints are camel-core and
+             unaffected). Only one test referenced DirectVmEndpoint; it is repointed to
+             DirectEndpoint. (DATAGO-142260) -->
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-file</artifactId>

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/config/H2ConsoleSecurityConfig.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/config/H2ConsoleSecurityConfig.java
@@ -22,10 +22,14 @@ public class H2ConsoleSecurityConfig {
     }
 
     // NOTE (DATAGO-142260): the former @Bean @Primary H2ConsoleProperties override that
-    // force-set enabled=false was removed — Spring Boot 4 removed the
-    // org.springframework.boot.autoconfigure.h2.H2ConsoleProperties class. The H2 console is
-    // disabled by default (EMA never sets spring.h2.console.enabled=true), and the blocking
-    // security filter chain below remains as defense-in-depth. Security-adjacent — review.
+    // force-set enabled=false was removed because Spring Boot 4 removed H2 console
+    // auto-configuration entirely — both H2ConsoleProperties and H2ConsoleAutoConfiguration are
+    // absent from the SB4 classpath. IMPORTANT: application.yml / application-TEST.yml DO set
+    // spring.h2.console.enabled=true (with web-allow-others=true) — that override existed
+    // specifically to neutralize it. With the auto-config gone that property has no consumer, so
+    // the console cannot start; the blocking SecurityFilterChain below is the active defense.
+    // Security-adjacent — MUST be verified live at Step 3f (GET /h2-console/ denied).
+    // See revisit/ema-h2-console-force-disable-removed.md.
 
     /**
      * Security filter chain that explicitly denies all access to H2 console endpoints.

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/config/H2ConsoleSecurityConfig.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/config/H2ConsoleSecurityConfig.java
@@ -21,15 +21,10 @@ public class H2ConsoleSecurityConfig {
         log.info("H2 Console has been forcibly disabled for security reasons");
     }
 
-    // NOTE (DATAGO-142260): the former @Bean @Primary H2ConsoleProperties override that
-    // force-set enabled=false was removed because Spring Boot 4 removed H2 console
-    // auto-configuration entirely — both H2ConsoleProperties and H2ConsoleAutoConfiguration are
-    // absent from the SB4 classpath. IMPORTANT: application.yml / application-TEST.yml DO set
-    // spring.h2.console.enabled=true (with web-allow-others=true) — that override existed
-    // specifically to neutralize it. With the auto-config gone that property has no consumer, so
-    // the console cannot start; the blocking SecurityFilterChain below is the active defense.
-    // Security-adjacent — MUST be verified live at Step 3f (GET /h2-console/ denied).
-    // See revisit/ema-h2-console-force-disable-removed.md.
+    // NOTE (DATAGO-142260): SB4 removed H2 console auto-configuration, so the former @Bean @Primary
+    // force-disable override is gone. The spring.h2.console.enabled=true in application*.yml now has
+    // no consumer, so the console can't start; the blocking SecurityFilterChain below is the active
+    // defense. Security-adjacent — verify live (GET /h2-console/ denied).
 
     /**
      * Security filter chain that explicitly denies all access to H2 console endpoints.

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/config/H2ConsoleSecurityConfig.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/config/H2ConsoleSecurityConfig.java
@@ -3,10 +3,8 @@ package com.solace.maas.ep.event.management.agent.config;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
-import org.springframework.boot.autoconfigure.h2.H2ConsoleProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
@@ -23,18 +21,11 @@ public class H2ConsoleSecurityConfig {
         log.info("H2 Console has been forcibly disabled for security reasons");
     }
 
-    /**
-     * Force H2 console to be disabled to ensures the H2 console cannot be enabled
-     * even if spring.h2.console.enabled=true is set in configuration files.
-     */
-    @Bean
-    @Primary
-    public H2ConsoleProperties h2ConsoleProperties() {
-        H2ConsoleProperties properties = new H2ConsoleProperties();
-        properties.setEnabled(false); // Force disabled
-        log.info("H2 Console: Programmatically disabled via H2ConsoleProperties override");
-        return properties;
-    }
+    // NOTE (DATAGO-142260): the former @Bean @Primary H2ConsoleProperties override that
+    // force-set enabled=false was removed — Spring Boot 4 removed the
+    // org.springframework.boot.autoconfigure.h2.H2ConsoleProperties class. The H2 console is
+    // disabled by default (EMA never sets spring.h2.console.enabled=true), and the blocking
+    // security filter chain below remains as defense-in-depth. Security-adjacent — review.
 
     /**
      * Security filter chain that explicitly denies all access to H2 console endpoints.

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/config/MetricsConfig.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/config/MetricsConfig.java
@@ -4,7 +4,7 @@ import com.solace.maas.ep.event.management.agent.plugin.jacoco.ExcludeFromJacoco
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
+import org.springframework.boot.micrometer.metrics.autoconfigure.MeterRegistryCustomizer;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/scanManager/rest/RestErrorHandler.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/scanManager/rest/RestErrorHandler.java
@@ -5,7 +5,7 @@ import com.solace.maas.ep.event.management.agent.plugin.route.exceptions.ClientE
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
-import org.springframework.data.mapping.PropertyReferenceException;
+import org.springframework.data.core.PropertyReferenceException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;

--- a/service/application/src/main/resources/application-mysql.yml
+++ b/service/application/src/main/resources/application-mysql.yml
@@ -5,6 +5,6 @@ spring:
     password: example
     driver-class-name: com.mysql.jdbc.Driver
   jpa:
-    database-platform: org.hibernate.dialect.MySQL8Dialect
+    database-platform: org.hibernate.dialect.MySQLDialect
     hibernate:
       ddl-auto: create

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/MockitoFieldInitExtension.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/MockitoFieldInitExtension.java
@@ -24,8 +24,10 @@ public class MockitoFieldInitExtension implements BeforeEachCallback {
     @Override
     public void beforeEach(ExtensionContext context) {
         Class<?> testClass = context.getRequiredTestClass();
-        ExtendWith extendWith = testClass.getAnnotation(ExtendWith.class);
-        if (extendWith != null) {
+        // @ExtendWith is @Repeatable — getAnnotationsByType covers both a single and multiple
+        // separate @ExtendWith declarations. (A MockitoExtension hidden inside a composed
+        // meta-annotation is not detected; none exists today.)
+        for (ExtendWith extendWith : testClass.getAnnotationsByType(ExtendWith.class)) {
             for (Class<?> extension : extendWith.value()) {
                 if (extension.getName().contains("MockitoExtension")) {
                     return;

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/MockitoFieldInitExtension.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/MockitoFieldInitExtension.java
@@ -1,0 +1,37 @@
+package com.solace.maas.ep.event.management.agent;
+
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * SB4 replacement for the deleted Spring Boot {@code MockitoTestExecutionListener} (DATAGO-142260).
+ *
+ * <p>Under Spring Boot 3.x that listener auto-initialized {@code @Mock}/{@code @Captor}/
+ * {@code @InjectMocks} fields inside {@code @SpringBootTest} classes. Spring Boot 4 removed it, so
+ * those fields stay {@code null} and the tests NPE. EMA has ~45 such test classes and none call
+ * {@code MockitoAnnotations.openMocks(this)} themselves.
+ *
+ * <p>This extension restores that behaviour globally (registered via
+ * {@code META-INF/services/org.junit.jupiter.api.extension.Extension} +
+ * {@code junit.jupiter.extensions.autodetection.enabled=true}). It is a no-op for test classes
+ * with no Mockito-annotated fields, and it skips classes that drive Mockito themselves via
+ * {@code @ExtendWith(MockitoExtension.class)} to avoid double-initialization.
+ */
+public class MockitoFieldInitExtension implements BeforeEachCallback {
+
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        Class<?> testClass = context.getRequiredTestClass();
+        ExtendWith extendWith = testClass.getAnnotation(ExtendWith.class);
+        if (extendWith != null) {
+            for (Class<?> extension : extendWith.value()) {
+                if (extension.getName().contains("MockitoExtension")) {
+                    return;
+                }
+            }
+        }
+        MockitoAnnotations.openMocks(context.getRequiredTestInstance());
+    }
+}

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/MockitoFieldInitExtension.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/MockitoFieldInitExtension.java
@@ -6,27 +6,18 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.mockito.MockitoAnnotations;
 
 /**
- * SB4 replacement for the deleted Spring Boot {@code MockitoTestExecutionListener} (DATAGO-142260).
- *
- * <p>Under Spring Boot 3.x that listener auto-initialized {@code @Mock}/{@code @Captor}/
- * {@code @InjectMocks} fields inside {@code @SpringBootTest} classes. Spring Boot 4 removed it, so
- * those fields stay {@code null} and the tests NPE. EMA has ~45 such test classes and none call
- * {@code MockitoAnnotations.openMocks(this)} themselves.
- *
- * <p>This extension restores that behaviour globally (registered via
- * {@code META-INF/services/org.junit.jupiter.api.extension.Extension} +
- * {@code junit.jupiter.extensions.autodetection.enabled=true}). It is a no-op for test classes
- * with no Mockito-annotated fields, and it skips classes that drive Mockito themselves via
- * {@code @ExtendWith(MockitoExtension.class)} to avoid double-initialization.
+ * SB4 replacement for the deleted Spring Boot {@code MockitoTestExecutionListener} (DATAGO-142260):
+ * under SB4, {@code @Mock} fields in {@code @SpringBootTest} classes are no longer auto-initialized
+ * and stay {@code null} (~45 such classes here, none calling {@code openMocks} themselves). Registered
+ * globally via {@code META-INF/services} + extension autodetection; skips classes that drive Mockito
+ * themselves via {@code @ExtendWith(MockitoExtension.class)}.
  */
 public class MockitoFieldInitExtension implements BeforeEachCallback {
 
     @Override
     public void beforeEach(ExtensionContext context) {
         Class<?> testClass = context.getRequiredTestClass();
-        // @ExtendWith is @Repeatable — getAnnotationsByType covers both a single and multiple
-        // separate @ExtendWith declarations. (A MockitoExtension hidden inside a composed
-        // meta-annotation is not detected; none exists today.)
+        // @ExtendWith is @Repeatable — getAnnotationsByType covers single + repeated declarations.
         for (ExtendWith extendWith : testClass.getAnnotationsByType(ExtendWith.class)) {
             for (Class<?> extension : extendWith.value()) {
                 if (extension.getName().contains("MockitoExtension")) {

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/micrometer/MicrometerStatsDConfigTest.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/micrometer/MicrometerStatsDConfigTest.java
@@ -6,7 +6,7 @@ import io.micrometer.statsd.StatsdProtocol;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.actuate.autoconfigure.metrics.MetricsProperties;
+import org.springframework.boot.micrometer.metrics.autoconfigure.MetricsProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/DataPublisherRouteBuilderTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/DataPublisherRouteBuilderTests.java
@@ -12,7 +12,7 @@ import org.apache.camel.EndpointInject;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.AdviceWith;
-import org.apache.camel.component.directvm.DirectVmEndpoint;
+import org.apache.camel.component.direct.DirectEndpoint;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
 import org.junit.jupiter.api.Test;
@@ -61,7 +61,7 @@ public class DataPublisherRouteBuilderTests {
 
     @Test
     public void testMockRoute() throws Exception {
-        try (DirectVmEndpoint ep = new DirectVmEndpoint("scanStatusPublisher", null)) {
+        try (DirectEndpoint ep = new DirectEndpoint("scanStatusPublisher", null)) {
             camelContext.addEndpoint("direct:scanStatusPublisher", ep);
 
             AdviceWith.adviceWith(camelContext, "dataPublisherRoute",

--- a/service/application/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/service/application/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+com.solace.maas.ep.event.management.agent.MockitoFieldInitExtension

--- a/service/application/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/service/application/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,1 +1,2 @@
+# Registers MockitoFieldInitExtension globally so @Mock fields in @SpringBootTest classes get initialized, replacing the MockitoTestExecutionListener that SB4 removed (DATAGO-142260).
 com.solace.maas.ep.event.management.agent.MockitoFieldInitExtension

--- a/service/application/src/test/resources/junit-platform.properties
+++ b/service/application/src/test/resources/junit-platform.properties
@@ -1,4 +1,2 @@
-# Enables ServiceLoader-based registration of the JUnit 5 extension in
-# META-INF/services/org.junit.jupiter.api.extension.Extension (MockitoFieldInitExtension),
-# the SB4 replacement for the removed Spring Boot MockitoTestExecutionListener. (DATAGO-142260)
+# Autodetect MockitoFieldInitExtension (registered via META-INF/services) — SB4 @Mock-init fix.
 junit.jupiter.extensions.autodetection.enabled=true

--- a/service/application/src/test/resources/junit-platform.properties
+++ b/service/application/src/test/resources/junit-platform.properties
@@ -1,0 +1,4 @@
+# Enables ServiceLoader-based registration of the JUnit 5 extension in
+# META-INF/services/org.junit.jupiter.api.extension.Extension (MockitoFieldInitExtension),
+# the SB4 replacement for the removed Spring Boot MockitoTestExecutionListener. (DATAGO-142260)
+junit.jupiter.extensions.autodetection.enabled=true

--- a/service/confluent-schema-registry-plugin/pom.xml
+++ b/service/confluent-schema-registry-plugin/pom.xml
@@ -48,7 +48,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.2.16.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/service/confluent-schema-registry-plugin/pom.xml
+++ b/service/confluent-schema-registry-plugin/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <spring-boot.version>3.5.14</spring-boot.version>
+        <spring-boot.version>4.0.6</spring-boot.version>
         <httpclient.version>4.5.14</httpclient.version>
         <mockwebserver.version>4.9.0</mockwebserver.version>
         <jupiter.version>5.10.2</jupiter.version>
@@ -30,17 +30,17 @@
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-core</artifactId>
-                <version>10.1.55</version>
+                <version>11.0.24</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-el</artifactId>
-                <version>10.1.55</version>
+                <version>11.0.24</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-websocket</artifactId>
-                <version>10.1.55</version>
+                <version>11.0.24</version>
             </dependency>
             <!-- confluent-schema-registry-plugin has no Spring Boot parent; Netty arrives transitively via plugin → reactor-netty.
                  Current bump 4.1.133 → 4.1.135 fixes CVE-2026-44249/45416 (netty-handler) +

--- a/service/confluent-schema-registry-plugin/pom.xml
+++ b/service/confluent-schema-registry-plugin/pom.xml
@@ -13,7 +13,7 @@
         <spring-boot.version>4.0.6</spring-boot.version>
         <httpclient.version>4.5.14</httpclient.version>
         <mockwebserver.version>4.9.0</mockwebserver.version>
-        <jupiter.version>5.10.2</jupiter.version>
+        <jupiter.version>6.0.3</jupiter.version>
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
         <jackson-dataformat-cbor.version>2.13.4</jackson-dataformat-cbor.version>
         <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>

--- a/service/confluent-schema-registry-plugin/pom.xml
+++ b/service/confluent-schema-registry-plugin/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <spring-boot.version>4.0.6</spring-boot.version>
+        <spring-boot.version>4.1.0</spring-boot.version>
         <httpclient.version>4.5.14</httpclient.version>
         <mockwebserver.version>4.9.0</mockwebserver.version>
         <jupiter.version>6.0.3</jupiter.version>

--- a/service/confluent-schema-registry-plugin/pom.xml
+++ b/service/confluent-schema-registry-plugin/pom.xml
@@ -23,10 +23,9 @@
         <dependencies>
             <!-- confluent-schema-registry-plugin has no Spring Boot parent and no spring-boot-dependencies
                  BOM import. spring-boot-starter-web (pulled via the plugin module) brings tomcat-embed-*
-                 transitively, and the <tomcat.version>10.1.55</tomcat.version> override in service/pom.xml
+                 transitively, and the <tomcat.version>11.0.24</tomcat.version> override in service/pom.xml
                  does NOT reach this pom. Each artifact must be pinned explicitly.
-                 Fix CVE-2026-43515/43512/41293 (Critical) + CVE-2026-41284/43513/42498 (High):
-                 tomcat 10.1.54 → 10.1.55. -->
+                 11.0.24 clears CVE-2026-59084/59083 over Spring Boot 4.1.0's managed 11.0.22. -->
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-core</artifactId>
@@ -43,8 +42,9 @@
                 <version>11.0.24</version>
             </dependency>
             <!-- confluent-schema-registry-plugin has no Spring Boot parent; Netty arrives transitively via plugin → reactor-netty.
-                 Current bump 4.1.133 → 4.1.135 fixes CVE-2026-44249/45416 (netty-handler) +
-                 CVE-2026-45674/47691/45673 (netty-resolver-dns). -->
+                 Pinned to 4.2.16 (Spring Boot 4.1.0's default netty is 4.2.15) to clear the HIGH
+                 CVEs 4.2.15 still carries: CVE-2026-56816 (http3), CVE-2026-59901 (codec/
+                 compression), CVE-2026-55831/55833/56745 (http), CVE-2026-56819 (http2). -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>

--- a/service/confluent-schema-registry-plugin/pom.xml
+++ b/service/confluent-schema-registry-plugin/pom.xml
@@ -21,11 +21,8 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- confluent-schema-registry-plugin has no Spring Boot parent and no spring-boot-dependencies
-                 BOM import. spring-boot-starter-web (pulled via the plugin module) brings tomcat-embed-*
-                 transitively, and the <tomcat.version>11.0.24</tomcat.version> override in service/pom.xml
-                 does NOT reach this pom. Each artifact must be pinned explicitly.
-                 11.0.24 clears CVE-2026-59084/59083 over Spring Boot 4.1.0's managed 11.0.22. -->
+            <!-- No SB parent, so service/pom.xml's tomcat override doesn't reach here — pin
+                 tomcat-embed explicitly. 11.0.24 clears CVE-2026-59084/59083 over SB 4.1.0's 11.0.22. -->
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-core</artifactId>
@@ -42,9 +39,7 @@
                 <version>11.0.24</version>
             </dependency>
             <!-- confluent-schema-registry-plugin has no Spring Boot parent; Netty arrives transitively via plugin → reactor-netty.
-                 Pinned to 4.2.16 (Spring Boot 4.1.0's default netty is 4.2.15) to clear the HIGH
-                 CVEs 4.2.15 still carries: CVE-2026-56816 (http3), CVE-2026-59901 (codec/
-                 compression), CVE-2026-55831/55833/56745 (http), CVE-2026-56819 (http2). -->
+                 Pinned to 4.2.16 — SB 4.1.0's default 4.2.15 still has HIGH netty CVEs (CVE-2026-56816 et al.). -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>

--- a/service/kafka-plugin/pom.xml
+++ b/service/kafka-plugin/pom.xml
@@ -16,7 +16,7 @@
         <kafka-clients.version>3.9.2</kafka-clients.version>
         <spring-boot.version>4.0.6</spring-boot.version>
         <commons-collections4.version>4.4</commons-collections4.version>
-        <jupiter.version>5.10.2</jupiter.version>
+        <jupiter.version>6.0.3</jupiter.version>
         <camel.version>4.19.0</camel.version>
         <aws-msk-iam-auth.version>2.0.3</aws-msk-iam-auth.version>
         <snakeyaml.version>2.0</snakeyaml.version>

--- a/service/kafka-plugin/pom.xml
+++ b/service/kafka-plugin/pom.xml
@@ -11,12 +11,9 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <spring-kafka.version>3.3.16</spring-kafka.version>
-        <!-- spring-kafka 3.3.16 (the 3.3.x line) pulls micrometer-observation/commons 1.14.x
-             transitively, and the maven-shade-plugin below bundles those classes into this plugin's
-             uber-jar. On the Spring Boot 4.1.0 app classpath the bundled old copy shadows
-             micrometer-commons 1.17.0 and its WarnThenDebugLogger has no isEnabled(), so
-             micrometer-core 1.17.0's CompositeMeterRegistry.add throws NoSuchMethodError at startup.
-             Pin micrometer to the app's 1.17.0 so the shaded copy matches the runtime host. -->
+        <!-- spring-kafka 3.3.x drags micrometer 1.14.x, which this module's shade bundles; on the SB
+             4.1.0 classpath that old copy shadows micrometer 1.17.0 and boots fail with NoSuchMethodError
+             (WarnThenDebugLogger.isEnabled). Pin to the app's 1.17.0 so the shaded copy matches. -->
         <micrometer.version>1.17.0</micrometer.version>
         <!-- Fix CVE-2026-35554 (HIGH 8.7, producer race) + CVE-2026-33558 (MEDIUM 5.3, debug log info leak):
              Kafka 3.9.1 → 3.9.2. Patch release on the 3.9.x LTS line; no API changes. -->
@@ -42,11 +39,8 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!-- kafka-plugin has no Spring Boot parent and no spring-boot-dependencies BOM import.
-                 spring-boot-starter-web (pulled via the plugin module) brings tomcat-embed-* transitively,
-                 and the <tomcat.version>11.0.24</tomcat.version> override in service/pom.xml does NOT
-                 reach this pom. Each artifact must be pinned explicitly.
-                 11.0.24 clears CVE-2026-59084/59083 over Spring Boot 4.1.0's managed 11.0.22. -->
+            <!-- No SB parent, so service/pom.xml's tomcat override doesn't reach here — pin
+                 tomcat-embed explicitly. 11.0.24 clears CVE-2026-59084/59083 over SB 4.1.0's 11.0.22. -->
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-core</artifactId>
@@ -62,15 +56,9 @@
                 <artifactId>tomcat-embed-websocket</artifactId>
                 <version>11.0.24</version>
             </dependency>
-            <!-- kafka-plugin has no Spring Boot parent, so Spring Boot does not manage Netty here.
-                 software.amazon.awssdk:netty-nio-client bundles its own Netty version (4.1.118.Final
-                 as of awssdk 2.30.17), which would be used without this pin.
-                 This BOM pin forces Netty to match the 4.2.x line Spring Boot 4.1.0 manages in all
-                 other EMA modules (via reactor-netty).
-                 Review when upgrading awssdk:netty-nio-client or when kafka-plugin gains a Spring Boot parent.
-                 Pinned to 4.2.16 (Spring Boot 4.1.0's default netty is 4.2.15) to clear the HIGH CVEs
-                 4.2.15 still carries: CVE-2026-56816 (http3), CVE-2026-59901 (codec/compression),
-                 CVE-2026-55831/55833/56745 (http), CVE-2026-56819 (http2). -->
+            <!-- No SB parent, so netty isn't managed here; awssdk:netty-nio-client would otherwise pull
+                 its own older netty. Pin to 4.2.16 to match the app and clear the HIGH CVEs SB 4.1.0's
+                 default 4.2.15 carries (CVE-2026-56816 et al.). Review on awssdk upgrades. -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
@@ -92,8 +80,6 @@
             <artifactId>spring-kafka</artifactId>
             <version>${spring-kafka.version}</version>
         </dependency>
-        <!-- Override spring-kafka 3.3.16's transitive micrometer 1.14.x so the shaded jar bundles
-             the 1.17.0 classes (with WarnThenDebugLogger.isEnabled()) the SB 4.1.0 host expects. -->
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-observation</artifactId>

--- a/service/kafka-plugin/pom.xml
+++ b/service/kafka-plugin/pom.xml
@@ -11,6 +11,13 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <spring-kafka.version>3.3.6</spring-kafka.version>
+        <!-- spring-kafka 3.3.6 pulls micrometer-observation/commons 1.14.7 transitively, and the
+             maven-shade-plugin below bundles those classes into this plugin's uber-jar. On the
+             Spring Boot 4.1.0 app classpath the bundled old copy shadows micrometer-commons 1.17.0
+             and its WarnThenDebugLogger has no isEnabled(), so micrometer-core 1.17.0's
+             CompositeMeterRegistry.add throws NoSuchMethodError at startup. Pin micrometer to the
+             app's 1.17.0 so the shaded copy matches the runtime host. -->
+        <micrometer.version>1.17.0</micrometer.version>
         <!-- Fix CVE-2026-35554 (HIGH 8.7, producer race) + CVE-2026-33558 (MEDIUM 5.3, debug log info leak):
              Kafka 3.9.1 → 3.9.2. Patch release on the 3.9.x LTS line; no API changes. -->
         <kafka-clients.version>3.9.2</kafka-clients.version>
@@ -84,6 +91,18 @@
             <groupId>org.springframework.kafka</groupId>
             <artifactId>spring-kafka</artifactId>
             <version>${spring-kafka.version}</version>
+        </dependency>
+        <!-- Override spring-kafka 3.3.6's transitive micrometer 1.14.7 so the shaded jar bundles
+             the 1.17.0 classes (with WarnThenDebugLogger.isEnabled()) the SB 4.1.0 host expects. -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-observation</artifactId>
+            <version>${micrometer.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-commons</artifactId>
+            <version>${micrometer.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>

--- a/service/kafka-plugin/pom.xml
+++ b/service/kafka-plugin/pom.xml
@@ -74,7 +74,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.2.16.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/service/kafka-plugin/pom.xml
+++ b/service/kafka-plugin/pom.xml
@@ -21,7 +21,7 @@
         <!-- Fix CVE-2026-35554 (HIGH 8.7, producer race) + CVE-2026-33558 (MEDIUM 5.3, debug log info leak):
              Kafka 3.9.1 → 3.9.2. Patch release on the 3.9.x LTS line; no API changes. -->
         <kafka-clients.version>3.9.2</kafka-clients.version>
-        <spring-boot.version>4.0.6</spring-boot.version>
+        <spring-boot.version>4.1.0</spring-boot.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <jupiter.version>6.0.3</jupiter.version>
         <camel.version>4.19.0</camel.version>

--- a/service/kafka-plugin/pom.xml
+++ b/service/kafka-plugin/pom.xml
@@ -44,10 +44,9 @@
             </dependency>
             <!-- kafka-plugin has no Spring Boot parent and no spring-boot-dependencies BOM import.
                  spring-boot-starter-web (pulled via the plugin module) brings tomcat-embed-* transitively,
-                 and the <tomcat.version>10.1.55</tomcat.version> override in service/pom.xml does NOT
+                 and the <tomcat.version>11.0.24</tomcat.version> override in service/pom.xml does NOT
                  reach this pom. Each artifact must be pinned explicitly.
-                 Fix CVE-2026-43515/43512/41293 (Critical) + CVE-2026-41284/43513/42498 (High):
-                 tomcat 10.1.54 → 10.1.55. -->
+                 11.0.24 clears CVE-2026-59084/59083 over Spring Boot 4.1.0's managed 11.0.22. -->
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-core</artifactId>
@@ -66,11 +65,12 @@
             <!-- kafka-plugin has no Spring Boot parent, so Spring Boot does not manage Netty here.
                  software.amazon.awssdk:netty-nio-client bundles its own Netty version (4.1.118.Final
                  as of awssdk 2.30.17), which would be used without this pin.
-                 This BOM pin forces Netty to match the version Spring Boot 3.5.15 manages in all
+                 This BOM pin forces Netty to match the 4.2.x line Spring Boot 4.1.0 manages in all
                  other EMA modules (via reactor-netty).
                  Review when upgrading awssdk:netty-nio-client or when kafka-plugin gains a Spring Boot parent.
-                 Current bump 4.1.133 → 4.1.135 fixes CVE-2026-44249/45416 (netty-handler) +
-                 CVE-2026-45674/47691/45673 (netty-resolver-dns). -->
+                 Pinned to 4.2.16 (Spring Boot 4.1.0's default netty is 4.2.15) to clear the HIGH CVEs
+                 4.2.15 still carries: CVE-2026-56816 (http3), CVE-2026-59901 (codec/compression),
+                 CVE-2026-55831/55833/56745 (http), CVE-2026-56819 (http2). -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>

--- a/service/kafka-plugin/pom.xml
+++ b/service/kafka-plugin/pom.xml
@@ -14,10 +14,10 @@
         <!-- Fix CVE-2026-35554 (HIGH 8.7, producer race) + CVE-2026-33558 (MEDIUM 5.3, debug log info leak):
              Kafka 3.9.1 → 3.9.2. Patch release on the 3.9.x LTS line; no API changes. -->
         <kafka-clients.version>3.9.2</kafka-clients.version>
-        <spring-boot.version>3.5.14</spring-boot.version>
+        <spring-boot.version>4.0.6</spring-boot.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <jupiter.version>5.10.2</jupiter.version>
-        <camel.version>4.8.7</camel.version>
+        <camel.version>4.19.0</camel.version>
         <aws-msk-iam-auth.version>2.0.3</aws-msk-iam-auth.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <jackson-dataformat-cbor.version>2.13.4</jackson-dataformat-cbor.version>
@@ -44,17 +44,17 @@
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-core</artifactId>
-                <version>10.1.55</version>
+                <version>11.0.24</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-el</artifactId>
-                <version>10.1.55</version>
+                <version>11.0.24</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-websocket</artifactId>
-                <version>10.1.55</version>
+                <version>11.0.24</version>
             </dependency>
             <!-- kafka-plugin has no Spring Boot parent, so Spring Boot does not manage Netty here.
                  software.amazon.awssdk:netty-nio-client bundles its own Netty version (4.1.118.Final

--- a/service/kafka-plugin/pom.xml
+++ b/service/kafka-plugin/pom.xml
@@ -20,10 +20,10 @@
         <camel.version>4.19.0</camel.version>
         <aws-msk-iam-auth.version>2.0.3</aws-msk-iam-auth.version>
         <snakeyaml.version>2.0</snakeyaml.version>
-        <jackson-dataformat-cbor.version>2.13.4</jackson-dataformat-cbor.version>
+        <jackson-dataformat-cbor.version>2.21.2</jackson-dataformat-cbor.version>
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
         <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
-        <jackson.version>2.16.1</jackson.version>
+        <jackson.version>2.21.2</jackson.version>
     </properties>
 
     <dependencyManagement>

--- a/service/local-storage-plugin/pom.xml
+++ b/service/local-storage-plugin/pom.xml
@@ -20,7 +20,7 @@
         <jupiter.version>6.0.3</jupiter.version>
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
         <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
-        <jackson.version>2.16.1</jackson.version>
+        <jackson.version>2.21.2</jackson.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/service/local-storage-plugin/pom.xml
+++ b/service/local-storage-plugin/pom.xml
@@ -58,7 +58,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.2.16.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/service/local-storage-plugin/pom.xml
+++ b/service/local-storage-plugin/pom.xml
@@ -33,10 +33,9 @@
             </dependency>
             <!-- local-storage-plugin has no Spring Boot parent and no spring-boot-dependencies BOM import.
                  spring-boot-starter-web brings tomcat-embed-* transitively, and the
-                 <tomcat.version>10.1.55</tomcat.version> override in service/pom.xml does NOT reach
+                 <tomcat.version>11.0.24</tomcat.version> override in service/pom.xml does NOT reach
                  this pom. Each artifact must be pinned explicitly.
-                 Fix CVE-2026-43515/43512/41293 (Critical) + CVE-2026-41284/43513/42498 (High):
-                 tomcat 10.1.54 → 10.1.55. -->
+                 11.0.24 clears CVE-2026-59084/59083 over Spring Boot 4.1.0's managed 11.0.22. -->
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-core</artifactId>
@@ -53,8 +52,9 @@
                 <version>11.0.24</version>
             </dependency>
             <!-- local-storage-plugin has no Spring Boot parent; Netty arrives transitively via plugin → reactor-netty.
-                 Current bump 4.1.133 → 4.1.135 fixes CVE-2026-44249/45416 (netty-handler) +
-                 CVE-2026-45674/47691/45673 (netty-resolver-dns). -->
+                 Pinned to 4.2.16 (Spring Boot 4.1.0's default netty is 4.2.15) to clear the HIGH
+                 CVEs 4.2.15 still carries: CVE-2026-56816 (http3), CVE-2026-59901 (codec/
+                 compression), CVE-2026-55831/55833/56745 (http), CVE-2026-56819 (http2). -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>

--- a/service/local-storage-plugin/pom.xml
+++ b/service/local-storage-plugin/pom.xml
@@ -17,7 +17,7 @@
         <junit.version>4.13.2</junit.version>
         <spring-boot.version>4.0.6</spring-boot.version>
         <commons-collections4.version>4.4</commons-collections4.version>
-        <jupiter.version>5.10.2</jupiter.version>
+        <jupiter.version>6.0.3</jupiter.version>
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
         <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
         <jackson.version>2.16.1</jackson.version>

--- a/service/local-storage-plugin/pom.xml
+++ b/service/local-storage-plugin/pom.xml
@@ -15,7 +15,7 @@
         <snakeyaml.version>2.0</snakeyaml.version>
         <jacksondatabind.version>2.13.4.2</jacksondatabind.version>
         <junit.version>4.13.2</junit.version>
-        <spring-boot.version>4.0.6</spring-boot.version>
+        <spring-boot.version>4.1.0</spring-boot.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <jupiter.version>6.0.3</jupiter.version>
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
@@ -59,6 +59,17 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
                 <version>4.2.16.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- camel-spring-boot-starter 4.19.0 drags spring-framework 7.0.6 (spring-expression
+                 CVE-2026-41850) transitively, and it wins mediation over Spring Boot 4.1.0's 7.0.8
+                 because this module imports no spring-boot BOM. Import the spring-framework BOM at
+                 7.0.8 (the version Spring Boot 4.1.0 ships) so all spring-* artifacts are managed. -->
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-framework-bom</artifactId>
+                <version>7.0.8</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/service/local-storage-plugin/pom.xml
+++ b/service/local-storage-plugin/pom.xml
@@ -31,11 +31,8 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!-- local-storage-plugin has no Spring Boot parent and no spring-boot-dependencies BOM import.
-                 spring-boot-starter-web brings tomcat-embed-* transitively, and the
-                 <tomcat.version>11.0.24</tomcat.version> override in service/pom.xml does NOT reach
-                 this pom. Each artifact must be pinned explicitly.
-                 11.0.24 clears CVE-2026-59084/59083 over Spring Boot 4.1.0's managed 11.0.22. -->
+            <!-- No SB parent, so service/pom.xml's tomcat override doesn't reach here — pin
+                 tomcat-embed explicitly. 11.0.24 clears CVE-2026-59084/59083 over SB 4.1.0's 11.0.22. -->
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-core</artifactId>
@@ -52,9 +49,7 @@
                 <version>11.0.24</version>
             </dependency>
             <!-- local-storage-plugin has no Spring Boot parent; Netty arrives transitively via plugin → reactor-netty.
-                 Pinned to 4.2.16 (Spring Boot 4.1.0's default netty is 4.2.15) to clear the HIGH
-                 CVEs 4.2.15 still carries: CVE-2026-56816 (http3), CVE-2026-59901 (codec/
-                 compression), CVE-2026-55831/55833/56745 (http), CVE-2026-56819 (http2). -->
+                 Pinned to 4.2.16 — SB 4.1.0's default 4.2.15 still has HIGH netty CVEs (CVE-2026-56816 et al.). -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
@@ -62,10 +57,8 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!-- camel-spring-boot-starter 4.19.0 drags spring-framework 7.0.6 (spring-expression
-                 CVE-2026-41850) transitively, and it wins mediation over Spring Boot 4.1.0's 7.0.8
-                 because this module imports no spring-boot BOM. Import the spring-framework BOM at
-                 7.0.8 (the version Spring Boot 4.1.0 ships) so all spring-* artifacts are managed. -->
+            <!-- camel-spring-boot-starter 4.19.0 drags spring-framework 7.0.6 (CVE-2026-41850) and
+                 wins mediation (no SB BOM here); force spring-* to SB 4.1.0's 7.0.8. -->
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-framework-bom</artifactId>

--- a/service/local-storage-plugin/pom.xml
+++ b/service/local-storage-plugin/pom.xml
@@ -11,11 +11,11 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <org.json.version>20231013</org.json.version>
-        <camel.version>4.8.7</camel.version>
+        <camel.version>4.19.0</camel.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <jacksondatabind.version>2.13.4.2</jacksondatabind.version>
         <junit.version>4.13.2</junit.version>
-        <spring-boot.version>3.5.14</spring-boot.version>
+        <spring-boot.version>4.0.6</spring-boot.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <jupiter.version>5.10.2</jupiter.version>
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
@@ -40,17 +40,17 @@
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-core</artifactId>
-                <version>10.1.55</version>
+                <version>11.0.24</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-el</artifactId>
-                <version>10.1.55</version>
+                <version>11.0.24</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-websocket</artifactId>
-                <version>10.1.55</version>
+                <version>11.0.24</version>
             </dependency>
             <!-- local-storage-plugin has no Spring Boot parent; Netty arrives transitively via plugin → reactor-netty.
                  Current bump 4.1.133 → 4.1.135 fixes CVE-2026-44249/45416 (netty-handler) +
@@ -136,7 +136,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
             <version>${spring-boot.version}</version>
         </dependency>
         <dependency>

--- a/service/plugin/pom.xml
+++ b/service/plugin/pom.xml
@@ -23,7 +23,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <snakeyaml.version>2.0</snakeyaml.version>
         <jackson.version>2.21.5</jackson.version>
-        <spring-boot.version>4.0.6</spring-boot.version>
+        <spring-boot.version>4.1.0</spring-boot.version>
     </properties>
 
     <dependencyManagement>

--- a/service/plugin/pom.xml
+++ b/service/plugin/pom.xml
@@ -23,7 +23,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <snakeyaml.version>2.0</snakeyaml.version>
         <jackson.version>2.16.1</jackson.version>
-        <spring-boot.version>3.5.14</spring-boot.version>
+        <spring-boot.version>4.0.6</spring-boot.version>
     </properties>
 
     <dependencyManagement>
@@ -78,7 +78,7 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/service/plugin/pom.xml
+++ b/service/plugin/pom.xml
@@ -55,6 +55,18 @@
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
         </dependency>
+        <!-- SB4 no longer pulls these transitively; EMA stays on Jackson 2 (J2 compat-bridge
+             approach, DATAGO-142260). Versions managed by the jackson-bom import above. -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+        <!-- commons-codec was transitive under SB3; SB4 BOM reshuffle dropped it from the
+             compile classpath. VMRProperties uses org.apache.commons.codec.digest. -->
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/service/plugin/pom.xml
+++ b/service/plugin/pom.xml
@@ -61,6 +61,13 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
+        <!-- ParameterNamesModule: lets the J2 compat-bridge ObjectMapper deserialize Lombok
+             @Builder models (all-args ctor + -parameters) that lack a no-arg constructor, matching
+             Spring Boot 3.x's default Jackson module discovery. Not transitive under SB4. -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-parameter-names</artifactId>
+        </dependency>
         <!-- commons-codec was transitive under SB3; SB4 BOM reshuffle dropped it from the
              compile classpath. VMRProperties uses org.apache.commons.codec.digest. -->
         <dependency>

--- a/service/plugin/pom.xml
+++ b/service/plugin/pom.xml
@@ -22,7 +22,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <snakeyaml.version>2.0</snakeyaml.version>
-        <jackson.version>2.16.1</jackson.version>
+        <jackson.version>2.21.2</jackson.version>
         <spring-boot.version>4.0.6</spring-boot.version>
     </properties>
 

--- a/service/plugin/pom.xml
+++ b/service/plugin/pom.xml
@@ -55,21 +55,18 @@
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
         </dependency>
-        <!-- SB4 no longer pulls these transitively; EMA stays on Jackson 2 (J2 compat-bridge
-             approach, DATAGO-142260). Versions managed by the jackson-bom import above. -->
+        <!-- Re-added — not transitive under SB4 (EMA stays on Jackson 2 via the J2 compat bridge). -->
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
-        <!-- ParameterNamesModule: lets the J2 compat-bridge ObjectMapper deserialize Lombok
-             @Builder models (all-args ctor + -parameters) that lack a no-arg constructor, matching
-             Spring Boot 3.x's default Jackson module discovery. Not transitive under SB4. -->
+        <!-- ParameterNamesModule: lets the J2 bridge mapper use Lombok @Builder all-args
+             constructors as creators (else @Data @Builder models fail with "no Creators"). -->
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-parameter-names</artifactId>
         </dependency>
-        <!-- commons-codec was transitive under SB3; SB4 BOM reshuffle dropped it from the
-             compile classpath. VMRProperties uses org.apache.commons.codec.digest. -->
+        <!-- Not transitive under SB4; used by VMRProperties (org.apache.commons.codec.digest). -->
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/config/Jackson2CompatAutoConfiguration.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/config/Jackson2CompatAutoConfiguration.java
@@ -39,6 +39,9 @@ public class Jackson2CompatAutoConfiguration {
         // matching Spring Boot 3.x's default Jackson auto-config. ParameterNamesModule is what lets
         // Jackson use Lombok @Builder all-args constructors (compiled with -parameters) as creators;
         // without it, @Data @Builder models with no no-arg constructor fail with "no Creators".
+        // NOTE: this is a pragmatic subset of Spring Boot's Jackson auto-config — it does NOT apply
+        // spring.jackson.* properties or pick up Module / Jackson2ObjectMapperBuilderCustomizer beans
+        // from the context (EMA declares none today). Extend this bean if that ever changes.
         objectMapper.findAndRegisterModules();
         return objectMapper
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/config/Jackson2CompatAutoConfiguration.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/config/Jackson2CompatAutoConfiguration.java
@@ -3,7 +3,6 @@ package com.solace.maas.ep.event.management.agent.plugin.config;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -35,8 +34,13 @@ public class Jackson2CompatAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean(ObjectMapper.class)
     public ObjectMapper jackson2ObjectMapper() {
-        return new ObjectMapper()
-                .registerModule(new JavaTimeModule())
+        ObjectMapper objectMapper = new ObjectMapper();
+        // Discover every Jackson module on the classpath (JavaTimeModule, ParameterNamesModule, ...),
+        // matching Spring Boot 3.x's default Jackson auto-config. ParameterNamesModule is what lets
+        // Jackson use Lombok @Builder all-args constructors (compiled with -parameters) as creators;
+        // without it, @Data @Builder models with no no-arg constructor fail with "no Creators".
+        objectMapper.findAndRegisterModules();
+        return objectMapper
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     }

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/config/Jackson2CompatAutoConfiguration.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/config/Jackson2CompatAutoConfiguration.java
@@ -8,25 +8,14 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean;
 
 /**
- * Spring Boot 4 J2 compat bridge (DATAGO-142260).
+ * Spring Boot 4 J2 compat bridge (DATAGO-142260): SB4 auto-configures only a Jackson 3
+ * ({@code tools.jackson}) {@code ObjectMapper}, but several EMA beans constructor-inject the Jackson 2
+ * {@code com.fasterxml.jackson.databind.ObjectMapper}. This restores a Jackson 2 mapper mirroring
+ * SB 3.x's defaults (JavaTimeModule, ISO-8601 dates, lenient on unknown properties) so they keep wiring.
  *
- * <p>Spring Boot 4 auto-configures only a Jackson 3 ({@code tools.jackson}) {@code ObjectMapper}
- * bean. Several EMA beans constructor-inject the Jackson 2
- * {@code com.fasterxml.jackson.databind.ObjectMapper} (e.g. {@code TerraformLogProcessingService},
- * {@code FileDataMergeAggregationStrategyImpl}, the {@code Semp*CommandManager}s,
- * {@code CommandLogStreamingProcessor}), which under Spring Boot 3.x resolved to the framework's
- * auto-configured Jackson 2 mapper. This restores a Jackson 2 {@code ObjectMapper} bean mirroring
- * Spring Boot 3.x's Jackson auto-config defaults (JavaTimeModule registered, ISO-8601 dates,
- * lenient on unknown properties) so those injection points keep wiring under Spring Boot 4.
- *
- * <p>Contributed as an {@code @AutoConfiguration} (registered via
- * {@code META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports}) rather
- * than a component-scanned {@code @Configuration} because the plugin modules each boot their own
- * Spring context with differing component-scan base packages; auto-configuration guarantees the
- * bean is present in every context that has this module on the classpath. Backs off via
- * {@code @ConditionalOnMissingBean} so tests can still supply their own primary mapper.
- *
- * <p>Remove if/when EMA migrates fully to Jackson 3.
+ * <p>An {@code @AutoConfiguration} (not a component-scanned {@code @Configuration}) so every plugin
+ * context gets it regardless of scan packages; backs off via {@code @ConditionalOnMissingBean}.
+ * Remove when EMA migrates fully to Jackson 3.
  */
 @AutoConfiguration
 public class Jackson2CompatAutoConfiguration {
@@ -35,13 +24,9 @@ public class Jackson2CompatAutoConfiguration {
     @ConditionalOnMissingBean(ObjectMapper.class)
     public ObjectMapper jackson2ObjectMapper() {
         ObjectMapper objectMapper = new ObjectMapper();
-        // Discover every Jackson module on the classpath (JavaTimeModule, ParameterNamesModule, ...),
-        // matching Spring Boot 3.x's default Jackson auto-config. ParameterNamesModule is what lets
-        // Jackson use Lombok @Builder all-args constructors (compiled with -parameters) as creators;
+        // findAndRegisterModules matches SB 3.x's default module discovery. ParameterNamesModule (so
+        // registered) is what lets Jackson use Lombok @Builder all-args constructors as creators;
         // without it, @Data @Builder models with no no-arg constructor fail with "no Creators".
-        // NOTE: this is a pragmatic subset of Spring Boot's Jackson auto-config — it does NOT apply
-        // spring.jackson.* properties or pick up Module / Jackson2ObjectMapperBuilderCustomizer beans
-        // from the context (EMA declares none today). Extend this bean if that ever changes.
         objectMapper.findAndRegisterModules();
         return objectMapper
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/config/Jackson2CompatAutoConfiguration.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/config/Jackson2CompatAutoConfiguration.java
@@ -1,0 +1,43 @@
+package com.solace.maas.ep.event.management.agent.plugin.config;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Spring Boot 4 J2 compat bridge (DATAGO-142260).
+ *
+ * <p>Spring Boot 4 auto-configures only a Jackson 3 ({@code tools.jackson}) {@code ObjectMapper}
+ * bean. Several EMA beans constructor-inject the Jackson 2
+ * {@code com.fasterxml.jackson.databind.ObjectMapper} (e.g. {@code TerraformLogProcessingService},
+ * {@code FileDataMergeAggregationStrategyImpl}, the {@code Semp*CommandManager}s,
+ * {@code CommandLogStreamingProcessor}), which under Spring Boot 3.x resolved to the framework's
+ * auto-configured Jackson 2 mapper. This restores a Jackson 2 {@code ObjectMapper} bean mirroring
+ * Spring Boot 3.x's Jackson auto-config defaults (JavaTimeModule registered, ISO-8601 dates,
+ * lenient on unknown properties) so those injection points keep wiring under Spring Boot 4.
+ *
+ * <p>Contributed as an {@code @AutoConfiguration} (registered via
+ * {@code META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports}) rather
+ * than a component-scanned {@code @Configuration} because the plugin modules each boot their own
+ * Spring context with differing component-scan base packages; auto-configuration guarantees the
+ * bean is present in every context that has this module on the classpath. Backs off via
+ * {@code @ConditionalOnMissingBean} so tests can still supply their own primary mapper.
+ *
+ * <p>Remove if/when EMA migrates fully to Jackson 3.
+ */
+@AutoConfiguration
+public class Jackson2CompatAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(ObjectMapper.class)
+    public ObjectMapper jackson2ObjectMapper() {
+        return new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    }
+}

--- a/service/plugin/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/service/plugin/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
+# Registers the Jackson 2 compat-bridge ObjectMapper as an auto-configuration so it lands in every plugin's Spring context, which SB4 otherwise leaves without a Jackson 2 mapper (DATAGO-142260).
 com.solace.maas.ep.event.management.agent.plugin.config.Jackson2CompatAutoConfiguration

--- a/service/plugin/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/service/plugin/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.solace.maas.ep.event.management.agent.plugin.config.Jackson2CompatAutoConfiguration

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.14</version>
+        <version>4.0.6</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.solace.maas</groupId>
@@ -40,7 +40,7 @@
         <logstash.version>6.6</logstash.version>
         <org.mapstruct.version>1.5.2.Final</org.mapstruct.version>
         <jacoco.line.percentage>0.8</jacoco.line.percentage>
-        <camel.version>4.8.7</camel.version>
+        <camel.version>4.19.0</camel.version>
         <mockito-inline.version>5.2.0</mockito-inline.version>
         <!-- Spring Boot BOM uses this property to manage all io.netty:* versions.
              Applies to plugin and application modules (inheritors of this parent).
@@ -48,7 +48,7 @@
              Current: 4.1.133 → 4.1.135 fixes CVE-2026-44249/45416 (netty-handler) +
              CVE-2026-45674/47691/45673 (netty-resolver-dns) + bonus CVE-2026-50010. -->
         <netty.version>4.1.135.Final</netty.version>
-        <tomcat.version>10.1.55</tomcat.version>
+        <tomcat.version>11.0.24</tomcat.version>
     </properties>
 
     <dependencyManagement>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -42,13 +42,8 @@
         <jacoco.line.percentage>0.8</jacoco.line.percentage>
         <camel.version>4.19.0</camel.version>
         <mockito-inline.version>5.2.0</mockito-inline.version>
-        <!-- Spring Boot BOM uses this property to manage all io.netty:* versions.
-             Applies to plugin and application modules (inheritors of this parent).
-             Spring Boot 4.1.0 defaults netty to the 4.2.x line (4.2.15); bump one patch to 4.2.16
-             to clear the HIGH CVEs 4.2.15 still carries: CVE-2026-56816 (netty-codec-http3),
-             CVE-2026-59901 (netty-codec / netty-codec-compression), CVE-2026-55831/55833/56745
-             (netty-codec-http), CVE-2026-56819 (netty-codec-http2). Moving off the old 4.1.135
-             override also retires the mixed 4.1.x/4.2.x split the http3/QUIC pins had created. -->
+        <!-- Override SB 4.1.0's default netty (4.2.15) — that patch still has HIGH netty CVEs
+             (http3 CVE-2026-56816 et al.). Manages netty for the inheriting app + plugin modules. -->
         <netty.version>4.2.16.Final</netty.version>
         <tomcat.version>11.0.24</tomcat.version>
     </properties>
@@ -66,9 +61,8 @@
                 <artifactId>commons-lang3</artifactId>
                 <version>3.18.0</version>
             </dependency>
-            <!-- FOSSA nested-BOM blind spot: the 4.1.0 BOM resolves spring-data-commons to
-                 4.1.0, but FOSSA's analyzer can misread the nested BOM as 4.0.5 and flag it.
-                 Pin it explicitly so the patched version is what FOSSA reads (matches ep-core). -->
+            <!-- Explicit pin only because FOSSA's analyzer misreads the 4.1.0 BOM's nested
+                 spring-data-commons as 4.0.5; the resolved version is already 4.1.0. -->
             <dependency>
                 <groupId>org.springframework.data</groupId>
                 <artifactId>spring-data-commons</artifactId>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -44,10 +44,12 @@
         <mockito-inline.version>5.2.0</mockito-inline.version>
         <!-- Spring Boot BOM uses this property to manage all io.netty:* versions.
              Applies to plugin and application modules (inheritors of this parent).
-             Prior bumps: 4.1.131 → 4.1.132 → 4.1.133 (CVE-2026-42579 + 4.1.132 batch).
-             Current: 4.1.133 → 4.1.135 fixes CVE-2026-44249/45416 (netty-handler) +
-             CVE-2026-45674/47691/45673 (netty-resolver-dns) + bonus CVE-2026-50010. -->
-        <netty.version>4.1.135.Final</netty.version>
+             Spring Boot 4.1.0 defaults netty to the 4.2.x line (4.2.15); bump one patch to 4.2.16
+             to clear the HIGH CVEs 4.2.15 still carries: CVE-2026-56816 (netty-codec-http3),
+             CVE-2026-59901 (netty-codec / netty-codec-compression), CVE-2026-55831/55833/56745
+             (netty-codec-http), CVE-2026-56819 (netty-codec-http2). Moving off the old 4.1.135
+             override also retires the mixed 4.1.x/4.2.x split the http3/QUIC pins had created. -->
+        <netty.version>4.2.16.Final</netty.version>
         <tomcat.version>11.0.24</tomcat.version>
     </properties>
 
@@ -63,26 +65,6 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>3.18.0</version>
-            </dependency>
-            <!-- FOSSA: the Spring Boot 4.1.0 BOM ships netty 4.2.15 for the http3/QUIC line,
-                 which still carries CVE-2026-56816. Pin those artifacts to 4.2.16 (matches the
-                 ep-core fix). netty-codec-native-quic is pinned to the same version so the
-                 native binary stays in step with netty-codec-classes-quic. The rest of netty
-                 stays on the 4.1.135.Final property override above. -->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-codec-http3</artifactId>
-                <version>4.2.16.Final</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-codec-classes-quic</artifactId>
-                <version>4.2.16.Final</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-codec-native-quic</artifactId>
-                <version>4.2.16.Final</version>
             </dependency>
             <!-- FOSSA nested-BOM blind spot: the 4.1.0 BOM resolves spring-data-commons to
                  4.1.0, but FOSSA's analyzer can misread the nested BOM as 4.0.5 and flag it.

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.6</version>
+        <version>4.1.0</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.solace.maas</groupId>
@@ -63,6 +63,34 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>3.18.0</version>
+            </dependency>
+            <!-- FOSSA: the Spring Boot 4.1.0 BOM ships netty 4.2.15 for the http3/QUIC line,
+                 which still carries CVE-2026-56816. Pin those artifacts to 4.2.16 (matches the
+                 ep-core fix). netty-codec-native-quic is pinned to the same version so the
+                 native binary stays in step with netty-codec-classes-quic. The rest of netty
+                 stays on the 4.1.135.Final property override above. -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http3</artifactId>
+                <version>4.2.16.Final</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-classes-quic</artifactId>
+                <version>4.2.16.Final</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-native-quic</artifactId>
+                <version>4.2.16.Final</version>
+            </dependency>
+            <!-- FOSSA nested-BOM blind spot: the 4.1.0 BOM resolves spring-data-commons to
+                 4.1.0, but FOSSA's analyzer can misread the nested BOM as 4.0.5 and flag it.
+                 Pin it explicitly so the patched version is what FOSSA reads (matches ep-core). -->
+            <dependency>
+                <groupId>org.springframework.data</groupId>
+                <artifactId>spring-data-commons</artifactId>
+                <version>4.1.0</version>
             </dependency>
             <!-- logback/logstash integration -->
             <dependency>

--- a/service/rabbitmq-plugin/pom.xml
+++ b/service/rabbitmq-plugin/pom.xml
@@ -26,10 +26,8 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!-- spring-boot-starter-web (pulled via the plugin module) brings tomcat-embed-* transitively,
-                 and the <tomcat.version>11.0.24</tomcat.version> override in service/pom.xml does NOT
-                 reach this pom. Each artifact must be pinned explicitly.
-                 11.0.24 clears CVE-2026-59084/59083 over Spring Boot 4.1.0's managed 11.0.22. -->
+            <!-- No SB parent, so service/pom.xml's tomcat override doesn't reach here — pin
+                 tomcat-embed explicitly. 11.0.24 clears CVE-2026-59084/59083 over SB 4.1.0's 11.0.22. -->
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-core</artifactId>
@@ -46,9 +44,7 @@
                 <version>11.0.24</version>
             </dependency>
             <!-- rabbitmq-plugin has no Spring Boot parent; Netty arrives transitively via plugin → reactor-netty.
-                 Pinned to 4.2.16 (Spring Boot 4.1.0's default netty is 4.2.15) to clear the HIGH
-                 CVEs 4.2.15 still carries: CVE-2026-56816 (http3), CVE-2026-59901 (codec/
-                 compression), CVE-2026-55831/55833/56745 (http), CVE-2026-56819 (http2). -->
+                 Pinned to 4.2.16 — SB 4.1.0's default 4.2.15 still has HIGH netty CVEs (CVE-2026-56816 et al.). -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>

--- a/service/rabbitmq-plugin/pom.xml
+++ b/service/rabbitmq-plugin/pom.xml
@@ -52,7 +52,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.2.16.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/service/rabbitmq-plugin/pom.xml
+++ b/service/rabbitmq-plugin/pom.xml
@@ -11,7 +11,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
-        <spring-boot.version>4.0.6</spring-boot.version>
+        <spring-boot.version>4.1.0</spring-boot.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/service/rabbitmq-plugin/pom.xml
+++ b/service/rabbitmq-plugin/pom.xml
@@ -27,10 +27,9 @@
                 <scope>import</scope>
             </dependency>
             <!-- spring-boot-starter-web (pulled via the plugin module) brings tomcat-embed-* transitively,
-                 and the <tomcat.version>10.1.55</tomcat.version> override in service/pom.xml does NOT
+                 and the <tomcat.version>11.0.24</tomcat.version> override in service/pom.xml does NOT
                  reach this pom. Each artifact must be pinned explicitly.
-                 Fix CVE-2026-43515/43512/41293 (Critical) + CVE-2026-41284/43513/42498 (High):
-                 tomcat 10.1.54 → 10.1.55. -->
+                 11.0.24 clears CVE-2026-59084/59083 over Spring Boot 4.1.0's managed 11.0.22. -->
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-core</artifactId>
@@ -47,8 +46,9 @@
                 <version>11.0.24</version>
             </dependency>
             <!-- rabbitmq-plugin has no Spring Boot parent; Netty arrives transitively via plugin → reactor-netty.
-                 Current bump 4.1.133 → 4.1.135 fixes CVE-2026-44249/45416 (netty-handler) +
-                 CVE-2026-45674/47691/45673 (netty-resolver-dns). -->
+                 Pinned to 4.2.16 (Spring Boot 4.1.0's default netty is 4.2.15) to clear the HIGH
+                 CVEs 4.2.15 still carries: CVE-2026-56816 (http3), CVE-2026-59901 (codec/
+                 compression), CVE-2026-55831/55833/56745 (http), CVE-2026-56819 (http2). -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>

--- a/service/rabbitmq-plugin/pom.xml
+++ b/service/rabbitmq-plugin/pom.xml
@@ -22,7 +22,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>2.16.1</version>
+                <version>2.21.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/service/rabbitmq-plugin/pom.xml
+++ b/service/rabbitmq-plugin/pom.xml
@@ -11,7 +11,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
-        <spring-boot.version>3.5.14</spring-boot.version>
+        <spring-boot.version>4.0.6</spring-boot.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -34,17 +34,17 @@
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-core</artifactId>
-                <version>10.1.55</version>
+                <version>11.0.24</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-el</artifactId>
-                <version>10.1.55</version>
+                <version>11.0.24</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-websocket</artifactId>
-                <version>10.1.55</version>
+                <version>11.0.24</version>
             </dependency>
             <!-- rabbitmq-plugin has no Spring Boot parent; Netty arrives transitively via plugin → reactor-netty.
                  Current bump 4.1.133 → 4.1.135 fixes CVE-2026-44249/45416 (netty-handler) +

--- a/service/solace-plugin/pom.xml
+++ b/service/solace-plugin/pom.xml
@@ -19,7 +19,7 @@
         <snakeyaml.version>2.0</snakeyaml.version>
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
         <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
-        <jackson.version>2.16.1</jackson.version>
+        <jackson.version>2.21.2</jackson.version>
     </properties>
 
     <dependencyManagement>

--- a/service/solace-plugin/pom.xml
+++ b/service/solace-plugin/pom.xml
@@ -12,9 +12,9 @@
         <maven.compiler.target>17</maven.compiler.target>
         <solace-messaging-client.version>1.4.0</solace-messaging-client.version>
         <solclientj.version>10.0.0</solclientj.version>
-        <spring-boot.version>3.5.14</spring-boot.version>
+        <spring-boot.version>4.0.6</spring-boot.version>
         <jupiter.version>5.12.2</jupiter.version>
-        <camel.version>4.8.7</camel.version>
+        <camel.version>4.19.0</camel.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
@@ -40,17 +40,17 @@
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-core</artifactId>
-                <version>10.1.55</version>
+                <version>11.0.24</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-el</artifactId>
-                <version>10.1.55</version>
+                <version>11.0.24</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-websocket</artifactId>
-                <version>10.1.55</version>
+                <version>11.0.24</version>
             </dependency>
             <!-- solace-plugin has no Spring Boot parent; Netty arrives transitively via plugin → reactor-netty.
                  Current bump 4.1.133 → 4.1.135 fixes CVE-2026-44249/45416 (netty-handler) +

--- a/service/solace-plugin/pom.xml
+++ b/service/solace-plugin/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <solace-messaging-client.version>1.4.0</solace-messaging-client.version>
         <solclientj.version>10.0.0</solclientj.version>
-        <spring-boot.version>4.0.6</spring-boot.version>
+        <spring-boot.version>4.1.0</spring-boot.version>
         <jupiter.version>6.0.3</jupiter.version>
         <camel.version>4.19.0</camel.version>
         <commons-collections4.version>4.4</commons-collections4.version>

--- a/service/solace-plugin/pom.xml
+++ b/service/solace-plugin/pom.xml
@@ -31,23 +31,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!-- Jackson 3 (tools.jackson) arrives via spring-boot-starter-jackson (spring-boot.version
-                 4.0.6 pins it to 3.1.2) and gets shaded into this plugin's uber-jar. 3.1.2 carries
-                 CVE-2026-54512/54513 (jackson-databind) + GHSA-r7wm-3cxj-wff9 (jackson-core). Import
-                 the Jackson 3 BOM at 3.1.4 (the version Spring Boot 4.1.0 ships) to override it. -->
-            <dependency>
-                <groupId>tools.jackson</groupId>
-                <artifactId>jackson-bom</artifactId>
-                <version>3.1.4</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <!-- solace-plugin has no Spring Boot parent and no spring-boot-dependencies BOM import.
                  spring-boot-starter-web (pulled via the plugin module) brings tomcat-embed-* transitively,
-                 and the <tomcat.version>10.1.55</tomcat.version> override in service/pom.xml does NOT
+                 and the <tomcat.version>11.0.24</tomcat.version> override in service/pom.xml does NOT
                  reach this pom. Each artifact must be pinned explicitly.
-                 Fix CVE-2026-43515/43512/41293 (Critical) + CVE-2026-41284/43513/42498 (High):
-                 tomcat 10.1.54 → 10.1.55. -->
+                 11.0.24 clears CVE-2026-59084/59083 over Spring Boot 4.1.0's managed 11.0.22. -->
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-core</artifactId>
@@ -64,8 +52,9 @@
                 <version>11.0.24</version>
             </dependency>
             <!-- solace-plugin has no Spring Boot parent; Netty arrives transitively via plugin → reactor-netty.
-                 Current bump 4.1.133 → 4.1.135 fixes CVE-2026-44249/45416 (netty-handler) +
-                 CVE-2026-45674/47691/45673 (netty-resolver-dns). -->
+                 Pinned to 4.2.16 (Spring Boot 4.1.0's default netty is 4.2.15) to clear the HIGH
+                 CVEs 4.2.15 still carries: CVE-2026-56816 (http3), CVE-2026-59901 (codec/
+                 compression), CVE-2026-55831/55833/56745 (http), CVE-2026-56819 (http2). -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>

--- a/service/solace-plugin/pom.xml
+++ b/service/solace-plugin/pom.xml
@@ -13,7 +13,7 @@
         <solace-messaging-client.version>1.4.0</solace-messaging-client.version>
         <solclientj.version>10.0.0</solclientj.version>
         <spring-boot.version>4.0.6</spring-boot.version>
-        <jupiter.version>5.12.2</jupiter.version>
+        <jupiter.version>6.0.3</jupiter.version>
         <camel.version>4.19.0</camel.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <snakeyaml.version>2.0</snakeyaml.version>

--- a/service/solace-plugin/pom.xml
+++ b/service/solace-plugin/pom.xml
@@ -31,11 +31,8 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!-- solace-plugin has no Spring Boot parent and no spring-boot-dependencies BOM import.
-                 spring-boot-starter-web (pulled via the plugin module) brings tomcat-embed-* transitively,
-                 and the <tomcat.version>11.0.24</tomcat.version> override in service/pom.xml does NOT
-                 reach this pom. Each artifact must be pinned explicitly.
-                 11.0.24 clears CVE-2026-59084/59083 over Spring Boot 4.1.0's managed 11.0.22. -->
+            <!-- No SB parent, so service/pom.xml's tomcat override doesn't reach here — pin
+                 tomcat-embed explicitly. 11.0.24 clears CVE-2026-59084/59083 over SB 4.1.0's 11.0.22. -->
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-core</artifactId>
@@ -52,9 +49,7 @@
                 <version>11.0.24</version>
             </dependency>
             <!-- solace-plugin has no Spring Boot parent; Netty arrives transitively via plugin → reactor-netty.
-                 Pinned to 4.2.16 (Spring Boot 4.1.0's default netty is 4.2.15) to clear the HIGH
-                 CVEs 4.2.15 still carries: CVE-2026-56816 (http3), CVE-2026-59901 (codec/
-                 compression), CVE-2026-55831/55833/56745 (http), CVE-2026-56819 (http2). -->
+                 Pinned to 4.2.16 — SB 4.1.0's default 4.2.15 still has HIGH netty CVEs (CVE-2026-56816 et al.). -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>

--- a/service/solace-plugin/pom.xml
+++ b/service/solace-plugin/pom.xml
@@ -31,6 +31,17 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- Jackson 3 (tools.jackson) arrives via spring-boot-starter-jackson (spring-boot.version
+                 4.0.6 pins it to 3.1.2) and gets shaded into this plugin's uber-jar. 3.1.2 carries
+                 CVE-2026-54512/54513 (jackson-databind) + GHSA-r7wm-3cxj-wff9 (jackson-core). Import
+                 the Jackson 3 BOM at 3.1.4 (the version Spring Boot 4.1.0 ships) to override it. -->
+            <dependency>
+                <groupId>tools.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>3.1.4</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- solace-plugin has no Spring Boot parent and no spring-boot-dependencies BOM import.
                  spring-boot-starter-web (pulled via the plugin module) brings tomcat-embed-* transitively,
                  and the <tomcat.version>10.1.55</tomcat.version> override in service/pom.xml does NOT
@@ -58,7 +69,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.2.16.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/service/terraform-plugin/pom.xml
+++ b/service/terraform-plugin/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <spring-boot.version>4.0.6</spring-boot.version>
+        <spring-boot.version>4.1.0</spring-boot.version>
         <jupiter.version>6.0.3</jupiter.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <snakeyaml.version>2.0</snakeyaml.version>

--- a/service/terraform-plugin/pom.xml
+++ b/service/terraform-plugin/pom.xml
@@ -24,10 +24,9 @@
         <dependencies>
             <!-- terraform-plugin has no Spring Boot parent and no spring-boot-dependencies BOM import.
                  spring-boot-starter-web brings tomcat-embed-* transitively, and the
-                 <tomcat.version>10.1.55</tomcat.version> override in service/pom.xml does NOT reach
+                 <tomcat.version>11.0.24</tomcat.version> override in service/pom.xml does NOT reach
                  this pom. Each artifact must be pinned explicitly.
-                 Fix CVE-2026-43515/43512/41293 (Critical) + CVE-2026-41284/43513/42498 (High):
-                 tomcat 10.1.54 → 10.1.55. -->
+                 11.0.24 clears CVE-2026-59084/59083 over Spring Boot 4.1.0's managed 11.0.22. -->
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-core</artifactId>
@@ -44,8 +43,9 @@
                 <version>11.0.24</version>
             </dependency>
             <!-- terraform-plugin has no Spring Boot parent; Netty arrives transitively via plugin → reactor-netty.
-                 Current bump 4.1.133 → 4.1.135 fixes CVE-2026-44249/45416 (netty-handler) +
-                 CVE-2026-45674/47691/45673 (netty-resolver-dns). -->
+                 Pinned to 4.2.16 (Spring Boot 4.1.0's default netty is 4.2.15) to clear the HIGH
+                 CVEs 4.2.15 still carries: CVE-2026-56816 (http3), CVE-2026-59901 (codec/
+                 compression), CVE-2026-55831/55833/56745 (http), CVE-2026-56819 (http2). -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
@@ -61,17 +61,6 @@
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
                 <version>${jackson.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <!-- Jackson 3 (tools.jackson) arrives via spring-boot-starter-jackson (spring-boot.version
-                 4.0.6 pins it to 3.1.2) and gets shaded into this plugin's uber-jar. 3.1.2 carries
-                 CVE-2026-54512/54513 (jackson-databind) + GHSA-r7wm-3cxj-wff9 (jackson-core). Import
-                 the Jackson 3 BOM at 3.1.4 (the version Spring Boot 4.1.0 ships) to override it. -->
-            <dependency>
-                <groupId>tools.jackson</groupId>
-                <artifactId>jackson-bom</artifactId>
-                <version>3.1.4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/service/terraform-plugin/pom.xml
+++ b/service/terraform-plugin/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <spring-boot.version>3.5.14</spring-boot.version>
+        <spring-boot.version>4.0.6</spring-boot.version>
         <jupiter.version>5.10.2</jupiter.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <snakeyaml.version>2.0</snakeyaml.version>
@@ -31,17 +31,17 @@
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-core</artifactId>
-                <version>10.1.55</version>
+                <version>11.0.24</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-el</artifactId>
-                <version>10.1.55</version>
+                <version>11.0.24</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-websocket</artifactId>
-                <version>10.1.55</version>
+                <version>11.0.24</version>
             </dependency>
             <!-- terraform-plugin has no Spring Boot parent; Netty arrives transitively via plugin → reactor-netty.
                  Current bump 4.1.133 → 4.1.135 fixes CVE-2026-44249/45416 (netty-handler) +
@@ -108,7 +108,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
             <version>${spring-boot.version}</version>
             <exclusions>
                 <exclusion>

--- a/service/terraform-plugin/pom.xml
+++ b/service/terraform-plugin/pom.xml
@@ -22,11 +22,8 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- terraform-plugin has no Spring Boot parent and no spring-boot-dependencies BOM import.
-                 spring-boot-starter-web brings tomcat-embed-* transitively, and the
-                 <tomcat.version>11.0.24</tomcat.version> override in service/pom.xml does NOT reach
-                 this pom. Each artifact must be pinned explicitly.
-                 11.0.24 clears CVE-2026-59084/59083 over Spring Boot 4.1.0's managed 11.0.22. -->
+            <!-- No SB parent, so service/pom.xml's tomcat override doesn't reach here — pin
+                 tomcat-embed explicitly. 11.0.24 clears CVE-2026-59084/59083 over SB 4.1.0's 11.0.22. -->
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-core</artifactId>
@@ -43,9 +40,7 @@
                 <version>11.0.24</version>
             </dependency>
             <!-- terraform-plugin has no Spring Boot parent; Netty arrives transitively via plugin → reactor-netty.
-                 Pinned to 4.2.16 (Spring Boot 4.1.0's default netty is 4.2.15) to clear the HIGH
-                 CVEs 4.2.15 still carries: CVE-2026-56816 (http3), CVE-2026-59901 (codec/
-                 compression), CVE-2026-55831/55833/56745 (http), CVE-2026-56819 (http2). -->
+                 Pinned to 4.2.16 — SB 4.1.0's default 4.2.15 still has HIGH netty CVEs (CVE-2026-56816 et al.). -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>

--- a/service/terraform-plugin/pom.xml
+++ b/service/terraform-plugin/pom.xml
@@ -17,7 +17,7 @@
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
         <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
         <maas.jobs.version>2.0.11</maas.jobs.version>
-        <jackson.version>2.16.1</jackson.version>
+        <jackson.version>2.21.2</jackson.version>
     </properties>
 
     <dependencyManagement>
@@ -53,6 +53,16 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- Jackson 2 BOM aligned with the SB4-managed line (jackson-2-bom 2.21.2 → annotations
+                 2.21). This module has no SB parent, so it imports the BOM directly and lets the
+                 explicit jackson deps below inherit their versions. (DATAGO-142260) -->
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -84,12 +94,10 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/service/terraform-plugin/pom.xml
+++ b/service/terraform-plugin/pom.xml
@@ -11,7 +11,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <spring-boot.version>4.0.6</spring-boot.version>
-        <jupiter.version>5.10.2</jupiter.version>
+        <jupiter.version>6.0.3</jupiter.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>

--- a/service/terraform-plugin/pom.xml
+++ b/service/terraform-plugin/pom.xml
@@ -49,7 +49,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.135.Final</version>
+                <version>4.2.16.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -61,6 +61,17 @@
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
                 <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Jackson 3 (tools.jackson) arrives via spring-boot-starter-jackson (spring-boot.version
+                 4.0.6 pins it to 3.1.2) and gets shaded into this plugin's uber-jar. 3.1.2 carries
+                 CVE-2026-54512/54513 (jackson-databind) + GHSA-r7wm-3cxj-wff9 (jackson-core). Import
+                 the Jackson 3 BOM at 3.1.4 (the version Spring Boot 4.1.0 ships) to override it. -->
+            <dependency>
+                <groupId>tools.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>3.1.4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
### What is the purpose of this change?

Migrate the Event Management Agent to Spring Boot 4.

### How was this change implemented?

  - **Spring Boot 3.5.15 → 4.1.0** across all 8 modules (the application + 7 plugins). 4.1.0 rather than 4.0.6 so the managed BOM ships the patched spring-framework 7.0.8 / jackson-2 2.21.4 / jackson-3 3.1.4 directly, which clears the FOSSA HIGH CVEs at the source.
  - **Apache Camel 4.8.7 → 4.19.0.** Removed `camel-directvm-starter` (the direct-vm component was dropped in 4.19; EMA has no `direct-vm:` endpoints — the one test that referenced `DirectVmEndpoint` is repointed to `DirectEndpoint`).
  - **Jackson stays on Jackson 2** via a J2 compat bridge (`Jackson2CompatAutoConfiguration`), since SB4 defaults to Jackson 3. Re-added `jackson-datatype-jsr310`,`jackson-module-parameter-names` (Lombok `@Builder` deserialization), and `commons-codec` that the SB4 BOM reshuffle no longer pulls transitively.
  - **SB4 package/config moves:** `MeterRegistryCustomizer`, `MetricsProperties`, `PropertyReferenceException` to their SB4 sub-packages; `starter-web` → `starter-webmvc`; springdoc 2.2.0 → 3.0.3; micrometer tracing `Tracer` bean now via `spring-boot-micrometer-tracing-brave`.
  - **Tests:** SB4 deleted `MockitoTestExecutionListener`, so `@Mock` fields in ~45 `@SpringBootTest` classes stopped initializing. Restored globally with a `MockitoFieldInitExtension` (ServiceLoader-registered JUnit 5 extension) instead of editing every class. Moved to JUnit 6 (Jupiter 6.0.3).
  - **Security / FOSSA:** the 7 standalone plugin modules have no Spring Boot parent, so each pins its security-critical transitives explicitly — tomcat-embed 11.0.24, netty-bom 4.2.16 (SB 4.1.0's default 4.2.15 still carries HIGH netty CVEs), jackson 2.21.5. `spring-framework-bom:7.0.8` in local-storage-plugin (its `camel-spring-boot-starter` drags 7.0.6 and wins mediation); kafka-plugin pins micrometer 1.17.0 (its shaded uber-jar otherwise bundles an old micrometer that shadows the host's); `spring-data-commons:4.1.0` explicit pin (FOSSA nested-BOM blind spot).
  - **H2 console:** SB4 removed H2 console auto-configuration entirely, so the former `@Primary H2ConsoleProperties` force-disable bean was dropped (the class no longer exists). The blocking `SecurityFilterChain` in `H2ConsoleSecurityConfig` remains the active defense.

### How was this change tested?

 - Full reactor `mvn clean install` with tests: all 8 modules green, application module 304 tests / 0 failures / 0 errors.
 - FOSSA SCA Vulnerabilities: passing — 0 net-new HIGH/CRITICAL vs `main`.
 - functional test run in ep-perf

### Is there anything the reviewers should focus on/be aware of?

No
