### PR TITLE
DATAGO-146935: Bump jackson-databind 2.16.1 -> 2.21.4 (event-management-agent)

### DIFF
--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -20,7 +20,7 @@
         <!-- Fix CVE-2026-35554 (HIGH 8.7, producer race) + CVE-2026-33558 (MEDIUM 5.3, debug log info leak):
              Kafka 3.9.1 → 3.9.2. Patch release on the 3.9.x LTS line; no API changes. -->
         <kafka-clients.version>3.9.2</kafka-clients.version>
-        <jackson.version>2.16.1</jackson.version>
+        <jackson.version>2.21.4</jackson.version>
         <awaitility.version>4.2.0</awaitility.version>
         <dockerfile-maven.version>1.4.13</dockerfile-maven.version>
         <swagger-codegen-maven-plugin.version>2.4.43</swagger-codegen-maven-plugin.version>

--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -20,7 +20,7 @@
         <!-- Fix CVE-2026-35554 (HIGH 8.7, producer race) + CVE-2026-33558 (MEDIUM 5.3, debug log info leak):
              Kafka 3.9.1 → 3.9.2. Patch release on the 3.9.x LTS line; no API changes. -->
         <kafka-clients.version>3.9.2</kafka-clients.version>
-        <jackson.version>2.21.4</jackson.version>
+        <jackson.version>2.21.5</jackson.version>
         <awaitility.version>4.2.0</awaitility.version>
         <dockerfile-maven.version>1.4.13</dockerfile-maven.version>
         <swagger-codegen-maven-plugin.version>2.4.43</swagger-codegen-maven-plugin.version>

--- a/service/confluent-schema-registry-plugin/pom.xml
+++ b/service/confluent-schema-registry-plugin/pom.xml
@@ -52,6 +52,16 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- confluent-schema-registry-plugin has no Spring Boot parent; jackson-databind arrives
+                 transitively (resolves 2.16.1 without this pin). Pin the jackson BOM to the version every
+                 other EMA module uses so all modules ship a single jackson version. -->
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>2.21.4</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/service/confluent-schema-registry-plugin/pom.xml
+++ b/service/confluent-schema-registry-plugin/pom.xml
@@ -58,7 +58,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>2.21.4</version>
+                <version>2.21.5</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/service/kafka-plugin/pom.xml
+++ b/service/kafka-plugin/pom.xml
@@ -23,7 +23,7 @@
         <jackson-dataformat-cbor.version>2.13.4</jackson-dataformat-cbor.version>
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
         <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
-        <jackson.version>2.21.4</jackson.version>
+        <jackson.version>2.21.5</jackson.version>
     </properties>
 
     <dependencyManagement>

--- a/service/kafka-plugin/pom.xml
+++ b/service/kafka-plugin/pom.xml
@@ -23,7 +23,7 @@
         <jackson-dataformat-cbor.version>2.13.4</jackson-dataformat-cbor.version>
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
         <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
-        <jackson.version>2.16.1</jackson.version>
+        <jackson.version>2.21.4</jackson.version>
     </properties>
 
     <dependencyManagement>

--- a/service/local-storage-plugin/pom.xml
+++ b/service/local-storage-plugin/pom.xml
@@ -20,7 +20,7 @@
         <jupiter.version>5.10.2</jupiter.version>
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
         <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
-        <jackson.version>2.21.4</jackson.version>
+        <jackson.version>2.21.5</jackson.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/service/local-storage-plugin/pom.xml
+++ b/service/local-storage-plugin/pom.xml
@@ -20,7 +20,7 @@
         <jupiter.version>5.10.2</jupiter.version>
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
         <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
-        <jackson.version>2.16.1</jackson.version>
+        <jackson.version>2.21.4</jackson.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/service/plugin/pom.xml
+++ b/service/plugin/pom.xml
@@ -22,7 +22,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <snakeyaml.version>2.0</snakeyaml.version>
-        <jackson.version>2.21.4</jackson.version>
+        <jackson.version>2.21.5</jackson.version>
         <spring-boot.version>3.5.14</spring-boot.version>
     </properties>
 

--- a/service/plugin/pom.xml
+++ b/service/plugin/pom.xml
@@ -22,7 +22,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <snakeyaml.version>2.0</snakeyaml.version>
-        <jackson.version>2.16.1</jackson.version>
+        <jackson.version>2.21.4</jackson.version>
         <spring-boot.version>3.5.14</spring-boot.version>
     </properties>
 

--- a/service/rabbitmq-plugin/pom.xml
+++ b/service/rabbitmq-plugin/pom.xml
@@ -18,11 +18,11 @@
             <!-- rabbitmq-plugin has no Spring Boot parent and no spring-boot-dependencies BOM import.
                  com.rabbitmq:http-client:4.2.0 bundles jackson-databind 2.14.0, which leaks through
                  without this pin. Fix CVE-2025-52999 (HIGH 8.7, jackson-core stack overflow on deeply
-                 nested JSON). 2.21.4 matches the jackson version every other EMA module uses. -->
+                 nested JSON). 2.21.5 matches the jackson version every other EMA module uses. -->
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>2.21.4</version>
+                <version>2.21.5</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/service/rabbitmq-plugin/pom.xml
+++ b/service/rabbitmq-plugin/pom.xml
@@ -18,11 +18,11 @@
             <!-- rabbitmq-plugin has no Spring Boot parent and no spring-boot-dependencies BOM import.
                  com.rabbitmq:http-client:4.2.0 bundles jackson-databind 2.14.0, which leaks through
                  without this pin. Fix CVE-2025-52999 (HIGH 8.7, jackson-core stack overflow on deeply
-                 nested JSON). 2.16.1 matches the jackson version every other EMA module uses. -->
+                 nested JSON). 2.21.4 matches the jackson version every other EMA module uses. -->
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>2.16.1</version>
+                <version>2.21.4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/service/solace-plugin/pom.xml
+++ b/service/solace-plugin/pom.xml
@@ -19,7 +19,7 @@
         <snakeyaml.version>2.0</snakeyaml.version>
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
         <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
