### PR TITLE
DATAGO-138706: Pin mchange-commons-java to 0.6.1 (CVE-2026-55153)

### DIFF
--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -40,6 +40,13 @@
                 <artifactId>okio</artifactId>
                 <version>1.17.6</version>
             </dependency>
+            <!-- CVE-2026-55153: mchange-commons-java < 0.6.0 JNDI dereferencing; transitive via
+                 camel-quartz-starter -> camel-quartz -> c3p0 -->
+            <dependency>
+                <groupId>com.mchange</groupId>
+                <artifactId>mchange-commons-java</artifactId>
+                <version>0.6.1</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>


### PR DESCRIPTION
## Summary
- CVE-2026-55153 (mchange-commons-java, HIGH) -- transitive via camel-quartz-starter -> camel-quartz -> c3p0 -> mchange-commons-java, currently resolving to 0.4.0
- Overridden in service/application/pom.xml dependencyManagement to 0.6.1 (Maven Central latest/release)
- Also clears the ticket's older CVE-2026-27727 -- already moot per Guardian's own "Resolved vulnerabilities" comment, cleared by the unrelated camel-quartz 4.19.0 bump that landed with the Spring Boot 4 upgrade on main since the last analysis

## Test plan
- [x] `mvn dependency:tree -Dincludes=com.mchange` -- confirms mchange-commons-java:0.6.1 resolves
- [x] `mvn clean compile` (full reactor) -- BUILD SUCCESS
- [x] `mvn test -pl application -am` -- 218 run, 0 failures, 0 errors

DATAGO-138706