### PR TITLE
DATAGO-146935: Bump spring-kafka 3.3.6 -> 3.3.16 (event-management-agent)

### DIFF
--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -16,7 +16,7 @@
         <spring-boot.version>3.5.14</spring-boot.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <spring-security-rsa.version>1.1.3</spring-security-rsa.version>
-        <spring-kafka.version>3.3.6</spring-kafka.version>
+        <spring-kafka.version>3.3.16</spring-kafka.version>
         <!-- Fix CVE-2026-35554 (HIGH 8.7, producer race) + CVE-2026-33558 (MEDIUM 5.3, debug log info leak):
              Kafka 3.9.1 → 3.9.2. Patch release on the 3.9.x LTS line; no API changes. -->
         <kafka-clients.version>3.9.2</kafka-clients.version>

--- a/service/kafka-plugin/pom.xml
+++ b/service/kafka-plugin/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <spring-kafka.version>3.3.6</spring-kafka.version>
+        <spring-kafka.version>3.3.16</spring-kafka.version>
         <!-- Fix CVE-2026-35554 (HIGH 8.7, producer race) + CVE-2026-33558 (MEDIUM 5.3, debug log info leak):
              Kafka 3.9.1 → 3.9.2. Patch release on the 3.9.x LTS line; no API changes. -->
         <kafka-clients.version>3.9.2</kafka-clients.version>


### PR DESCRIPTION
## Summary

Bumps `spring-kafka` **3.3.6 → 3.3.16** in event-management-agent.

**Fixes [DATAGO-141738](https://sol-jira.atlassian.net/browse/DATAGO-141738).**

| Advisory | Severity | Fixed in |
|---|---|---|
| CVE-2026-41731 | High 8.1 | 3.3.16 — CWE-502 deserialization RCE: `JsonKafkaHeaderMapper` / `DefaultKafkaHeaderMapper` matched trusted packages by prefix, implicitly trusting subpackages → crafted headers could deserialize arbitrary JDK types |
| CVE-2026-41726 | Medium 6.5 | 3.3.16 — `DelegatingDeserializer` unbounded heap growth via unique `spring.kafka.serialization.selector` headers → GC thrash / OutOfMemoryError |

Tracked for release under DATAGO-146935 (title reference).

## Changes

`spring-kafka` is an explicitly-pinned dependency via `<spring-kafka.version>` in two modules; both bumped:
- `service/application/pom.xml`
- `service/kafka-plugin/pom.xml`

Patch release on the 3.3.x line — no API changes. (3.3.16 was unpublished at first triage on 2026-07-06; it is now on Maven Central.)

## Verification

`mvn dependency:tree -Dincludes='org.springframework.kafka:spring-kafka'` across all 9 modules → both `kafka-plugin` and `application` resolve `spring-kafka:jar:3.3.16:compile`; the other 7 modules don't pull spring-kafka. **BUILD SUCCESS.**

## Exploitability

Not exploitable in EMA today — the vulnerable `KafkaHeaderMapper` / `DelegatingDeserializer` code paths are not used. Patched per defense-in-depth: direct, explicitly-pinned dependency with a low-risk same-line patch available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
