### PR TITLE
Bump OpenTofu 1.12.3 -> 1.12.6 (EMA Docker image)

### DIFF
--- a/service/application/docker/Dockerfile
+++ b/service/application/docker/Dockerfile
@@ -20,8 +20,8 @@ WORKDIR /opt/ema
 
 ARG PLATFORM=linux_amd64
 
-COPY tofu_1.12.3_amd64.apk /opt/ema/terraform
-RUN apk --update add --allow-untrusted /opt/ema/terraform/tofu_1.12.3_amd64.apk
+COPY tofu_1.12.6_amd64.apk /opt/ema/terraform
+RUN apk --update add --allow-untrusted /opt/ema/terraform/tofu_1.12.6_amd64.apk
 
 COPY .terraformrc $HOME/.terraformrc
 RUN printf '#!/bin/ash\ntofu $*' > /opt/ema/terraform/terraform

--- a/service/application/docker/tofu_1.12.3_amd64.apk
+++ b/service/application/docker/tofu_1.12.3_amd64.apk
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8c0f912e4f47174e1cbf58513b195b3b12524d19e1662ceb5b0e1c6aa4c73d82
-size 36262149

--- a/service/application/docker/tofu_1.12.6_amd64.apk
+++ b/service/application/docker/tofu_1.12.6_amd64.apk
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d63332b4e09cb142dbfb81123bf0156ede8c6a3449ce52fdcd187e53dedfe37d
+size 36239222


### PR DESCRIPTION
## Summary

Bumps the bundled **OpenTofu binary 1.12.3 → 1.12.6** (`service/application/docker/Dockerfile`). Official v1.12.6 apk release asset; checksum verified against `tofu_1.12.6_SHA256SUMS`.

Patch-line bump (1.12.x), no breaking changes. Fully or partially clears 7 open findings:

| Ticket | CVE | Result |
|---|---|---|
| DATAGO-147276 | CVE-2026-50151 (oras-go) | Fully cleared — 2.6.0 → 2.6.1 |
| DATAGO-149470 | CVE-2026-56859 (encoding/xml) | Fully cleared — OpenTofu-only instance, Go toolchain 1.26.6 |
| DATAGO-138701 | CVE-2026-46600 (net) | Fully cleared — OpenTofu-only instance |
| DATAGO-147279 | CVE-2026-39822 (os) | OpenTofu-side instance cleared; provider-side (v1.25.5) instance remains, stays excluded `--nofix` |
| DATAGO-149469 | CVE-2026-33818 (encoding/asn1) | Same split as above |
| DATAGO-138703 | CVE-2026-39821, CVE-2026-56853 (net/http) | Same split as above |
| DATAGO-138708 | CVE-2026-56862 (crypto/tls) | Same split as above |

## Not fixed by this bump

Upstream OpenTofu v1.12.6's go.mod still pins `golang.org/x/net@v0.54.0`, `golang.org/x/text@v0.37.0`, `google.golang.org/grpc@v1.79.3`, `go.opentelemetry.io/otel@v1.42.0` — no newer OpenTofu release resolves these yet. DATAGO-147188, 147273, 147278, 147277, 147281 stay excluded (fix not available).

## Scope limit

Touches only the OpenTofu binary. `terraform-provider-solacebroker` 1.3.0 (Go 1.25.5) is not rebuilt — its residual CVE instances remain excluded until SolaceProducts ships a fixed provider release.

## Verification

- SHA256 checksum of the downloaded apk matches `tofu_1.12.6_SHA256SUMS`
- Built a minimal image on the same base (`eclipse-temurin:17.0.19_10-jre-alpine`): apk installs cleanly (`Installing tofu (1.12.6)`), `tofu version` → `OpenTofu v1.12.6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)