### PR TITLE
DATAGO-146935: Bump OpenTofu 1.12.0 -> 1.12.3 (EMA Docker image)

### DIFF
--- a/service/application/docker/Dockerfile
+++ b/service/application/docker/Dockerfile
@@ -20,8 +20,8 @@ WORKDIR /opt/ema
 
 ARG PLATFORM=linux_amd64
 
-COPY tofu_1.12.0_amd64.apk /opt/ema/terraform
-RUN apk --update add --allow-untrusted /opt/ema/terraform/tofu_1.12.0_amd64.apk
+COPY tofu_1.12.3_amd64.apk /opt/ema/terraform
+RUN apk --update add --allow-untrusted /opt/ema/terraform/tofu_1.12.3_amd64.apk
 
 COPY .terraformrc $HOME/.terraformrc
 RUN printf '#!/bin/ash\ntofu $*' > /opt/ema/terraform/terraform

--- a/service/application/docker/tofu_1.12.0_amd64.apk
+++ b/service/application/docker/tofu_1.12.0_amd64.apk
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6e5b1873e5c5fbb26a0b287386684cdaf6e8b8173526d663b9151ca267495b2a
-size 36202716

--- a/service/application/docker/tofu_1.12.3_amd64.apk
+++ b/service/application/docker/tofu_1.12.3_amd64.apk
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8c0f912e4f47174e1cbf58513b195b3b12524d19e1662ceb5b0e1c6aa4c73d82
+size 36262149


### PR DESCRIPTION
## Summary

Bumps the bundled **OpenTofu binary 1.12.0 → 1.12.3** in the EMA Docker image (`service/application/docker/Dockerfile`).

**Fixes [DATAGO-141742](https://sol-jira.atlassian.net/browse/DATAGO-141742)** — GHSA-q7j3-v8qv-22vq (HIGH 7.5, arbitrary file read via crafted git URL; underlying `hashicorp/go-getter` CVE-2026-4660). v1.12.3 ships go-getter v1.8.6, which contains the fix.

Tracked for release under DATAGO-146935 (title reference).

## Changes

- `service/application/docker/Dockerfile` lines 23-24: `tofu_1.12.0_amd64.apk` → `tofu_1.12.3_amd64.apk`
- Added `tofu_1.12.3_amd64.apk` (official v1.12.3 release asset), removed `tofu_1.12.0_amd64.apk`

Patch-version bump within the 1.12.x line — no breaking changes.

## Bonus CVE coverage

v1.12.3 is built with the **Go 1.26.4** toolchain and newer modules, so this one bump also clears a family of Go CVEs embedded in the tofu binary:

| Module / toolchain | 1.12.0 | 1.12.3 | Clears |
|---|---|---|---|
| `golang.org/x/crypto` | 0.49.0 | **0.52.0** | x/crypto/ssh + ssh/agent CVEs (DATAGO-138037 / -138699 / -138035 / -138692, OpenTofu copy) |
| `golang.org/x/net` | 0.52.0 | **0.54.0** | x/net/html CVEs |
| Go toolchain | 1.26.3 | **1.26.4** | net/textproto (DATAGO-138994), crypto/tls, net/http stdlib CVEs |
| `hashicorp/go-getter` | 1.8.5 | **1.8.6** | GHSA-q7j3-v8qv-22vq (this ticket) |

## Verification

- Alpine build installs the apk cleanly (`Installing tofu (1.12.3)`); `tofu version` → **`OpenTofu v1.12.3`**.
- Go build-info in the installed binary confirms the embedded fixes: `golang.org/x/crypto@v0.52.0`, `hashicorp/go-getter@v1.8.6`, `golang.org/x/net@v0.54.0`, toolchain `go1.26.4`.

## Scope limit

This touches **only** the OpenTofu binary. The separate `terraform-provider-solacebroker` 1.3.0 binary (Dockerfile line 32, compiled with Go 1.25.5) is **not** rebuilt — its x/crypto 0.49.0 and Go-stdlib CVE copies persist until SolaceProducts ships a rebuilt provider. Those residuals remain not-exploitable in EMA (provider loaded locally via `.terraformrc` dev_overrides; no remote module/provider git sources in generated HCL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
