### PR TITLE
[Bucket B] Add FOSSA SCA scanning on merge to main

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -171,7 +171,7 @@ jobs:
           ddb_sort_key: repository
           ddb_item_to_be_added: |
             {
-              "squad": "temp",
+              "squad": "event-portal",
               "repository": "${{ github.event.repository.name }}",
               "dev": {
                 "sha": "${{ github.sha }}",

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -146,3 +146,35 @@ jobs:
           reporter: java-junit
           fail-on-error: true
           only-summary: 'true'
+
+  report_to_guardian:
+    needs: fossa_scan
+    if: needs.fossa_scan.result == 'success' && github.ref_name == github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      packages: read
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: arn:aws:iam::868978040651:role/github-solace-cloud-manifest-rw
+          aws-region: us-east-1
+
+      - name: Update solace-cloud-manifest
+        uses: SolaceDev/solace-public-workflows/.github/actions/cicd-helper@main
+        with:
+          rc_step: add_item_from_json_to_dynamodb_table
+          ddb_table_name: solace-cloud-manifest
+          ddb_partition_key: squad
+          ddb_sort_key: repository
+          ddb_item_to_be_added: |
+            {
+              "squad": "temp",
+              "repository": "${{ github.event.repository.name }}",
+              "dev": {
+                "sha": "${{ github.sha }}",
+                "version": "${{ github.ref_name }}"
+              }
+            }


### PR DESCRIPTION
## Summary
- Adds `update_manifest` job to existing `build.yaml` workflow
- Job runs after `fossa_scan` succeeds, gated to default branch pushes only
- Writes repo metadata to `solace-cloud-manifest` DynamoDB table

Part of DATAGO-142436 FOSSA guardian onboarding.