### PR TITLE
DATAGO-146935: Bump Spring Boot 3.5.14 -> 3.5.15 (event-management-agent)

### DIFF
--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -13,7 +13,7 @@
     <name>Solace Event Management Agent - Application</name>
     <description>Solace Event Management Agent - Application</description>
     <properties>
-        <spring-boot.version>3.5.14</spring-boot.version>
+        <spring-boot.version>3.5.15</spring-boot.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <spring-security-rsa.version>1.1.3</spring-security-rsa.version>
         <spring-kafka.version>3.3.16</spring-kafka.version>

--- a/service/confluent-schema-registry-plugin/pom.xml
+++ b/service/confluent-schema-registry-plugin/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <spring-boot.version>3.5.14</spring-boot.version>
+        <spring-boot.version>3.5.15</spring-boot.version>
         <httpclient.version>4.5.14</httpclient.version>
         <mockwebserver.version>4.9.0</mockwebserver.version>
         <jupiter.version>5.10.2</jupiter.version>

--- a/service/kafka-plugin/pom.xml
+++ b/service/kafka-plugin/pom.xml
@@ -14,7 +14,7 @@
         <!-- Fix CVE-2026-35554 (HIGH 8.7, producer race) + CVE-2026-33558 (MEDIUM 5.3, debug log info leak):
              Kafka 3.9.1 → 3.9.2. Patch release on the 3.9.x LTS line; no API changes. -->
         <kafka-clients.version>3.9.2</kafka-clients.version>
-        <spring-boot.version>3.5.14</spring-boot.version>
+        <spring-boot.version>3.5.15</spring-boot.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <jupiter.version>5.10.2</jupiter.version>
         <camel.version>4.8.7</camel.version>
@@ -59,7 +59,7 @@
             <!-- kafka-plugin has no Spring Boot parent, so Spring Boot does not manage Netty here.
                  software.amazon.awssdk:netty-nio-client bundles its own Netty version (4.1.118.Final
                  as of awssdk 2.30.17), which would be used without this pin.
-                 This BOM pin forces Netty to match the version Spring Boot 3.5.14 manages in all
+                 This BOM pin forces Netty to match the version Spring Boot 3.5.15 manages in all
                  other EMA modules (via reactor-netty).
                  Review when upgrading awssdk:netty-nio-client or when kafka-plugin gains a Spring Boot parent.
                  Current bump 4.1.133 → 4.1.135 fixes CVE-2026-44249/45416 (netty-handler) +

--- a/service/local-storage-plugin/pom.xml
+++ b/service/local-storage-plugin/pom.xml
@@ -15,7 +15,7 @@
         <snakeyaml.version>2.0</snakeyaml.version>
         <jacksondatabind.version>2.13.4.2</jacksondatabind.version>
         <junit.version>4.13.2</junit.version>
-        <spring-boot.version>3.5.14</spring-boot.version>
+        <spring-boot.version>3.5.15</spring-boot.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <jupiter.version>5.10.2</jupiter.version>
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>

--- a/service/plugin/pom.xml
+++ b/service/plugin/pom.xml
@@ -23,7 +23,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <snakeyaml.version>2.0</snakeyaml.version>
         <jackson.version>2.21.5</jackson.version>
-        <spring-boot.version>3.5.14</spring-boot.version>
+        <spring-boot.version>3.5.15</spring-boot.version>
     </properties>
 
     <dependencyManagement>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.14</version>
+        <version>3.5.15</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.solace.maas</groupId>

--- a/service/rabbitmq-plugin/pom.xml
+++ b/service/rabbitmq-plugin/pom.xml
@@ -11,7 +11,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
-        <spring-boot.version>3.5.14</spring-boot.version>
+        <spring-boot.version>3.5.15</spring-boot.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/service/solace-plugin/pom.xml
+++ b/service/solace-plugin/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <solace-messaging-client.version>1.4.0</solace-messaging-client.version>
         <solclientj.version>10.0.0</solclientj.version>
-        <spring-boot.version>3.5.14</spring-boot.version>
+        <spring-boot.version>3.5.15</spring-boot.version>
         <jupiter.version>5.12.2</jupiter.version>
         <camel.version>4.8.7</camel.version>
         <commons-collections4.version>4.4</commons-collections4.version>

--- a/service/terraform-plugin/pom.xml
+++ b/service/terraform-plugin/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <spring-boot.version>3.5.14</spring-boot.version>
+        <spring-boot.version>3.5.15</spring-boot.version>
         <jupiter.version>5.10.2</jupiter.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <snakeyaml.version>2.0</snakeyaml.version>


### PR DESCRIPTION
## Summary

Bumps **Spring Boot 3.5.14 → 3.5.15** in event-management-agent. One parent-POM bump closes **three tickets** by pulling patched Spring Framework and Spring Security.

**Fixes [DATAGO-141737](https://sol-jira.atlassian.net/browse/DATAGO-141737), [DATAGO-141739](https://sol-jira.atlassian.net/browse/DATAGO-141739), and [DATAGO-141741](https://sol-jira.atlassian.net/browse/DATAGO-141741).**

| Managed dependency | 3.5.14 | 3.5.15 | Tickets / CVEs cleared |
|---|---|---|---|
| Spring Framework | 6.2.18 | **6.2.19** | **DATAGO-141737** (spring-core) + **DATAGO-141739** (spring-web): CVE-2026-41838, -41844, -41845, -41846, -41848, -41851, -41852, -41854, -41855 |
| Spring Security | 6.5.10 | **6.5.11** | **DATAGO-141741** (spring-security-core): CVE-2026-47838, -41003, -41694 |

Tracked for release under DATAGO-146935 (title reference).

## Coverage verification

- **Spring Framework 6.2.19** ≥ the `6.2.18.1` / `6.2.19` fix listed for all 9 framework CVEs (CVE-2026-41848 explicitly lists 6.2.19).
- **Spring Security 6.5.11** is the **OSS** fix for all three security CVEs. The scanner lists `6.5.10.2` for CVE-2026-41003 / -41694, but that is the **enterprise-only** patch line — confirmed against the Spring advisories ([CVE-2026-41003](https://spring.io/security/cve-2026-41003), [CVE-2026-41694](https://spring.io/security/cve-2026-41694)) that **6.5.11 (OSS)** fixes both. No residual; no higher Boot version needed.

## Changes

Spring Boot version is set via the `<parent>` in `service/pom.xml` **and** `<spring-boot.version>` in all 8 plugin poms (EMA is a 9-module build; the parent bump does not cascade to the standalone plugin poms). All 9 bumped 3.5.14 → 3.5.15.

## Verification

Full `mvn clean package -DskipTests` across all 9 modules → **BUILD SUCCESS**. `dependency:tree` confirms `spring-core` / `spring-web` resolve **6.2.19** and `spring-security-core` resolves **6.5.11**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