-        <jackson.version>2.21.4</jackson.version>
+        <jackson.version>2.21.5</jackson.version>
     </properties>
 
     <dependencyManagement>

--- a/service/solace-plugin/pom.xml
+++ b/service/solace-plugin/pom.xml
@@ -19,7 +19,7 @@
         <snakeyaml.version>2.0</snakeyaml.version>
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
         <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
-        <jackson.version>2.16.1</jackson.version>
+        <jackson.version>2.21.4</jackson.version>
     </properties>
 
     <dependencyManagement>

--- a/service/terraform-plugin/pom.xml
+++ b/service/terraform-plugin/pom.xml
@@ -17,7 +17,7 @@
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
         <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
         <maas.jobs.version>2.0.11</maas.jobs.version>
-        <jackson.version>2.21.4</jackson.version>
+        <jackson.version>2.21.5</jackson.version>
     </properties>
 
     <dependencyManagement>
@@ -56,7 +56,7 @@
             <!-- terraform-plugin has no Spring Boot parent; import the jackson BOM so all jackson
                  artifacts resolve consistently. jackson-annotations tracks its own version line
                  (2.21, no patch) since Jackson 2.20, so it must be BOM-managed rather than pinned
-                 to ${jackson.version} (which would demand a non-existent jackson-annotations 2.21.4). -->
+                 to ${jackson.version} (which would demand a non-existent jackson-annotations 2.21.5). -->
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>

--- a/service/terraform-plugin/pom.xml
+++ b/service/terraform-plugin/pom.xml
@@ -17,7 +17,7 @@
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
         <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
         <maas.jobs.version>2.0.11</maas.jobs.version>
-        <jackson.version>2.16.1</jackson.version>
+        <jackson.version>2.21.4</jackson.version>
     </properties>
 
     <dependencyManagement>

--- a/service/terraform-plugin/pom.xml
+++ b/service/terraform-plugin/pom.xml
@@ -53,6 +53,17 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- terraform-plugin has no Spring Boot parent; import the jackson BOM so all jackson
+                 artifacts resolve consistently. jackson-annotations tracks its own version line
+                 (2.21, no patch) since Jackson 2.20, so it must be BOM-managed rather than pinned
+                 to ${jackson.version} (which would demand a non-existent jackson-annotations 2.21.4). -->
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -84,12 +95,10 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
## Summary

Bumps `jackson-databind` **2.16.1 → 2.21.4** across event-management-agent.

**Fixes [DATAGO-141740](https://sol-jira.atlassian.net/browse/DATAGO-141740).**

| Advisory | Severity | Fixed in |
|---|---|---|
| CVE-2026-54512 | High 8.1 | 2.21.4 — PolymorphicTypeValidator allow-list bypass (CWE-502) |
| CVE-2026-54513 | High | 2.21.4 — `allowIfSubTypeIsArray` element-type not validated |
| CVE-2026-54514 | Medium | 2.21.4 — `InetSocketAddress` deserialization / SSRF |
| CVE-2026-54515 | Medium | 2.21.4 — case-insensitive `@JsonIgnoreProperties` bypass |
| CVE-2026-59888 | Medium | 2.21.4 — (added 2026-08-05; also covered) |

Tracked for release under DATAGO-146935 (title reference).

## Changes

`jackson-databind` resolves to `2.16.1` in **all 9 EMA modules**. EMA is a multi-module build where only some modules inherit a BOM, so the fix is applied per-pom (8 modules touched):

- **6 modules** — bump `<jackson.version>` `2.16.1 → 2.21.4`: `application`, `plugin`, `kafka-plugin`, `solace-plugin`, `local-storage-plugin`, `terraform-plugin`.
- **`rabbitmq-plugin`** — no Boot parent; hardcoded `jackson-bom` import `2.16.1 → 2.21.4` (pin exists because `com.rabbitmq:http-client` leaks jackson 2.14.0).
- **`confluent-schema-registry-plugin`** — had **no** jackson pin and was resolving `2.16.1` transitively; **added** a `jackson-bom:2.21.4` import (same pattern as its existing tomcat / netty-bom pins).

Same-major forward patch; fleet-standard version (matches the `maas-*` services).

## Verification

`mvn dependency:tree -Dincludes='com.fasterxml.jackson.core:jackson-databind'` across all 9 modules → **every module** resolves `jackson-databind:jar:2.21.4:compile` (including `confluent-schema-registry-plugin`, previously transitive 2.16.1). **BUILD SUCCESS.**

## Exploitability

The HIGH pair (54512/54513) are polymorphic-typing bypasses reachable only when the app enables PTV / default typing over attacker-controlled JSON; no such mapper confirmed in EMA. Patched per defense-in-depth — direct dependency, clean same-major patch, fleet standardization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
