### PR TITLE
DATAGO-149211: fix config push failure with ObjectOptimisticLockingFailureException

### DIFF
--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/repository/messagingservice/MessagingServiceRepository.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/repository/messagingservice/MessagingServiceRepository.java
@@ -1,9 +1,20 @@
 package com.solace.maas.ep.event.management.agent.repository.messagingservice;
 
 import com.solace.maas.ep.event.management.agent.repository.model.mesagingservice.MessagingServiceEntity;
-import org.springframework.data.repository.CrudRepository;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
-public interface MessagingServiceRepository extends CrudRepository<MessagingServiceEntity, String> {
+public interface MessagingServiceRepository extends JpaRepository<MessagingServiceEntity, String> {
+
+    // Pessimistic write lock (SELECT ... FOR UPDATE) to serialize concurrent upserts of the same broker (DATAGO-149211).
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT m FROM MessagingServiceEntity m WHERE m.id = :id")
+    Optional<MessagingServiceEntity> findAndLockById(@Param("id") String id);
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/repository/messagingservice/MessagingServiceRepository.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/repository/messagingservice/MessagingServiceRepository.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 @Repository
 public interface MessagingServiceRepository extends JpaRepository<MessagingServiceEntity, String> {
 
-    // Pessimistic write lock (SELECT ... FOR UPDATE) to serialize concurrent upserts of the same broker (DATAGO-149211).
+    // Pessimistic write lock (SELECT ... FOR UPDATE) to serialize concurrent upserts of the same broker.
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT m FROM MessagingServiceEntity m WHERE m.id = :id")
     Optional<MessagingServiceEntity> findAndLockById(@Param("id") String id);

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/MessagingServiceDelegateServiceImpl.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/MessagingServiceDelegateServiceImpl.java
@@ -91,7 +91,7 @@ public class MessagingServiceDelegateServiceImpl implements MessagingServiceDele
                 .map(toBeUpserted -> {
                     MessagingServiceEntity updated = eventToEntityConverter.convert(toBeUpserted);
                     // Lock the broker row so concurrent same-broker upserts don't both orphan-remove the same
-                    // cascaded child row, which would fail the second commit with an optimistic-lock error (DATAGO-149211).
+                    // cascaded child row, which would fail the second commit with an optimistic-lock error.
                     Optional<MessagingServiceEntity> existing = repository.findAndLockById(toBeUpserted.getId());
                     if (existing.isPresent()) {
                         MessagingServiceEntity existingEntity = existing.get();

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/MessagingServiceDelegateServiceImpl.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/MessagingServiceDelegateServiceImpl.java
@@ -12,12 +12,13 @@ import com.solace.maas.ep.event.management.agent.repository.messagingservice.Ser
 import com.solace.maas.ep.event.management.agent.repository.model.mesagingservice.MessagingServiceEntity;
 import com.solace.maas.ep.event.management.agent.repository.model.mesagingservice.ServiceAssociationsCompositeKey;
 import com.solace.maas.ep.event.management.agent.repository.model.mesagingservice.ServiceAssociationsEntity;
-import jakarta.transaction.Transactional;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -82,7 +83,7 @@ public class MessagingServiceDelegateServiceImpl implements MessagingServiceDele
     }
 
 
-    @Transactional
+    @Transactional(isolation = Isolation.READ_COMMITTED)
     public Iterable<MessagingServiceEntity> upsertMessagingServiceEvents(List<MessagingServiceEvent> messagingServiceEvents) {
         if (CollectionUtils.isEmpty(messagingServiceEvents)) {
             return List.of();
@@ -90,7 +91,9 @@ public class MessagingServiceDelegateServiceImpl implements MessagingServiceDele
         List<MessagingServiceEntity> messagingServiceEntities = messagingServiceEvents.stream()
                 .map(toBeUpserted -> {
                     MessagingServiceEntity updated = eventToEntityConverter.convert(toBeUpserted);
-                    Optional<MessagingServiceEntity> existing = repository.findById(toBeUpserted.getId());
+                    // Lock the broker row so concurrent same-broker upserts don't both orphan-remove the same
+                    // cascaded child row, which would fail the second commit with an optimistic-lock error (DATAGO-149211).
+                    Optional<MessagingServiceEntity> existing = repository.findAndLockById(toBeUpserted.getId());
                     if (existing.isPresent()) {
                         MessagingServiceEntity existingEntity = existing.get();
                         updated.setScanEntities(existingEntity.getScanEntities());

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/MessagingServiceDelegateServiceImpl.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/MessagingServiceDelegateServiceImpl.java
@@ -12,13 +12,12 @@ import com.solace.maas.ep.event.management.agent.repository.messagingservice.Ser
 import com.solace.maas.ep.event.management.agent.repository.model.mesagingservice.MessagingServiceEntity;
 import com.solace.maas.ep.event.management.agent.repository.model.mesagingservice.ServiceAssociationsCompositeKey;
 import com.solace.maas.ep.event.management.agent.repository.model.mesagingservice.ServiceAssociationsEntity;
+import jakarta.transaction.Transactional;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Isolation;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -83,7 +82,7 @@ public class MessagingServiceDelegateServiceImpl implements MessagingServiceDele
     }
 
 
-    @Transactional(isolation = Isolation.READ_COMMITTED)
+    @Transactional
     public Iterable<MessagingServiceEntity> upsertMessagingServiceEvents(List<MessagingServiceEvent> messagingServiceEvents) {
         if (CollectionUtils.isEmpty(messagingServiceEvents)) {
             return List.of();

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/service/MessagingServiceDelegateServiceTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/service/MessagingServiceDelegateServiceTests.java
@@ -113,7 +113,7 @@ public class MessagingServiceDelegateServiceTests {
     }
 
     @Test
-    public void testUpsertMessagingServiceEventsAcquiresPessimisticLock() {
+    void testUpsertMessagingServiceEventsAcquiresPessimisticLock() {
         MessagingServiceEvent messagingServiceEvent = MessagingServiceEvent.builder()
                 .id("testService")
                 .messagingServiceType(MessagingServiceType.SOLACE.name())

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/service/MessagingServiceDelegateServiceTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/service/MessagingServiceDelegateServiceTests.java
@@ -41,6 +41,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ActiveProfiles("TEST")
@@ -107,6 +110,33 @@ public class MessagingServiceDelegateServiceTests {
         messagingServiceDelegateService.addMessagingService(messagingServiceEvent);
 
         assertThatNoException();
+    }
+
+    @Test
+    public void testUpsertMessagingServiceEventsAcquiresPessimisticLock() {
+        MessagingServiceEvent messagingServiceEvent = MessagingServiceEvent.builder()
+                .id("testService")
+                .messagingServiceType(MessagingServiceType.SOLACE.name())
+                .name("service1")
+                .connectionDetails(List.of())
+                .build();
+
+        MessagingServiceEntity existingEntity = MessagingServiceEntity.builder()
+                .id("testService")
+                .name("service1")
+                .type(MessagingServiceType.SOLACE.name())
+                .build();
+
+        when(repository.findAndLockById("testService"))
+                .thenReturn(Optional.of(existingEntity));
+        when(repository.saveAll(any()))
+                .thenReturn(List.of(existingEntity));
+
+        messagingServiceDelegateService.upsertMessagingServiceEvents(List.of(messagingServiceEvent));
+
+        verify(repository, times(1)).findAndLockById("testService");
+        verify(repository, never()).findById(any(String.class));
+        verify(repository, times(1)).saveAll(any());
     }
 
     @Test

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/testConfigs/MessagingServiceTestConfig.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/testConfigs/MessagingServiceTestConfig.java
@@ -39,13 +39,17 @@ public class MessagingServiceTestConfig {
                 .url("localhost:9090")
                 .build();
 
+        MessagingServiceEntity messagingServiceEntity = MessagingServiceEntity.builder()
+                .type(MessagingServiceType.SOLACE.name())
+                .name("service1")
+                .id(UUID.randomUUID().toString())
+                .connections(List.of(connectionDetailsEntity))
+                .build();
+
         when(repository.findById(any(String.class)))
-                .thenReturn(Optional.of(MessagingServiceEntity.builder()
-                        .type(MessagingServiceType.SOLACE.name())
-                        .name("service1")
-                        .id(UUID.randomUUID().toString())
-                        .connections(List.of(connectionDetailsEntity))
-                        .build()));
+                .thenReturn(Optional.of(messagingServiceEntity));
+        when(repository.findAndLockById(any(String.class)))
+                .thenReturn(Optional.of(messagingServiceEntity));
         return repository;
     }
 


### PR DESCRIPTION
### What is the purpose of this change?

### Problem

When several config-push `CommandMessage`s for **different apps but the same broker** arrive ~100ms apart, EMA fails to process some of them. Production stack trace (org `2v99i8lq4nb`, broker `6iu9mezp3t0`):

```log
  java.lang.IllegalArgumentException: org.springframework.orm.ObjectOptimisticLockingFailureException:
    Row was updated or deleted by another transaction ... [CredentialOperationsEntity#285fdeb4-...]
    at ...DynamicResourceConfigurationHelper.loadSolaceBrokerResourceConfigurations(...:47)
  Caused by: ObjectOptimisticLockingFailureException ... at JpaTransactionManager.doCommit(...)
    ... MessagingServiceDelegateServiceImpl$$SpringCGLIB$$0.upsertMessagingServiceEvents(<generated>)
  Caused by: org.hibernate.StaleObjectStateException ... EntityDeleteAction.execute(...) (flush during commit)
```

Datadog confirmed this is intra-pod thread-pool concurrency (threads `pool-1/2/4`, single active replica), not a transient infra issue.

### Root cause

Two concurrent transactions for the same broker both issue a `DELETE` for the same child row; the first wins, the second's delete affects 0 rows → `StaleObjectStateException` → `ObjectOptimisticLockingFailureException`. 
The collision key is the **broker**, which is why different-app concurrency still races.

### How was this change implemented?

Serialize same-broker upserts by locking the parent broker row at the start of the transaction:
  - `MessagingServiceRepository` now extends `JpaRepository` and exposes `findAndLockById` with `@Lock(PESSIMISTIC_WRITE)` (`SELECT ... FOR UPDATE`).
  - `upsertMessagingServiceEvents` uses `findAndLockById` for the existing-broker lookup.

### How was this change tested?

 Added `testUpsertMessagingServiceEventsAcquiresPessimisticLock`: verifies the upsert calls `findAndLockById` (never `findById`) then `saveAll`.

### Is there anything the reviewers should focus on/be aware of?

No
